### PR TITLE
Fix for #337 - Parameterize ports for the LivingAtlas docker-based tests

### DIFF
--- a/livingatlas/README.md
+++ b/livingatlas/README.md
@@ -72,7 +72,11 @@ These steps will load a dataset into a SOLR index.
 
 ### Running la-pipelines
 
-1. Start required docker containers using `mvn docker:start`
+1. Start required docker containers using
+```
+docker-compose -f pipelines/src/main/docker/ala-nameservice.yml up -d
+docker-compose -f pipelines/src/main/docker/solr8.yml up -d
+```
 1. `cd scripts`
 1. To convert DwCA to AVRO, run `./dwca-avro.sh dr893`
 1. To interpret, run `./interpret-spark-embedded.sh dr893`
@@ -101,27 +105,21 @@ To start the required containers for local development purposes,
 install [Docker Desktop](https://www.docker.com/products/docker-desktop) and run the following:
 
 ```
-mvn docker:start
-```
-
-and shutdown like so:
-
-```
-mvn docker:stop
-```
-
-Alternatively, they can be ran separately like so
-
-```
-docker-compose -f src/main/docker/ala-nameservice.yml up -d
-docker-compose -f src/main/docker/solr8.yml up -d
+docker-compose -f pipelines/src/main/docker/ala-nameservice.yml up -d
+docker-compose -f pipelines/src/main/docker/solr8.yml up -d
 ```
 
 To shutdown, run the following:
 ```
-docker-compose -f src/main/docker/ala-nameservice.yml kill
-docker-compose -f src/main/docker/solr8.yml kill
+docker-compose -f pipelines/src/main/docker/ala-nameservice.yml kill
+docker-compose -f pipelines/src/main/docker/solr8.yml kill
 ```
+
+Note: The docker containers that are ran as part of the maven build run on different 
+ports to those specified in the docker compose files `pipelines/src/main/docker`. 
+This was a deliberate choice allow developers to run integration tests in IDEs while developing pipelines,
+and then run maven builds on the same machine without port clashes.
+
 
 ## Code style and tools
 

--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -75,6 +75,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <systemPropertyVariables>
+            <pipelinesTestYamlConfigFile>target/test-classes/pipelines-maven.yaml</pipelinesTestYamlConfigFile>
+          </systemPropertyVariables>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -89,6 +92,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <pipelinesTestYamlConfigFile>target/test-classes/pipelines-maven.yaml</pipelinesTestYamlConfigFile>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
       <!-- Shade the project into an uber jar to send to Spark -->
       <plugin>
@@ -189,22 +197,32 @@
             <image>
               <alias>solr8</alias>
               <name>djtfmartin/biocache-pipelines-solr8:v3</name>
-              <external>
-                <type>compose</type>
-                <composeFile>solr8.yml</composeFile>
-              </external>
+              <run>
+                <ports>
+                  <port>${solr8.zk.port}:${solr8.zk.port}</port>
+                  <port>${solr8.http.port}:${solr8.http.port}</port>
+                </ports>
+                <env>
+                  <ZK_HOST>localhost:${solr8.zk.port}</ZK_HOST>
+                  <SOLR_PORT>${solr8.http.port}</SOLR_PORT>
+                  <SOLR_HOST>localhost</SOLR_HOST>
+                </env>
+                <entrypoint>
+                  <shell>solr start -c -f  -p ${solr8.http.port}</shell>
+                </entrypoint>
+              </run>
             </image>
             <image>
               <alias>ala-nameservice</alias>
               <name>djtfmartin/ala-namematching-service:v20200214-4</name>
-              <external>
-                <type>compose</type>
-                <composeFile>ala-nameservice.yml</composeFile>
-              </external>
               <run>
+                <ports>
+                  <port>${alanm.admin.port}:9180</port>
+                  <port>${alanm.port}:9179</port>
+                </ports>
                 <wait>
                   <http>
-                    <url>http://localhost:${alanm.port}/api/search?q=Acacia</url>
+                    <url>http://${alanm.host}:${alanm.port}/api/search?q=Acacia</url>
                     <method>GET</method>
                     <status>200</status>
                   </http>
@@ -223,8 +241,14 @@
     <surefireArgLine>-Xmx1024m</surefireArgLine>
 
     <!-- Default port for ALA Name Matcher Docker container -->
-    <alanm.port>9179</alanm.port>
-    <!-- TODO: Port to replace 9180, and the SOLR container -->
+    <alanm.port>9279</alanm.port>
+    <alanm.admin.port>9280</alanm.admin.port>
+    <alanm.host>localhost</alanm.host>
+    <solr8.zk.port>9973</solr8.zk.port>
+    <solr8.http.port>8973</solr8.http.port>
+    <solr8.zk.host>localhost</solr8.zk.host>
+    <solr8.http.host>localhost</solr8.http.host>
+    <collectory.url>https://collections.ala.org.au</collectory.url>
 
     <!-- Tools-->
     <geotools.version>20.5</geotools.version>

--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -25,6 +25,13 @@
   </repositories>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
     <plugins>
       <!-- Download supporting shapefiles -->
       <plugin>
@@ -197,7 +204,7 @@
               <run>
                 <wait>
                   <http>
-                    <url>http://localhost:9179/api/search?q=Acacia</url>
+                    <url>http://localhost:${alanm.port}/api/search?q=Acacia</url>
                     <method>GET</method>
                     <status>200</status>
                   </http>
@@ -214,6 +221,10 @@
   <properties>
     <!-- Common variables -->
     <surefireArgLine>-Xmx1024m</surefireArgLine>
+
+    <!-- Default port for ALA Name Matcher Docker container -->
+    <alanm.port>9179</alanm.port>
+    <!-- TODO: Port to replace 9180, and the SOLR container -->
 
     <!-- Tools-->
     <geotools.version>20.5</geotools.version>

--- a/livingatlas/pipelines/src/main/docker/ala-nameservice.yml
+++ b/livingatlas/pipelines/src/main/docker/ala-nameservice.yml
@@ -6,4 +6,4 @@ services:
     image: "djtfmartin/ala-namematching-service:v20200214-4"
     ports:
       - "9180:9180"
-      - "9179:9179"
+      - "alanm.port:9179"

--- a/livingatlas/pipelines/src/main/docker/ala-nameservice.yml
+++ b/livingatlas/pipelines/src/main/docker/ala-nameservice.yml
@@ -6,4 +6,4 @@ services:
     image: "djtfmartin/ala-namematching-service:v20200214-4"
     ports:
       - "9180:9180"
-      - "alanm.port:9179"
+      - "9179:9179"

--- a/livingatlas/pipelines/src/test/java/au/org/ala/kvs/NameMatchKVStoreTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/kvs/NameMatchKVStoreTestIT.java
@@ -33,28 +33,4 @@ public class NameMatchKVStoreTestIT {
 
     kvs.close();
   }
-
-  //    /**
-  //     * Tests the Get operation on {@link KeyValueCache} that wraps a simple KV store backed by a
-  // HashMap.
-  //     */
-  //    @Test
-  //    public void getCacheFailTest() throws Exception {
-  //
-  //        ClientConfiguration cc = ClientConfiguration.builder()
-  //                .withBaseApiUrl("http://localhostXXXXXX:9179") //GBIF base API url
-  //                .withTimeOut(10000l) //Geocode service connection time-out
-  //                .build();
-  //        KeyValueStore<ALASpeciesMatchRequest, ALANameUsageMatch> kvs =
-  // ALANameMatchKVStoreFactory.create(TestUtils.getConfig());
-  //
-  //        try {
-  //            ALASpeciesMatchRequest req =
-  // ALASpeciesMatchRequest.builder().scientificName("Macropus rufus").build();
-  //            ALANameUsageMatch match = kvs.get(req);
-  //            fail("Exception should be thrown");
-  //        } catch (RuntimeException e){
-  //            //expected
-  //        }
-  //    }
 }

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import au.org.ala.pipelines.options.ALASolrPipelineOptions;
 import au.org.ala.sampling.LayerCrawler;
 import au.org.ala.util.SolrUtils;
