### PR TITLE
Vocabularies

### DIFF
--- a/ala/pom.xml
+++ b/ala/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ala/pom.xml
+++ b/ala/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.gbif.pipelines</groupId>
+    <artifactId>pipelines-parent</artifactId>
+    <version>2.5.2-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>ala</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Pipelines :: ALA</name>
+  <description>Atlas of Living Australia</description>
+
+
+</project>

--- a/cli/crawler-integration-tests/pom.xml
+++ b/cli/crawler-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler-integration-tests/pom.xml
+++ b/cli/crawler-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler-integration-tests/pom.xml
+++ b/cli/crawler-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler/pom.xml
+++ b/cli/crawler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler/pom.xml
+++ b/cli/crawler/pom.xml
@@ -42,6 +42,7 @@
               <excludes>
                 <exclude>hidden/com/fasterxml/jackson/**</exclude>
                 <exclude>retrofit2/**</exclude>
+                <exclude>vocab/**</exclude>
               </excludes>
             </filter>
           </filters>

--- a/cli/crawler/pom.xml
+++ b/cli/crawler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler/pom.xml
+++ b/cli/crawler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>cli</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/crawler/pom.xml
+++ b/cli/crawler/pom.xml
@@ -42,7 +42,6 @@
               <excludes>
                 <exclude>hidden/com/fasterxml/jackson/**</exclude>
                 <exclude>retrofit2/**</exclude>
-                <exclude>vocab/**</exclude>
               </excludes>
             </filter>
           </filters>

--- a/cli/crawler/src/main/java/org/gbif/pipelines/crawler/interpret/InterpreterConfiguration.java
+++ b/cli/crawler/src/main/java/org/gbif/pipelines/crawler/interpret/InterpreterConfiguration.java
@@ -120,6 +120,9 @@ public class InterpreterConfiguration implements BaseConfiguration {
   @Parameter(names = "--delete-after-days")
   public long deleteAfterDays = 7L;
 
+  @Parameter(names = "--vocabularies-path")
+  public String vocabulariesPath;
+
   @Override
   public String getHdfsSiteConfig() {
     return stepConfig.hdfsSiteConfig;

--- a/cli/crawler/src/main/java/org/gbif/pipelines/crawler/interpret/ProcessRunnerBuilder.java
+++ b/cli/crawler/src/main/java/org/gbif/pipelines/crawler/interpret/ProcessRunnerBuilder.java
@@ -124,7 +124,8 @@ final class ProcessRunnerBuilder {
         .add("--hdfsSiteConfig=" + Objects.requireNonNull(config.stepConfig.hdfsSiteConfig))
         .add("--coreSiteConfig=" + Objects.requireNonNull(config.stepConfig.coreSiteConfig))
         .add("--properties=" + Objects.requireNonNull(config.pipelinesConfig))
-        .add("--endPointType=" + Objects.requireNonNull(message.getEndpointType()));
+        .add("--endPointType=" + Objects.requireNonNull(message.getEndpointType()))
+        .add("--vocabulariesPath=" + Objects.requireNonNull(config.vocabulariesPath));;
 
     Optional.ofNullable(message.getValidationResult())
         .ifPresent(vr -> command

--- a/cli/crawler/src/test/java/org/gbif/pipelines/crawler/interpret/ProcessRunnerBuilderTest.java
+++ b/cli/crawler/src/test/java/org/gbif/pipelines/crawler/interpret/ProcessRunnerBuilderTest.java
@@ -39,7 +39,7 @@ public class ProcessRunnerBuilderTest {
             + "-cp java.jar org.gbif.Test --pipelineStep=VERBATIM_TO_INTERPRETED --datasetId=de7ffb5e-c07b-42dc-8a88-f67a4465fe3d --attempt=1 "
             + "--interpretationTypes=ALL --runner=SparkRunner --targetPath=tmp --metaFileName=verbatim-to-interpreted.yml --inputPath=verbatim.avro "
             + "--avroCompressionType=SNAPPY --avroSyncInterval=1 --hdfsSiteConfig=hdfs.xml --coreSiteConfig=core.xml "
-            + "--properties=/path/ws.config --endPointType=DWC_ARCHIVE --tripletValid=true --occurrenceIdValid=true";
+            + "--properties=/path/ws.config --endPointType=DWC_ARCHIVE --vocabulariesPath=vocabs --tripletValid=true --occurrenceIdValid=true";
 
     InterpreterConfiguration config = new InterpreterConfiguration();
     config.standaloneJarPath = "java.jar";
@@ -54,6 +54,7 @@ public class ProcessRunnerBuilderTest {
     config.stepConfig.coreSiteConfig = "core.xml";
     config.stepConfig.hdfsSiteConfig = "hdfs.xml";
     config.stepConfig.repositoryPath = "tmp";
+    config.vocabulariesPath = "vocabs";
 
     UUID datasetId = UUID.fromString("de7ffb5e-c07b-42dc-8a88-f67a4465fe3d");
     int attempt = 1;
@@ -83,7 +84,8 @@ public class ProcessRunnerBuilderTest {
             + "--driver-memory 4G java.jar --datasetId=de7ffb5e-c07b-42dc-8a88-f67a4465fe3d --attempt=1 --interpretationTypes=ALL "
             + "--runner=SparkRunner --targetPath=tmp --metaFileName=verbatim-to-interpreted.yml --inputPath=verbatim.avro "
             + "--avroCompressionType=SNAPPY --avroSyncInterval=1 --hdfsSiteConfig=hdfs.xml --coreSiteConfig=core.xml "
-            + "--properties=/path/ws.config --endPointType=DWC_ARCHIVE --tripletValid=true --occurrenceIdValid=true --useExtendedRecordId=true";
+            + "--properties=/path/ws.config --endPointType=DWC_ARCHIVE --vocabulariesPath=vocabs --tripletValid=true --occurrenceIdValid=true "
+            + "--useExtendedRecordId=true";
 
     InterpreterConfiguration config = new InterpreterConfiguration();
     config.distributedJarPath = "java.jar";
@@ -103,6 +105,7 @@ public class ProcessRunnerBuilderTest {
     config.stepConfig.repositoryPath = "tmp";
     config.stepConfig.coreSiteConfig = "core.xml";
     config.stepConfig.hdfsSiteConfig = "hdfs.xml";
+    config.vocabulariesPath = "vocabs";
 
     UUID datasetId = UUID.fromString("de7ffb5e-c07b-42dc-8a88-f67a4465fe3d");
     int attempt = 1;
@@ -141,7 +144,8 @@ public class ProcessRunnerBuilderTest {
             + "--deploy-mode cluster --executor-memory 1G --executor-cores 1 --num-executors 1 --driver-memory 4G java.jar "
             + "--datasetId=de7ffb5e-c07b-42dc-8a88-f67a4465fe3d --attempt=1 --interpretationTypes=ALL --runner=SparkRunner "
             + "--targetPath=tmp --metaFileName=verbatim-to-interpreted.yml --inputPath=verbatim.avro --avroCompressionType=SNAPPY "
-            + "--avroSyncInterval=1 --hdfsSiteConfig=hdfs.xml --coreSiteConfig=core.xml --properties=/path/ws.config --endPointType=DWC_ARCHIVE";
+            + "--avroSyncInterval=1 --hdfsSiteConfig=hdfs.xml --coreSiteConfig=core.xml --properties=/path/ws.config --endPointType=DWC_ARCHIVE "
+            + "--vocabulariesPath=vocabs";
 
     InterpreterConfiguration config = new InterpreterConfiguration();
     config.distributedJarPath = "java.jar";
@@ -166,6 +170,7 @@ public class ProcessRunnerBuilderTest {
     config.stepConfig.hdfsSiteConfig = "hdfs.xml";
     config.stepConfig.coreSiteConfig = "core.xml";
     config.stepConfig.repositoryPath = "tmp";
+    config.vocabulariesPath = "vocabs";
 
     UUID datasetId = UUID.fromString("de7ffb5e-c07b-42dc-8a88-f67a4465fe3d");
     int attempt = 1;

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/metrics/pom.xml
+++ b/examples/metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/metrics/pom.xml
+++ b/examples/metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/metrics/pom.xml
+++ b/examples/metrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines-parent</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines-parent</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines-parent</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/transform/pom.xml
+++ b/examples/transform/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/transform/pom.xml
+++ b/examples/transform/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/transform/pom.xml
+++ b/examples/transform/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>examples</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/beam-common/pom.xml
+++ b/pipelines/beam-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/beam-common/pom.xml
+++ b/pipelines/beam-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/beam-common/pom.xml
+++ b/pipelines/beam-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/common/pom.xml
+++ b/pipelines/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/export-gbif-hbase/pom.xml
+++ b/pipelines/export-gbif-hbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/export-gbif-hbase/pom.xml
+++ b/pipelines/export-gbif-hbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/export-gbif-hbase/pom.xml
+++ b/pipelines/export-gbif-hbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-fragmenter/pom.xml
+++ b/pipelines/ingest-fragmenter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-fragmenter/pom.xml
+++ b/pipelines/ingest-fragmenter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-fragmenter/pom.xml
+++ b/pipelines/ingest-fragmenter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-fragmenter/src/main/java/org/gbif/pipelines/fragmenter/common/Keygen.java
+++ b/pipelines/ingest-fragmenter/src/main/java/org/gbif/pipelines/fragmenter/common/Keygen.java
@@ -65,9 +65,6 @@ public class Keygen {
   }
 
   public static String getSaltedKey(Long key) {
-    if (Objects.equals(key, ERROR_KEY)) {
-      return ERROR_KEY.toString();
-    }
     long salt = key % 100;
     String result = salt + ":" + key;
     return salt >= 10 ? result : "0" + result;

--- a/pipelines/ingest-gbif-java/pom.xml
+++ b/pipelines/ingest-gbif-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif-java/pom.xml
+++ b/pipelines/ingest-gbif-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif-java/pom.xml
+++ b/pipelines/ingest-gbif-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/io/AvroReader.java
+++ b/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/io/AvroReader.java
@@ -123,8 +123,7 @@ public class AvroReader {
   @SneakyThrows
   private static List<Path> parseWildcardPath(FileSystem fs, String path) {
     if (path.contains("*")) {
-      File parentFile = new File(path).getParentFile();
-      Path pp = new Path(parentFile.getPath().replace("hdfs:/ha-nn", "hdfs://ha-nn"));
+      Path pp = new Path(path).getParent();
       RemoteIterator<LocatedFileStatus> files = fs.listFiles(pp, false);
       List<Path> paths = new ArrayList<>();
       while (files.hasNext()) {

--- a/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/io/AvroReader.java
+++ b/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/io/AvroReader.java
@@ -1,6 +1,5 @@
 package org.gbif.pipelines.ingest.java.io;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,7 +21,8 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,7 +30,7 @@ import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.AVRO_EXTENSI
 
 /** Avro format reader, reads {@link Record} based objects using sting or {@link List<Path>} path */
 @Slf4j
