### PR TITLE
Creates a file per dataset for the HBase export (issue #158)

### DIFF
--- a/pipelines/export-gbif-hbase/README.md
+++ b/pipelines/export-gbif-hbase/README.md
@@ -1,0 +1,12 @@
+# Export GBIF HBase
+
+This is a interim pipeline to export the verbatim data from the GBIF HBase tables and save as `ExtendedRecord` avro files.
+
+To run this:
+```
+java -jar target/export-gbif-hbase-2.1.4-SNAPSHOT-shaded.jar \
+ --runner=SparkRunner \
+ --hbaseZk=c3zk1.gbif-dev.org,c3zk2.gbif-dev.org,c3zk3.gbif-dev.org \
+ --exportPath=/tmp/delme \
+ --table=dev_occurrence
+```

--- a/pipelines/export-gbif-hbase/pom.xml
+++ b/pipelines/export-gbif-hbase/pom.xml
@@ -9,7 +9,8 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>ingest-gbif-hbase</artifactId>
+
+    <artifactId>export-gbif-hbase</artifactId>
 
     <packaging>jar</packaging>
 
@@ -61,6 +62,9 @@
                             <shadedClassifierName>shaded</shadedClassifierName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.gbif.pipelines.hbase.beam.ExportHBase</mainClass>
+                                </transformer>
                             </transformers>
                             <relocations>
                                 <relocation>
@@ -108,7 +112,49 @@
             <artifactId>beam-sdks-java-io-hbase</artifactId>
             <version>${apache.beam.version}</version>
         </dependency>
+
+        <!-- TODO: all following dependencies should not be needed for running on a cluster -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-core</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.11</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
     </dependencies>
-
-
 </project>

--- a/pipelines/export-gbif-hbase/src/main/java/org/gbif/pipelines/hbase/beam/ExportHBaseOptions.java
+++ b/pipelines/export-gbif-hbase/src/main/java/org/gbif/pipelines/hbase/beam/ExportHBaseOptions.java
@@ -7,7 +7,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 /**
  * Pipeline settings and arguments for Hbase to Avro export.
  */
-public interface BulkLoadOptions extends PipelineOptions {
+public interface ExportHBaseOptions extends PipelineOptions {
 
   @Description("HBase Zookeeper ensemble")
   String getHbaseZk();

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -21,7 +21,7 @@
     <module>ingest-transforms</module>
     <module>ingest-gbif</module>
     <module>ingest-gbif-standalone</module>
-      <module>ingest-gbif-hbase</module>
+    <module>export-gbif-hbase</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
     <!-- GBIF libraries -->
     <gbif-parsers.version>0.40</gbif-parsers.version>
     <dwca-io.version>2.5</dwca-io.version>
-    <gbif-api.version>0.70</gbif-api.version>
+    <gbif-api.version>0.81</gbif-api.version>
     <gbif-common.version>0.44</gbif-common.version>
-    <dwc-api.version>1.21</dwc-api.version>
+    <dwc-api.version>1.22</dwc-api.version>
     <kvs.version>1.2</kvs.version>
     <hbase-utils.version>0.12</hbase-utils.version>
 

--- a/sdks/models/src/main/avro/extended-record.avsc
+++ b/sdks/models/src/main/avro/extended-record.avsc
@@ -8,7 +8,7 @@
   "type": "record",
   "doc": "A container for an extended DwC record (core plus extension data for a single record)",
   "fields": [
-    {"name": "id", "type": "string", "doc":"Pipelines identifier"},
+    {"name": "id", "type": "string", "doc":"Core record identifier (Equivalent to the id field in a DwC-A)"},
     {"name": "coreRowType","type": "string","doc": "A URI for the term identifying the class of data represented by each row", "default": "http://rs.tdwg.org/dwc/terms/Occurrence"},
     {"name": "coreTerms", "doc": "The core record terms", "default": {}, "type": {"type": "map", "values": "string"}},
     {"name": "extensions", "doc": "The extensions records", "default": {}, "type": {


### PR DESCRIPTION
This is the first steps towards addressing #158 but still needs some work before closing the issue (work outstanding is to provide packaging to run on the cluster, save to HDFS, parameterise the sharding of the avro files and to allow a parameter to exclude datasets to avoid reprocessing e.g. eBird).