+import au.org.ala.util.TestUtils;
 import java.io.File;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
@@ -90,7 +91,7 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -105,7 +106,7 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);
@@ -120,7 +121,7 @@ public class CompleteIngestPipelineTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline",
-              "--properties=target/test-classes/pipelines.yaml"
+              "--properties=" + TestUtils.getPipelinesConfigFile()
             });
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
@@ -141,8 +142,8 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
-              "--zkHost=localhost:9983",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
+              "--zkHost=" + SolrUtils.getZkHost(),
               "--solrCollection=" + SolrUtils.BIOCACHE_TEST_SOLR_COLLECTION,
               "--includeSampling=true"
             });

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
@@ -90,7 +90,7 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -105,7 +105,7 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);
@@ -120,7 +120,7 @@ public class CompleteIngestPipelineTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline",
-              "--properties=src/test/resources/pipelines.yaml"
+              "--properties=target/test-classes/pipelines.yaml"
             });
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
@@ -141,7 +141,7 @@ public class CompleteIngestPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--zkHost=localhost:9983",
               "--solrCollection=" + SolrUtils.BIOCACHE_TEST_SOLR_COLLECTION,
               "--includeSampling=true"

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/DefaultValuesTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/DefaultValuesTestIT.java
@@ -1,5 +1,6 @@
 package au.org.ala.pipelines.beam;
 