-@AllArgsConstructor(staticName = "create")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AvroReader {
 
   /**

--- a/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -56,6 +56,7 @@ import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
 import org.gbif.pipelines.transforms.extension.MultimediaTransform;
 import org.gbif.pipelines.transforms.metadata.MetadataTransform;
 import org.gbif.pipelines.transforms.metadata.TaggedValuesTransform;
+import org.gbif.vocabulary.lookup.VocabularyLookup;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
@@ -150,6 +151,7 @@ public class VerbatimToInterpretedPipeline {
     String endPointType = options.getEndPointType();
     String hdfsSiteConfig = options.getHdfsSiteConfig();
     PipelinesConfig config = PipelinesConfigFactory.getInstance(hdfsSiteConfig, options.getProperties()).get();
+    String vocabulariesPath = options.getVocabulariesPath();
 
     FsUtils.deleteInterpretIfExist(hdfsSiteConfig, targetPath, datasetId, attempt, types);
 
@@ -176,6 +178,10 @@ public class VerbatimToInterpretedPipeline {
     BasicTransform basicTransform =
         BasicTransform.builder()
             .keygenServiceSupplier(KeygenServiceFactory.getInstanceSupplier(config, datasetId))
+            .lifeStageLookupSupplier(
+                () ->
+                    VocabularyLookup.load(
+                        FsUtils.readVocabularyFile(hdfsSiteConfig, vocabulariesPath, "LifeStage")))
             .isTripletValid(tripletValid)
             .isOccurrenceIdValid(occIdValid)
             .useExtendedRecordId(useErdId)

--- a/pipelines/ingest-gbif-standalone/pom.xml
+++ b/pipelines/ingest-gbif-standalone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif-standalone/pom.xml
+++ b/pipelines/ingest-gbif-standalone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif-standalone/pom.xml
+++ b/pipelines/ingest-gbif-standalone/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif/pom.xml
+++ b/pipelines/ingest-gbif/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif/pom.xml
+++ b/pipelines/ingest-gbif/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif/pom.xml
+++ b/pipelines/ingest-gbif/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/ingest-gbif/pom.xml
+++ b/pipelines/ingest-gbif/pom.xml
@@ -210,10 +210,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
 
     <!-- test -->
     <dependency>

--- a/pipelines/ingest-gbif/pom.xml
+++ b/pipelines/ingest-gbif/pom.xml
@@ -210,6 +210,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/options/InterpretationPipelineOptions.java
+++ b/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/options/InterpretationPipelineOptions.java
@@ -87,6 +87,11 @@ public interface InterpretationPipelineOptions
 
   void setNumberOfShards(Integer numberOfShards);
 
+  @Description("Path to the directory that contains the vocabularies")
+  String getVocabulariesPath();
+
+  void setVocabulariesPath(String path);
+
   /** A {@link DefaultValueFactory} which locates a default directory. */
   class TempDirectoryFactory implements DefaultValueFactory<String> {
 

--- a/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/pipelines/VerbatimToInterpretedPipeline.java
+++ b/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/pipelines/VerbatimToInterpretedPipeline.java
@@ -34,6 +34,7 @@ import org.gbif.pipelines.transforms.extension.MultimediaTransform;
 import org.gbif.pipelines.transforms.metadata.DefaultValuesTransform;
 import org.gbif.pipelines.transforms.metadata.MetadataTransform;
 import org.gbif.pipelines.transforms.metadata.TaggedValuesTransform;
+import org.gbif.vocabulary.lookup.VocabularyLookup;
 
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -111,6 +112,7 @@ public class VerbatimToInterpretedPipeline {
     String targetPath = options.getTargetPath();
     String hdfsSiteConfig = options.getHdfsSiteConfig();
     PipelinesConfig config = FsUtils.readConfigFile(hdfsSiteConfig, options.getProperties());
+    String vocabulariesPath = options.getVocabulariesPath();
 
     FsUtils.deleteInterpretIfExist(hdfsSiteConfig, targetPath, datasetId, attempt, types);
 
@@ -139,6 +141,10 @@ public class VerbatimToInterpretedPipeline {
     BasicTransform basicTransform =
         BasicTransform.builder()
             .keygenServiceSupplier(KeygenServiceFactory.createSupplier(config, datasetId))
+            .lifeStageLookupSupplier(
+                () ->
+                    VocabularyLookup.load(
+                        FsUtils.readVocabularyFile(hdfsSiteConfig, vocabulariesPath, "LifeStage")))
             .isTripletValid(tripletValid)
             .isOccurrenceIdValid(occurrenceIdValid)
             .useExtendedRecordId(useExtendedRecordId)

--- a/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/utils/FsUtils.java
+++ b/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/utils/FsUtils.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -300,7 +301,28 @@ public final class FsUtils {
         return mapper.readValue(br, PipelinesConfig.class);
       }
     }
+
     throw new FileNotFoundException("The properties file doesn't exist - " + filePath);
+  }
+
+  /**
+   * Read a file from HDFS/Local FS
+   *
+   * @param hdfsSiteConfig HDFS config file
+   * @param vocabulariesDir dir where the vocabulary files are
+   * @param vocabularyName name of the vocabulary
+   * @return {@link InputStream}
+   */
+  @SneakyThrows
+  public static InputStream readVocabularyFile(String hdfsSiteConfig, String vocabulariesDir, String vocabularyName) {
+    FileSystem fs = FsUtils.getFileSystem(hdfsSiteConfig, vocabulariesDir);
+    Path fPath = buildPath(vocabulariesDir, vocabularyName + ".json");
+    if (fs.exists(fPath)) {
+      log.info("Reading vocabularies path - {}", fPath);
+      return fs.open(fPath);
+    }
+
+    throw new FileNotFoundException("The vocabularies file doesn't exist - " + fPath);
   }
 
   /**

--- a/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/utils/FsUtils.java
+++ b/pipelines/ingest-gbif/src/main/java/org/gbif/pipelines/ingest/utils/FsUtils.java
@@ -306,11 +306,11 @@ public final class FsUtils {
   }
 
   /**
-   * Read a file from HDFS/Local FS
+   * Reads a vocabulary file from HDFS/Local FS
    *
    * @param hdfsSiteConfig HDFS config file
    * @param vocabulariesDir dir where the vocabulary files are
-   * @param vocabularyName name of the vocabulary
+   * @param vocabularyName name of the vocabulary. It has to be the same as the one used in the file name.
    * @return {@link InputStream}
    */
   @SneakyThrows
@@ -322,7 +322,7 @@ public final class FsUtils {
       return fs.open(fPath);
     }
 
-    throw new FileNotFoundException("The vocabularies file doesn't exist - " + fPath);
+    throw new FileNotFoundException("The vocabulary file doesn't exist - " + fPath);
   }
 
   /**

--- a/pipelines/ingest-transforms/pom.xml
+++ b/pipelines/ingest-transforms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pipelines/ingest-transforms/pom.xml
+++ b/pipelines/ingest-transforms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pipelines/ingest-transforms/pom.xml
+++ b/pipelines/ingest-transforms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>pipelines</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pipelines/ingest-transforms/src/test/java/org/gbif/pipelines/transforms/core/BasicRecordTransformTest.java
+++ b/pipelines/ingest-transforms/src/test/java/org/gbif/pipelines/transforms/core/BasicRecordTransformTest.java
@@ -50,10 +50,10 @@ public class BasicRecordTransformTest {
 
     // State
     final String[] one = {
-        "0", "OBSERVATION", "MALE", "INTRODUCED", "SPOROPHYTE", "HOLOTYPE", "2", "http://refs.com"
+        "0", "OBSERVATION", "MALE", "INTRODUCED", "HOLOTYPE", "2", "http://refs.com"
     };
     final String[] two = {
-        "1", "UNKNOWN", "HERMAPHRODITE", "INTRODUCED", "GAMETE", "HAPANTOTYPE", "1", "http://refs.com"
+        "1", "UNKNOWN", "HERMAPHRODITE", "INTRODUCED", "HAPANTOTYPE", "1", "http://refs.com"
     };
     final List<ExtendedRecord> records = createExtendedRecordList(one, two);
 
@@ -119,10 +119,9 @@ public class BasicRecordTransformTest {
               record.getCoreTerms().put(DwcTerm.basisOfRecord.qualifiedName(), x[1]);
               record.getCoreTerms().put(DwcTerm.sex.qualifiedName(), x[2]);
               record.getCoreTerms().put(DwcTerm.establishmentMeans.qualifiedName(), x[3]);
-              record.getCoreTerms().put(DwcTerm.lifeStage.qualifiedName(), x[4]);
-              record.getCoreTerms().put(DwcTerm.typeStatus.qualifiedName(), x[5]);
-              record.getCoreTerms().put(DwcTerm.individualCount.qualifiedName(), x[6]);
-              record.getCoreTerms().put(DcTerm.references.qualifiedName(), x[7]);
+              record.getCoreTerms().put(DwcTerm.typeStatus.qualifiedName(), x[4]);
+              record.getCoreTerms().put(DwcTerm.individualCount.qualifiedName(), x[5]);
+              record.getCoreTerms().put(DcTerm.references.qualifiedName(), x[6]);
               return record;
             })
         .collect(Collectors.toList());
@@ -138,10 +137,9 @@ public class BasicRecordTransformTest {
                     .setBasisOfRecord(x[1])
                     .setSex(x[2])
                     .setEstablishmentMeans(x[3])
-                    .setLifeStage(x[4])
-                    .setTypeStatus(x[5])
-                    .setIndividualCount(Integer.valueOf(x[6]))
-                    .setReferences(x[7])
+                    .setTypeStatus(x[4])
+                    .setIndividualCount(Integer.valueOf(x[5]))
+                    .setReferences(x[6])
                     .setLicense(License.UNSPECIFIED.name())
                     .build())
         .collect(Collectors.toList());

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.gbif.pipelines</groupId>
   <artifactId>pipelines-parent</artifactId>
-  <version>2.5.2-SNAPSHOT</version>
+  <version>2.5.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.gbif.pipelines</groupId>
   <artifactId>pipelines-parent</artifactId>
-  <version>2.5.1</version>
+  <version>2.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -29,7 +29,7 @@
     <connection>scm:git:git@github.com:gbif/pipelines.git</connection>
     <url>https://github.com/gbif/pipelines</url>
     <developerConnection>scm:git:git@github.com:gbif/pipelines.git</developerConnection>
-    <tag>pipelines-parent-2.5.1</tag>
+    <tag>pipelines-parent-2.2.11</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.gbif.pipelines</groupId>
   <artifactId>pipelines-parent</artifactId>
-  <version>2.5.1-SNAPSHOT</version>
+  <version>2.5.1</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -29,7 +29,7 @@
     <connection>scm:git:git@github.com:gbif/pipelines.git</connection>
     <url>https://github.com/gbif/pipelines</url>
     <developerConnection>scm:git:git@github.com:gbif/pipelines.git</developerConnection>
-    <tag>pipelines-parent-2.2.11</tag>
+    <tag>pipelines-parent-2.5.1</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>pipelines</module>
     <module>examples</module>
     <module>cli</module>
+    <module>ala</module>
   </modules>
 
   <name>Pipelines :: Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <gbif-wrangler.version>0.3</gbif-wrangler.version>
     <gbif-occurrence.version>0.124</gbif-occurrence.version>
     <data-repo-api.version>1.2</data-repo-api.version>
+    <vocabulary-lookup.version>0.22-SNAPSHOT</vocabulary-lookup.version>
 
     <!-- Common libraries -->
     <avro.version>1.8.2</avro.version>
@@ -513,6 +514,12 @@
         <artifactId>data-repo-api</artifactId>
         <version>${data-repo-api.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.gbif.vocabulary</groupId>
+        <artifactId>vocabulary-lookup</artifactId>
+        <version>${vocabulary-lookup.version}</version>
+        <classifier>shaded</classifier>
+      </dependency>
 
       <!-- Avro -->
       <dependency>
@@ -739,6 +746,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-avro</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
       </dependency>
 

--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -64,6 +64,11 @@
       <groupId>org.gbif.pipelines</groupId>
       <artifactId>keygen</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.gbif.vocabulary</groupId>
+      <artifactId>vocabulary-lookup</artifactId>
+      <classifier>shaded</classifier>
+    </dependency>
 
     <!-- HDFS Table -->
     <dependency>

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/BasicInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/BasicInterpreter.java
@@ -162,7 +162,9 @@ public class BasicInterpreter {
       }
 
       String value = extractValue(er, DwcTerm.lifeStage);
-      vocabularyLookup.lookup(value).map(Concept::getName).ifPresent(br::setLifeStage);
+      if (!Strings.isNullOrEmpty(value)) {
+        vocabularyLookup.lookup(value).map(Concept::getName).ifPresent(br::setLifeStage);
+      }
     };
   }
 

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/LocationInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/LocationInterpreter.java
@@ -59,7 +59,7 @@ public class LocationInterpreter {
 
   private static final double COORDINATE_PRECISION_LOWER_BOUND = 0d;
   // 45 close to 5000 km
-  private static final double COORDINATE_PRECISION_UPPER_BOUND = 45d;
+  private static final double COORDINATE_PRECISION_UPPER_BOUND = 1d;
 
   //List of Geospatial Issues
   private static final Set<String> SPATIAL_ISSUES =

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
@@ -20,7 +20,6 @@ import org.gbif.api.vocabulary.Country;
 import org.gbif.api.vocabulary.EndpointType;
 import org.gbif.api.vocabulary.EstablishmentMeans;
 import org.gbif.api.vocabulary.License;
-import org.gbif.api.vocabulary.LifeStage;
 import org.gbif.api.vocabulary.OccurrenceIssue;
 import org.gbif.api.vocabulary.Sex;
 import org.gbif.api.vocabulary.TypeStatus;
@@ -203,7 +202,7 @@ public class OccurrenceHdfsRecordConverterTest {
     basicRecord.setBasisOfRecord(BasisOfRecord.HUMAN_OBSERVATION.name());
     basicRecord.setSex(Sex.HERMAPHRODITE.name());
     basicRecord.setIndividualCount(99);
-    basicRecord.setLifeStage(LifeStage.GAMETE.name());
+    basicRecord.setLifeStage("Larva");
     basicRecord.setTypeStatus(TypeStatus.ALLOTYPE.name());
     basicRecord.setTypifiedName("noName");
     basicRecord.setEstablishmentMeans(EstablishmentMeans.INVASIVE.name());
@@ -224,7 +223,7 @@ public class OccurrenceHdfsRecordConverterTest {
     Assert.assertEquals(BasisOfRecord.HUMAN_OBSERVATION.name(), hdfsRecord.getBasisofrecord());
     Assert.assertEquals(Sex.HERMAPHRODITE.name(), hdfsRecord.getSex());
     Assert.assertEquals(Integer.valueOf(99), hdfsRecord.getIndividualcount());
-    Assert.assertEquals(LifeStage.GAMETE.name(), hdfsRecord.getLifestage());
+    Assert.assertEquals("Larva", hdfsRecord.getLifestage());
     Assert.assertEquals(TypeStatus.ALLOTYPE.name(), hdfsRecord.getTypestatus());
     Assert.assertEquals("noName", hdfsRecord.getTypifiedname());
     Assert.assertEquals(EstablishmentMeans.INVASIVE.name(), hdfsRecord.getEstablishmentmeans());

--- a/sdks/keygen/pom.xml
+++ b/sdks/keygen/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/keygen/pom.xml
+++ b/sdks/keygen/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/keygen/pom.xml
+++ b/sdks/keygen/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/models/pom.xml
+++ b/sdks/models/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/models/pom.xml
+++ b/sdks/models/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/models/pom.xml
+++ b/sdks/models/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>sdks</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/models/src/main/avro/core/location-record.avsc
+++ b/sdks/models/src/main/avro/core/location-record.avsc
@@ -33,6 +33,7 @@
     {"name": "repatriated","type":["null","boolean"],"default":null, "doc":"https://gbif.github.io/gbif-api/apidocs/org/gbif/api/model/occurrence/search/OccurrenceSearchParameter.html#REPATRIATED"},
     {"name": "hasGeospatialIssue","type":["null","boolean"],"default":null, "doc":"https://gbif.github.io/gbif-api/apidocs/org/gbif/api/model/occurrence/search/OccurrenceSearchParameter.html#HAS_GEOSPATIAL_ISSUE"},
     {"name": "locality","type":["null","string"],"default":null, "doc":"http://rs.tdwg.org/dwc/terms/locality"},
+     {"name": "georeferencedDate", "type": ["null", "string"], "logicalType":"timestamp-millis", "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/dateIdentified"},
     {"name": "issues", "type": "IssueRecord", "default":{}}
   ]
 }

--- a/sdks/parsers/pom.xml
+++ b/sdks/parsers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>sdks</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sdks/parsers/pom.xml
+++ b/sdks/parsers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>sdks</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sdks/parsers/pom.xml
+++ b/sdks/parsers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>sdks</artifactId>
     <groupId>org.gbif.pipelines</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sdks/parsers/src/main/java/org/gbif/pipelines/parsers/parsers/VocabularyParser.java
+++ b/sdks/parsers/src/main/java/org/gbif/pipelines/parsers/parsers/VocabularyParser.java
@@ -61,6 +61,7 @@ public class VocabularyParser<T extends Enum<T>> {
   }
 
   /** @return a life stage parser. */
+  @Deprecated
   public static VocabularyParser<LifeStage> lifeStageParser() {
     return new VocabularyParser<>(LST_PARSER, DwcTerm.lifeStage);
   }

--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/archives-converters/pom.xml
+++ b/tools/archives-converters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/archives-converters/pom.xml
+++ b/tools/archives-converters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/archives-converters/pom.xml
+++ b/tools/archives-converters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/elasticsearch-tools/pom.xml
+++ b/tools/elasticsearch-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/elasticsearch-tools/pom.xml
+++ b/tools/elasticsearch-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/elasticsearch-tools/pom.xml
+++ b/tools/elasticsearch-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pipelines-maven-plugin/pom.xml
+++ b/tools/pipelines-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pipelines-maven-plugin/pom.xml
+++ b/tools/pipelines-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pipelines-maven-plugin/pom.xml
+++ b/tools/pipelines-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>tools</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
NOTE: this can't be merged yet until the other parts are ready and deployed (UI, API, vocabulary reviewed, etc.) but I think we can already do a first review of this integration to see how it fits - no hurries.

For this integration, pipelines reads the vocabularies from HDFS and uses the [`vocabulary-lookup library`](https://github.com/gbif/vocabulary/tree/master/vocabulary-lookup) to find matches. The vocabulary ws will update these files in the HDFS directory every time there is a new release of a vocabulary, therefore pipelines doesn't have to worry about vocabulary versions. This part is not implemented in the vocabulary ws yet though (it'll be soon even though at the beginning it's not fully required, we can copy the file manually). In DEV the vocabulary to test it is in http://c3master3-vh.gbif.org:8888/hue/filebrowser/view=/user/admin#/pipelines/vocabularies.

Instead of reading the file and passing it to the `vocabulary-lookup` library, we can also tell the library to download the latest version of a vocabulary. To be decided if this can be useful or not, I think for pipelines it's more convenient to read from HDFS but I don't know for others (e.g.: ALA).

Also, I had to shade the `vocabulary-lookup` library because I was getting classpath issues with jackson dependencies. The size of the library shaded is around 6.5MB. 

In addition, I wanted to keep it simple for now but when we add more vocabularies I believe we'd probably have to encapsulate all the vocabularies in a class because we'd need a `VocabularyLookup` instance for each of them.