+import au.org.ala.util.TestUtils;
 import java.io.File;
 import java.io.Serializable;
 import java.util.function.Function;
@@ -48,7 +49,7 @@ public class DefaultValuesTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
 
@@ -77,7 +78,7 @@ public class DefaultValuesTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -92,7 +93,7 @@ public class DefaultValuesTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/interpreted/verbatim/interpret-*",
-              "--properties=target/test-classes/pipelines.yaml"
+              "--properties=" + TestUtils.getPipelinesConfigFile()
             });
 
     // check default values are populated

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/DefaultValuesTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/DefaultValuesTestIT.java
@@ -48,7 +48,7 @@ public class DefaultValuesTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
 
@@ -77,7 +77,7 @@ public class DefaultValuesTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -92,7 +92,7 @@ public class DefaultValuesTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/default-values",
               "--inputPath=/tmp/la-pipelines-test/default-values/dr893/1/interpreted/verbatim/interpret-*",
-              "--properties=src/test/resources/pipelines.yaml"
+              "--properties=target/test-classes/pipelines.yaml"
             });
 
     // check default values are populated

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/MigrationPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/MigrationPipelineTestIT.java
@@ -3,6 +3,7 @@ package au.org.ala.pipelines.beam;
 import static org.junit.Assert.assertEquals;
 
 import au.org.ala.util.AvroUtils;
+import au.org.ala.util.TestUtils;
 import java.io.File;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -28,7 +29,7 @@ public class MigrationPipelineTestIT {
               "--metaFileName=/tmp/la-pipelines-test/uuid-migration/migration-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/uuid-migration",
               "--inputPath=" + absolutePath + "/uuid-migration/occ_uuid.csv",
-              "--properties=target/test-classes/pipelines.yaml"
+              "--properties=" + TestUtils.getPipelinesConfigFile()
             });
     MigrateUUIDPipeline.run(options);
 

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/MigrationPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/MigrationPipelineTestIT.java
@@ -28,7 +28,7 @@ public class MigrationPipelineTestIT {
               "--metaFileName=/tmp/la-pipelines-test/uuid-migration/migration-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/uuid-migration",
               "--inputPath=" + absolutePath + "/uuid-migration/occ_uuid.csv",
-              "--properties=src/test/resources/pipelines.yaml"
+              "--properties=target/test-classes/pipelines.yaml"
             });
     MigrateUUIDPipeline.run(options);
 

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/UUIDPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/UUIDPipelineTestIT.java
@@ -129,7 +129,7 @@ public class UUIDPipelineTestIT {
               "--inputPath=/tmp/la-pipelines-test/uuid-management/"
                   + datasetID
                   + "/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -146,7 +146,7 @@ public class UUIDPipelineTestIT {
               "--inputPath=/tmp/la-pipelines-test/uuid-management/"
                   + datasetID
                   + "/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/UUIDPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/UUIDPipelineTestIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import au.org.ala.util.AvroUtils;
+import au.org.ala.util.TestUtils;
 import java.io.File;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -129,7 +130,7 @@ public class UUIDPipelineTestIT {
               "--inputPath=/tmp/la-pipelines-test/uuid-management/"
                   + datasetID
                   + "/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -146,7 +147,7 @@ public class UUIDPipelineTestIT {
               "--inputPath=/tmp/la-pipelines-test/uuid-management/"
                   + datasetID
                   + "/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
@@ -96,7 +96,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     au.org.ala.pipelines.java.ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -111,7 +111,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);
@@ -126,7 +126,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline",
-              "--properties=src/test/resources/pipelines.yaml"
+              "--properties=target/test-classes/pipelines.yaml"
             });
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
@@ -147,7 +147,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=src/test/resources/pipelines.yaml",
+              "--properties=target/test-classes/pipelines.yaml",
               "--zkHost=localhost:9983",
               "--solrCollection=" + SolrUtils.BIOCACHE_TEST_SOLR_COLLECTION,
               "--includeSampling=true"

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
@@ -9,6 +9,7 @@ import au.org.ala.pipelines.beam.ALAUUIDMintingPipeline;
 import au.org.ala.pipelines.options.ALASolrPipelineOptions;
 import au.org.ala.sampling.LayerCrawler;
 import au.org.ala.util.SolrUtils;
+import au.org.ala.util.TestUtils;
 import java.io.File;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
@@ -96,7 +97,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=interpretation-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     au.org.ala.pipelines.java.ALAVerbatimToInterpretedPipeline.run(interpretationOptions);
@@ -111,7 +112,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
               "--useExtendedRecordId=true"
             });
     ALAUUIDMintingPipeline.run(uuidOptions);
@@ -126,7 +127,7 @@ public class CompleteIngestJavaPipelineTestIT {
               "--runner=DirectRunner",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline",
-              "--properties=target/test-classes/pipelines.yaml"
+              "--properties=" + TestUtils.getPipelinesConfigFile()
             });
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
@@ -147,8 +148,8 @@ public class CompleteIngestJavaPipelineTestIT {
               "--metaFileName=uuid-metrics.yml",
               "--targetPath=/tmp/la-pipelines-test/complete-pipeline",
               "--inputPath=/tmp/la-pipelines-test/complete-pipeline/dr893/1/verbatim.avro",
-              "--properties=target/test-classes/pipelines.yaml",
-              "--zkHost=localhost:9983",
+              "--properties=" + TestUtils.getPipelinesConfigFile(),
+              "--zkHost=" + SolrUtils.getZkHost(),
               "--solrCollection=" + SolrUtils.BIOCACHE_TEST_SOLR_COLLECTION,
               "--includeSampling=true"
             });

--- a/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
@@ -7,7 +7,7 @@ import java.io.File;
 public class TestUtils {
 
   public static ALAPipelinesConfig getConfig() {
-    String absolutePath = new File("src/test/resources/pipelines.yaml").getAbsolutePath();
+    String absolutePath = new File("target/test-classes/pipelines.yaml").getAbsolutePath();
     return ALAPipelinesConfigFactory.getInstance(null, null, absolutePath).get();
   }
 }

--- a/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
@@ -3,11 +3,17 @@ package au.org.ala.util;
 import au.org.ala.kvs.ALAPipelinesConfig;
 import au.org.ala.kvs.ALAPipelinesConfigFactory;
 import java.io.File;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TestUtils {
 
   public static ALAPipelinesConfig getConfig() {
-    String absolutePath = new File("target/test-classes/pipelines.yaml").getAbsolutePath();
+    String absolutePath = new File(getPipelinesConfigFile()).getAbsolutePath();
     return ALAPipelinesConfigFactory.getInstance(null, null, absolutePath).get();
+  }
+
+  public static String getPipelinesConfigFile() {
+    return System.getProperty("pipelinesTestYamlConfigFile", "target/test-classes/pipelines.yaml");
   }
 }

--- a/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -21,7 +21,7 @@ public class CombinedConfigurationTest {
               "--someArg=1",
               "--runner=other",
               "--datasetId=dr893",
-              "--config=src/test/resources/pipelines.yaml,src/test/resources/pipelines-local.yaml"
+              "--config=target/test-classes/pipelines.yaml,src/test/resources/pipelines-local.yaml"
             });
   }
 
@@ -37,7 +37,7 @@ public class CombinedConfigurationTest {
   @Test
   public void getUnknownValueReturnsEmptyList() throws FileNotFoundException {
     assertThat(
-        new CombinedYamlConfiguration(new String[] {"--config=src/test/resources/pipelines.yaml"})
+        new CombinedYamlConfiguration(new String[] {"--config=target/test-classes/pipelines.yaml"})
             .subSet("general2")
             .size(),
         equalTo(0));

--- a/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
@@ -1,9 +1,9 @@
 alaNameMatch:
-  wsUrl: http://localhost:9179
+  wsUrl: http://${alanm.host}:${alanm.port}
   timeoutSec: 70
 
 collectory:
-  wsUrl: https://collections.ala.org.au
+  wsUrl: ${collectory.url}
   timeoutSec: 70
 
 geocodeConfig:
@@ -81,18 +81,18 @@ index:
     metaFileName: indexing-metrics.yml
   java:
     includeSampling: true
-    zkHost: localhost:9983
+    zkHost: ${solr8.zk.host}:${solr8.zk.port}
     solrCollection: biocache
   spark-cluster:
   spark-embedded:
     appName: SOLR indexing for {datasetId}
     runner: SparkRunner
-    zkHost: localhost:9983
+    zkHost: ${solr8.zk.host}:${solr8.zk.port}
     solrCollection: biocache
     includeSampling: true
 
 test:
-  zkHost: localhost:9983
-  solrAdminHost: localhost:8983
+  zkHost: ${solr8.zk.host}:${solr8.zk.port}
+  solrAdminHost: ${solr8.http.host}:${solr8.http.port}
 
 root-test: 1

--- a/livingatlas/pipelines/src/test/resources/pipelines.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines.yaml
@@ -1,5 +1,5 @@
 alaNameMatch:
-  wsUrl: http://localhost:9179
+  wsUrl: http://localhost:${alanm.port}
   timeoutSec: 70
 
 collectory:


### PR DESCRIPTION
Fixed for Parameterize ports for the LivingAtlas docker-based tests - https://github.com/gbif/pipelines/issues/337
Allowing ports to set in jenkins build definition using the following options:
```
-Dalanm.port=9279
-Dalanm.admin.port=9280
-Dsolr8.zk.port=9973
-Dsolr8.http.port=8973
```