### PR TITLE
CLI improvements

### DIFF
--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -16,7 +16,7 @@ run:
     sparkTmp: /data/spark-tmp
     sparkMaster: spark://aws-spark-quoll-1.ala:7077
 
-# where filesystem to use: local or hdfs
+# which filesystem to use: local or hdfs
 fs:
   platform: local
   local:

--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -1,10 +1,42 @@
+### run options:
+
+run:
+  # where to run: local, spark-embedded or spark-cluster
+  platform: local
+  local:
+    # jar: we get the jar from our dev or production environment
+    sparkTmp: /data/spark-tmp
+    sparkMaster: ""
+  spark-embedded:
+    # jar: we get the jar from our dev or production environment
+    sparkTmp: /data/spark-tmp
+    sparkMaster: ""
+  spark-cluster:
+    jar: /efs-mount-point/pipelines.jar
+    sparkTmp: /data/spark-tmp
+    sparkMaster: spark://aws-spark-quoll-1.ala:7077
+
+# where filesystem to use: local or hdfs
+fs:
+  platform: local
+  local:
+    fsPath: /data
+  hdfs:
+    fsPath: hdfs://localhost:8020
+  # fsPath: hdfs://aws-spark-quoll-1.ala:9000/
+
 ### pipelines options: should match each GBIF PipelineOptions class options, that is, not extra options should be added
 ### on each yml category
+
+# As PipelineOptions does not admits extra arguments, we use this comma separated list of --args to remove it after
+# use it. In the case of fsPath be substitute '{fsPath}/pipelines-data' with fs.hdfs.fsPath if hdfs is selected in
+# fs.platform or '/data' if 'local' is selected.
+pipelineExcludeArgs: fsPath
 
 # Common PipelineOptions
 general:
   # Target path where the outputs of the pipeline will be written to
-  targetPath: /data/pipelines-data
+  targetPath: '{fsPath}/pipelines-data'
   # Attempt of the dataset used to name the target file in file system
   attempt: 1
   # The absolute path to a hdfs-site.xml with default.FS configuration
@@ -24,7 +56,7 @@ dwca-avro:
 interpret:
   appName: Interpretation for {datasetId}
   interpretationTypes: ALL
-  inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
+  inputPath: '{fsPath}/pipelines-data/{datasetId}/1/verbatim.avro'
   metaFileName: interpretation-metrics.yml
   # Skips GBIF id generation and copies ids from ExtendedRecord ids
   useExtendedRecordId: true
@@ -41,7 +73,7 @@ interpret:
 uuid:
   appName: UUID minting for {datasetId}
   runner: SparkRunner
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   metaFileName: uuid-metrics.yml
   properties: ../scripts/pipelines.yaml
   ## For spark-cluster:
@@ -50,13 +82,13 @@ uuid:
 
 # class: au.org.ala.pipelines.beam.ALAInterpretedToLatLongCSVPipeline
 export-latlng:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   runner: SparkRunner
   appName: Lat Long export for {datasetId}
 
 # class: au.org.ala.sampling.LayerCrawler
 sample:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   appName: Sample for {datasetId}
   metaFileName: indexing-metrics.yml
   runner: SparkRunner
@@ -65,7 +97,7 @@ sample:
 
 # class: au.org.ala.pipelines.beam.ALASamplingToAvroPipeline
 sample-avro:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   runner: SparkRunner
   metaFileName: indexing-metrics.yml
   # TODO improve/move this
@@ -78,7 +110,7 @@ sample-avro:
 
 # class: au.org.ala.pipelines.java.ALAInterpretedToSolrIndexPipeline
 index:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   metaFileName: indexing-metrics.yml
   properties: ../scripts/pipelines.yaml
   solrCollection: biocache
@@ -94,12 +126,12 @@ index:
 
 # class: au.org.ala.utils.DumpDatasetSize
 dataset-count-dump:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   targetPath: /tmp/dataset-counts.csv
 
 migrate-uuids:
-  inputPath: /data/pipelines-data/occ_uuid.csv
-  targetPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data/occ_uuid.csv'
+  targetPath: '{fsPath}/pipelines-data'
   hdfsSiteConfig: ""
   # FIXME: MigrateUUIDPipeline should use this also?
 

--- a/livingatlas/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
@@ -54,6 +54,14 @@ public class CombinedYamlConfiguration {
         combined = combineMap(combined, loaded);
       }
     }
+
+    // Remove pipelineExcludeArgs as they are not used by PipelineOptions
+    Object excludeArgs = get("pipelineExcludeArgs");
+    if (excludeArgs != null) {
+      for (String excludeArg : excludeArgs.toString().split(",")) {
+        this.mainArgs.remove(excludeArg.trim());
+      }
+    }
   }
 
   /**

--- a/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -21,6 +21,7 @@ public class CombinedConfigurationTest {
               "--someArg=1",
               "--runner=other",
               "--datasetId=dr893",
+              "--fsPath=/data",
               "--config=target/test-classes/pipelines.yaml,src/test/resources/pipelines-local.yaml"
             });
   }
@@ -45,7 +46,7 @@ public class CombinedConfigurationTest {
 
   @Test
   public void weCanJoinSeveralConfigsAndConvertToArgs() {
-    String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-embedded");
+    String[] args = testConf.toArgs("general", "interpret");
     // it should be --args=value arrays
     assertThat(args.length, greaterThan(0));
     LinkedHashMap<String, Object> argsInMap = argsToMap(args);
@@ -71,17 +72,25 @@ public class CombinedConfigurationTest {
 
   @Test
   public void weCanJoinSeveralConfigsAndConvertToArgsWithParams() {
-    String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-cluster");
+    String[] args = testConf.toArgs("general", "interpret");
     LinkedHashMap<String, Object> argsInMap = argsToMap(args);
     assertThat(argsInMap.get("name"), equalTo("interpret dr893"));
     assertThat(argsInMap.get("appName"), equalTo("Interpretation for dr893"));
     assertThat(argsInMap.get("inputPath"), equalTo("/data/pipelines-data/dr893/1/verbatim.avro"));
+    assertThat(argsInMap.get("fsPath"), is(nullValue()));
+  }
+
+  @Test
+  public void weSubstituteYamlValuesWithArgs() {
+    String[] args = testConf.toArgs("general", "export-latlng");
+    LinkedHashMap<String, Object> argsInMap = argsToMap(args);
+    assertThat(argsInMap.get("appName"), equalTo("Lat Long export for dr893"));
+    assertThat(argsInMap.get("inputPath"), equalTo("/data/pipelines-data"));
   }
 
   @Test
   public void weCanJoinSeveralConfigs() {
-    LinkedHashMap<String, Object> embedConf =
-        testConf.subSet("general", "services", "interpret.default", "interpret.spark-embedded");
+    LinkedHashMap<String, Object> embedConf = testConf.subSet("general", "interpret");
     assertThat(embedConf.get("interpretationTypes"), equalTo("ALL"));
     assertThat(embedConf.get("runner"), equalTo("other")); // as main args has preference
     assertThat(embedConf.get("attempt"), equalTo(1));
@@ -100,9 +109,9 @@ public class CombinedConfigurationTest {
 
   @Test
   public void dotVars() {
-    assertThat(testConf.get("index.spark-embedded").getClass(), equalTo(LinkedHashMap.class));
-    assertThat(testConf.get("index.spark-embedded.includeSampling"), equalTo(true));
-    assertThat(testConf.get("index.spark-embedded.solrCollection"), equalTo("biocache"));
+    assertThat(testConf.get("index").getClass(), equalTo(LinkedHashMap.class));
+    assertThat(testConf.get("index.includeSampling"), equalTo(true));
+    assertThat(testConf.get("index.solrCollection"), equalTo("biocache"));
   }
 
   @Test

--- a/livingatlas/pipelines/src/test/resources/pipelines.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines.yaml
@@ -1,96 +1,197 @@
-alaNameMatch:
-  wsUrl: http://localhost:9179
-  timeoutSec: 70
+### run options:
 
-collectory:
-  wsUrl: https://collections.ala.org.au
-  timeoutSec: 70
+run:
+  # where to run: local, spark-embedded or spark-cluster
+  platform: local
+  local:
+    # jar: we get the jar from our dev or production environment
+    sparkTmp: /data/spark-tmp
+    sparkMaster: ""
+  spark-embedded:
+    # jar: we get the jar from our dev or production environment
+    sparkTmp: /data/spark-tmp
+    sparkMaster: ""
+  spark-cluster:
+    jar: /efs-mount-point/pipelines.jar
+    sparkTmp: /data/spark-tmp
+    sparkMaster: spark://aws-spark-quoll-1.ala:7077
 
-geocodeConfig:
-  country:
-    path: "/tmp/pipelines-shp/political"
-    field: ISO_A2
-    source: "http://www.naturalearthdata.com"
-  eez:
-    path: "/tmp/pipelines-shp/eez"
-    field: ISO2
-    source: "http://www.naturalearthdata.com"
-  stateProvince:
-    path: "/tmp/pipelines-shp/cw_state_poly"
-    field: FEATURE
-    source: "http://vliz.be/vmdcdata/marbound/"
+# where filesystem to use: local or hdfs
+fs:
+  platform: local
+  local:
+    fsPath: /data
+  hdfs:
+    fsPath: hdfs://localhost:8020
+  # fsPath: hdfs://aws-spark-quoll-1.ala:9000/
 
+### pipelines options: should match each GBIF PipelineOptions class options, that is, not extra options should be added
+### on each yml category
+
+# As PipelineOptions does not admits extra arguments, we use this comma separated list of --args to remove it after
+# use it. In the case of fsPath be substitute '{fsPath}/pipelines-data' with fs.hdfs.fsPath if hdfs is selected in
+# fs.platform or '/data' if 'local' is selected.
+pipelineExcludeArgs: fsPath
+
+# Common PipelineOptions
 general:
-  targetPath: /data/pipelines-data
+  # Target path where the outputs of the pipeline will be written to
+  targetPath: '{fsPath}/pipelines-data'
+  # Attempt of the dataset used to name the target file in file system
   attempt: 1
+  # The absolute path to a hdfs-site.xml with default.FS configuration
   hdfsSiteConfig: ""
+  # Path to core-site-config.xml
   coreSiteConfig: ""
 
+# class: au.org.ala.pipelines.beam.ALADwcaToVerbatimPipeline
 dwca-avro:
   runner: SparkRunner
   metaFileName: dwca-metrics.yml
-  inputPath: /data/biocache-load/{datasetId}
+  # Path of the input file
+  inputPath: /data/biocache-load/{datasetId}/{datasetId}.zip
+  tempLocation: /data/biocache-load/{datasetId}/tmp/
 
+# class: au.org.ala.pipelines.beam.ALAVerbatimToInterpretedPipeline
 interpret:
-  default:
-    interpretationTypes: ALL
-    inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
-    metaFileName: interpretation-metrics.yml
-    useExtendedRecordId: true
-  spark-cluster:
-    name: interpret {datasetId}
-    appName: Interpretation for {datasetId}
-    runner: SparkRunner
-  spark-embedded:
-    runner: SparkRunner
+  appName: Interpretation for {datasetId}
+  interpretationTypes: ALL
+  inputPath: '{fsPath}/pipelines-data/{datasetId}/1/verbatim.avro'
+  metaFileName: interpretation-metrics.yml
+  # Skips GBIF id generation and copies ids from ExtendedRecord ids
+  useExtendedRecordId: true
+  runner: SparkRunner
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  name: interpret {datasetId}
+  #  appName: Interpretation for {datasetId}
+  ## For spark-embedded:
+  #  appName: Interpretation for {datasetId}
 
+# class: au.org.ala.pipelines.beam.ALAUUIDMintingPipeline
+uuid:
+  appName: UUID minting for {datasetId}
+  runner: SparkRunner
+  inputPath: '{fsPath}/pipelines-data'
+  metaFileName: uuid-metrics.yml
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  # interpretationTypes: ALL
+  # useExtendedRecordId: true
+
+# class: au.org.ala.pipelines.beam.ALAInterpretedToLatLongCSVPipeline
 export-latlng:
-  inputPath: /data/pipelines-data
+  inputPath: '{fsPath}/pipelines-data'
   runner: SparkRunner
   appName: Lat Long export for {datasetId}
 
+# class: au.org.ala.sampling.LayerCrawler
 sample:
-  default:
-  cluster:
-  avro-cluster:
-  embedded:
-    appName: SamplingToAvro indexing for {datasetId}
-    runner: SparkRunner
-    inputPath: /data/pipelines-data
-    metaFileName: indexing-metrics.yml
+  inputPath: '{fsPath}/pipelines-data'
+  appName: Sample for {datasetId}
+  metaFileName: indexing-metrics.yml
+  runner: SparkRunner
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
+
+# class: au.org.ala.pipelines.beam.ALASamplingToAvroPipeline
+sample-avro:
+  inputPath: '{fsPath}/pipelines-data'
+  runner: SparkRunner
+  metaFileName: indexing-metrics.yml
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  # appName: Add Sampling for {datasetId}
+  # useExtendedRecordId: true
+  ## For spark-embedded:
+  # appName: SamplingToAvro indexing for {datasetId}
+
+# class: au.org.ala.pipelines.java.ALAInterpretedToSolrIndexPipeline
+index:
+  inputPath: '{fsPath}/pipelines-data'
+  metaFileName: indexing-metrics.yml
+  properties: ../scripts/pipelines.yaml
+  solrCollection: biocache
+  includeSampling: true
+  runner: SparkRunner
+  zkHost: localhost:9983
+  ## For spark-cluster:
+  # appName: SOLR indexing for {datasetId}
+  # runner: SparkRunner
+  ## For spark-embedded:
+  # appName: SOLR indexing for {datasetId}
+  # runner: SparkRunner
+
+# class: au.org.ala.utils.DumpDatasetSize
+dataset-count-dump:
+  inputPath: '{fsPath}/pipelines-data'
+  targetPath: /tmp/dataset-counts.csv
 
 migrate-uuids:
-  default:
-    runner: SparkRunner
-    metaFileName: uuid-metrics.yml
-    targetPath: /data/pipelines-data
-    inputPath: /data/pipelines-data/occ_uuid.csv
-  test:
-    runner: DirectRunner
+  inputPath: '{fsPath}/pipelines-data/occ_uuid.csv'
+  targetPath: '{fsPath}/pipelines-data'
+  hdfsSiteConfig: ""
+  # FIXME: MigrateUUIDPipeline should use this also?
 
-uuid:
-  embedded:
-    appName: UUID minting for {datasetId}
-    runner: SparkRunner
-    inputPath: /data/pipelines-data
-    metaFileName: uuid-metrics.yml
+### la-pipelines cli additional arguments, like JVM or spark command line arguments
 
-index:
-  default:
-    inputPath: /data/pipelines-data
-    metaFileName: indexing-metrics.yml
-  java:
-    includeSampling: true
-    zkHost: localhost:9983
-    solrCollection: biocache
-  spark-cluster:
+interpret-sh-args:
+  local:
+    jvm: -Xmx8g -XX:+UseG1GC -Dspark.master=local[*]
   spark-embedded:
-    appName: SOLR indexing for {datasetId}
-    runner: SparkRunner
-    zkHost: localhost:9983
-    solrCollection: biocache
-    includeSampling: true
+    jvm: -Xmx8g -XX:+UseG1GC -Dspark.master=local[*]
+  spark-cluster:
+    conf: spark.default.parallelism=144
+    num-executors: 16
+    executor-cores: 8
+    executor-memory: 7G
+    driver-memory: 1G
 
+uuid-sh-args:
+  spark-embedded:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-cluster:
+    num-executors: 24
+    executor-cores: 8
+    executor-memory: 7G
+    driver-memory: 1G
+
+export-latlng-sh-args:
+  spark-embedded:
+    jvm:
+  spark-cluster:
+    num-executors: 8
+    executor-cores: 8
+    executor-memory: 16G
+    driver-memory: 4G
+
+sample-sh-args:
+  local:
+    jvm: -Xmx8g -XX:+UseG1GC
+
+sample-avro-sh-args:
+  spark-embedded:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-cluster:
+    conf: spark.default.parallelism=192
+    num-executors: 24
+    executor-cores: 8
+    executor-memory: 7G
+    driver-memory: 1G
+
+index-sh-args:
+  local:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-embedded:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-cluster:
+    conf: spark.default.parallelism=192
+    num-executors: 24
+    executor-cores: 8
+    executor-memory: 7G
+    driver-memory: 4G
 test:
   zkHost: localhost:9983
   solrAdminHost: localhost:8983

--- a/livingatlas/pipelines/src/test/resources/pipelines.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines.yaml
@@ -16,7 +16,7 @@ run:
     sparkTmp: /data/spark-tmp
     sparkMaster: spark://aws-spark-quoll-1.ala:7077
 
-# where filesystem to use: local or hdfs
+# which filesystem to use: local or hdfs
 fs:
   platform: local
   local:

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -2,8 +2,6 @@
 
 CMD=$(basename $0)
 
-source ./set-env.sh
-
 FIND_DOCOPTS=$(which docopts)
 FIND_YQ=$(which yq)
 
@@ -78,8 +76,7 @@ Options:
   -v --version         Show version.
 ----
 $CMD $VER
-Copyright (C) 2020 ALA Development Team
-License MPL v 1.1
+License Apache-2.0
 EOF
 )"
 
@@ -108,21 +105,16 @@ error_catch() {
 
 log.info "Starting $CMD"
 
-# TODO: externalize this CONFIG_DIR in some way, ask other locations
 if [[ $PROD = true ]] ; then CONFIG_DIR=/data/la-pipelines/config ; else CONFIG_DIR=../configs; fi
-
-if ($local); then unset EXTRA_CONFIG ; fi
-if ($embedded); then EXTRA_CONFIG=,$CONFIG_DIR/la-pipelines-spark-embedded.yaml ; fi
-if ($cluster); then EXTRA_CONFIG=,$CONFIG_DIR/la-pipelines-spark-cluster.yaml ; fi
 
 if ($dry_run); then _D=echo; else _D=; fi
 # Set default config locations for Production and Development
-if [[ -z $config ]]; then config=$CONFIG_DIR/la-pipelines.yaml$EXTRA_CONFIG,$CONFIG_DIR/la-pipelines-local.yaml; fi
+if [[ -z $config ]]; then config=$CONFIG_DIR/la-pipelines.yaml,$CONFIG_DIR/la-pipelines-local.yaml; fi
 
 if [[ $PROD = false && $no_colors = false ]]; then logConfig=$PWD/../pipelines/src/main/resources/log4j-colorized.properties; fi
-if [[ $PROD = false && $no_colors = true ]]; then logConfig=$PWD/../pipelines/src/main/resources/log4j.properties; fi
-if [[ $PROD = true && $no_colors = false ]]; then logConfig=$CONFIG_DIR/log4j-colorized.properties; fi
-if [[ $PROD = true && $no_colors = true ]]; then logConfig=$CONFIG_DIR/log4j.properties; fi
+if [[ $PROD = false && $no_colors = true ]];  then logConfig=$PWD/../pipelines/src/main/resources/log4j.properties; fi
+if [[ $PROD = true &&  $no_colors = false ]]; then logConfig=$CONFIG_DIR/log4j-colorized.properties; fi
+if [[ $PROD = true &&  $no_colors = true ]];  then logConfig=$CONFIG_DIR/log4j.properties; fi
 
 for dr in "${dr[@]}"; do
     if [[ -n $dr && $dr != all && $dr != dr* ]]; then >&2 log.error "Wrong dataResource '$dr'. It should start with 'dr', like 'dr893'"; exit 1 ; fi
@@ -136,11 +128,6 @@ else
     ARGS=
 fi
 
-TYPE=local # by default
-if ($local) ; then TYPE=local; fi
-if ($embedded) ; then TYPE=spark-embedded; fi
-if ($cluster) ; then TYPE=spark-cluster; fi
-
 log.info Config: $config
 log.info Extra arguments: $ARGS
 log.debug Logs without colors: $no_colors
@@ -153,6 +140,13 @@ log.debug Config list: $configList
 for f in $configList $logConfig
 do
     if [[ ! -f $f ]] ; then log.error File $f doesn\'t exits ; exit 1; fi
+done
+
+# Validate yaml of configs
+for f in $configList
+do
+    YML_V=$(yq v $f; echo $?)
+    if [[ $YML_V != 0 ]] ; then log.error Config $f is not valid ; exit 1; fi
 done
 
 # Gets a config value from yaml configList files
@@ -172,12 +166,54 @@ function toArg() {
   echo --$KEY $(getConf $PREFIX.$KEY)
 }
 
-#log.debug Target $(getConf general.targetPath)
-#PIPELINES_JAR=$(eval echo $(getConf java.PIPELINES_JAR))
-#SPARK_TMP=$(getConf spark.SPARK_TMP)
+## Process run options
 
-log.debug Using $PIPELINES_JAR
-log.debug Using $SPARK_TMP
+# Where to run, --local/etc options has precedence over yaml run.platform
+if ($local || $dwca_avro || $sample)  ; then TYPE=local;
+elif ($embedded) ; then TYPE=spark-embedded;
+elif ($cluster) ; then TYPE=spark-cluster;
+else TYPE=$(getConf run.platform);
+fi
+
+if [[ $TYPE = "spark-cluster" ]]; then USE_CLUSTER=true; else USE_CLUSTER=false; fi
+
+log.info "Running in: $TYPE"
+log.debug "Is cluster: $USE_CLUSTER"
+
+if [[ $PROD = true ]]; then PIPELINES_JAR=/usr/share/la-pipelines/la-pipelines.jar
+else
+    PIPELINES_JAR=../pipelines/target/pipelines-$VER-shaded.jar
+fi
+
+# dwca-avro, sample and dump-datasize uses local_jar
+LOCAL_PIPELINES_JAR=$PIPELINES_JAR
+
+if [[ $USE_CLUSTER = true ]]; then PIPELINES_JAR=$(getConf run.spark-cluster.jar); fi
+
+for JAR in $LOCAL_PIPELINES_JAR; do
+    if [[ ! -f $JAR ]]
+    then
+        log.error "Cannot find $JAR."
+        exit 1
+    fi
+done
+
+FS_PATH=$(getConf fs.$(getConf fs.platform).fsPath)
+if [[ ! -d $FS_PATH ]]
+then
+    log.error "Cannot find $FS_PATH."
+    exit 1
+fi
+
+SPARK_TMP=$(getConf run.$TYPE.sparkTmp);
+
+log.debug Target $(getConf general.targetPath)
+log.debug Jar: $PIPELINES_JAR
+log.debug Spart tmp: $SPARK_TMP
+
+FS_PATH_ARG="--fsPath=$FS_PATH"
+
+ARGS="$ARGS $FS_PATH_ARG"
 
 # Uncomment this to debug log4j
 # if ( $debug) ; then EXTRA_JVM_CLI_ARGS="-Dlog4j.debug"; fi
@@ -224,7 +260,7 @@ function dwca-avro () {
     fi
 
     $_D java $EXTRA_JVM_CLI_ARGS -Dspark.local.dir=$SPARK_TMP \
-        -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALADwcaToVerbatimPipeline \
+        -cp $LOCAL_PIPELINES_JAR au.org.ala.pipelines.beam.ALADwcaToVerbatimPipeline \
         --datasetId=$dr \
         --config=$config $ARGS
 
@@ -245,7 +281,7 @@ function interpret () {
             $(getConf $PRE.jvm) \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=interpret-sh-args.spark-embedded
@@ -256,7 +292,7 @@ function interpret () {
             $(getConf $PRE.jvm) \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=interpret-sh-args.spark-cluster
@@ -273,7 +309,7 @@ function interpret () {
             --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
             $PIPELINES_JAR \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
             # TODO set here an optional colorized log4j properties
     fi
 
@@ -295,7 +331,7 @@ function uuid () {
             $(getConf $PRE.jvm)  \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr\
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=uuid-sh-args.spark-cluster
@@ -311,7 +347,7 @@ function uuid () {
             --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
             $PIPELINES_JAR \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
             # TODO set here an optional colorized log4j properties
     fi
 
@@ -332,7 +368,7 @@ function export-latlng () {
             $(getConf $PRE.jvm)  \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=export-latlng-sh-args.spark-cluster
@@ -348,7 +384,7 @@ function export-latlng () {
             --driver-java -options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
             $PIPELINES_JAR \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
             # TODO set here an optional colorized log4j properties
     fi
 
@@ -365,9 +401,9 @@ function sample () {
     PRE=sample-sh-args.local
     $_D java $EXTRA_JVM_CLI_ARGS \
         $(getConf $PRE.jvm)  \
-        -cp $PIPELINES_JAR $CLASS \
+        -cp $LOCAL_PIPELINES_JAR $CLASS \
         --datasetId=$dr \
-        --config=$config
+        --config=$config $ARGS
 
     logStepEnd "Sampling" $dr local $SECONDS
 }
@@ -386,7 +422,7 @@ function sample-avro () {
             $(getConf $PRE.jvm)  \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=sample-avro-sh-args.spark-cluster
@@ -403,7 +439,7 @@ function sample-avro () {
             --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
             $PIPELINES_JAR \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
             # TODO set here an optional colorized log4j properties
     fi
 
@@ -424,7 +460,7 @@ function index () {
             $(getConf $PRE.jvm)  \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=index-sh-args.spark-embedded
@@ -433,7 +469,7 @@ function index () {
             $(getConf $PRE.jvm)  \
             -cp $PIPELINES_JAR $CLASS \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
     fi
 
     PRE=index-sh-args.spark-cluster
@@ -450,7 +486,7 @@ function index () {
             --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
             $PIPELINES_JAR \
             --datasetId=$dr \
-            --config=$config
+            --config=$config $ARGS
             # TODO set here an optional colorized log4j properties
     fi
 
@@ -459,8 +495,8 @@ function index () {
 
 if [[ $dr = "all" ]] ; then
     log.info Dump dataset size for all
-    java $EXTRA_JVM_CLI_ARGS -cp $PIPELINES_JAR au.org.ala.utils.DumpDatasetSize \
-         --config=$config
+    java $EXTRA_JVM_CLI_ARGS -cp $LOCAL_PIPELINES_JAR au.org.ala.utils.DumpDatasetSize \
+         --config=$config $ARGS
 fi # This should create /tmp/dataset-counts.csv
 
 if ($do_all || $dwca_avro) ; then
@@ -506,7 +542,7 @@ if ($interpret || $do_all); then
         do
             log.info "Dataset = $datasetID and count = $recordCount"
             if [ "$recordCount" -gt "50000" ]; then
-                if [ "$USE_CLUSTER" == "TRUE" ]; then
+                if [ $USE_CLUSTER = true ]; then
                     interpret $datasetID spark-cluster
                 else
                     interpret $datasetID spark-embedded
@@ -528,7 +564,7 @@ if ($uuid || $do_all); then
         do
             log.info "Dataset = $datasetID and count = $recordCount"
             if [ "$recordCount" -gt "50000" ]; then
-                if [ "$USE_CLUSTER" == "TRUE" ]; then
+                if [ $USE_CLUSTER = true ]; then
                     uuid $datasetID spark-cluster
                 else
                     uuid $datasetID spark-embedded
@@ -550,7 +586,7 @@ if ($export_latlng || $do_all); then
       do
           log.info "Dataset = $datasetID and count = $recordCount"
           if [ "$recordCount" -gt "50000" ]; then
-              if [ "$USE_CLUSTER" == "TRUE" ]; then
+              if [ $USE_CLUSTER = true ]; then
                   export-latlng $datasetID spark-cluster
               else
                   export-latlng $datasetID spark-embedded
@@ -583,7 +619,7 @@ if ($sample_avro || $do_all); then
         do
             log.info "Dataset = $datasetID and count = $recordCount"
             if [ "$recordCount" -gt "50000" ]; then
-                if [ "$USE_CLUSTER" == "TRUE" ]; then
+                if [ $USE_CLUSTER = true ]; then
                     sample-avro $datasetID spark-cluster
                 else
                     sample-avro $datasetID spark-embedded
@@ -605,7 +641,7 @@ if ($index || $do_all); then
         do
             log.info "Dataset = $datasetID and count = $recordCount"
             if [ "$recordCount" -gt "50000" ]; then
-                if [ "$USE_CLUSTER" == "TRUE" ]; then
+                if [ $USE_CLUSTER = true ]; then
                     index $datasetID spark-cluster
                 else
                     index $datasetID spark-embedded

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -2,6 +2,9 @@
 
 CMD=$(basename $0)
 
+# Where this is executing (to detect if we are in production)
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 FIND_DOCOPTS=$(which docopts)
 FIND_YQ=$(which yq)
 
@@ -13,14 +16,14 @@ fi
 
 if [[ -z $FIND_YQ ]]
 then
-    echo "ERROR: Please install yq, see https://github.com/mikefarah/yq"
+    echo "ERROR: Please install yq debian/ubuntu package (not the snap package), see https://github.com/mikefarah/yq"
     exit 1
 fi
 
 set -e # Stop on any failure
 
 # Detect if we are in production or not
-if [[ $PWD == "/usr/bin" ]] ; then PROD=true ; else PROD=false ; fi
+if [[ $SCRIPTPATH == "/usr/bin" ]] ; then PROD=true ; else PROD=false ; fi
 
 if [[ $PROD = false ]]; then
     VER=$(grep -oPm1 "(?<=<version>)[^<]+" "../pom.xml")
@@ -82,7 +85,8 @@ EOF
 
 # Enable logging
 if ($debug) ; then verbosity=6; else verbosity=5; fi
-source ./logging_lib.sh $verbosity $no_colors $dr
+if [[ $PROD = true ]] ; then LIB_DIR=/usr/share/la-pipelines ; else LIB_DIR=. ; fi
+source $LIB_DIR/logging_lib.sh $verbosity $no_colors $dr
 
 STEP=Initial
 
@@ -104,6 +108,7 @@ error_catch() {
 }
 
 log.info "Starting $CMD"
+log.debug "Production: $PROD"
 
 if [[ $PROD = true ]] ; then CONFIG_DIR=/data/la-pipelines/config ; else CONFIG_DIR=../configs; fi
 
@@ -180,7 +185,7 @@ if [[ $TYPE = "spark-cluster" ]]; then USE_CLUSTER=true; else USE_CLUSTER=false;
 log.info "Running in: $TYPE"
 log.debug "Is cluster: $USE_CLUSTER"
 
-if [[ $PROD = true ]]; then PIPELINES_JAR=/usr/share/la-pipelines/la-pipelines.jar
+if [[ $PROD = true ]]; then PIPELINES_JAR=$LIB_DIR/la-pipelines.jar
 else
     PIPELINES_JAR=../pipelines/target/pipelines-$VER-shaded.jar
 fi

--- a/livingatlas/scripts/la-pipelines-bash-completion.sh
+++ b/livingatlas/scripts/la-pipelines-bash-completion.sh
@@ -30,9 +30,9 @@ _la-pipelines()
     elif [ $prev = "dr" ] ; then
         # Work in progress drTAB autocopletion
         # move back
-        echo -en "\033[1D"
+        ## echo -en "\033[1D"
         # delete til the end
-        echo -en "\033[K"
+        ## echo -en "\033[K"
         suggestions="$( ( ls -1 /data/biocache-load/ | sed 's/dr//g' ) )  "
         COMPREPLY=( $( compgen -W "$suggestions" -- "$cur" ) )
     fi


### PR DESCRIPTION
More work for AtlasOfLivingAustralia/la-pipelines#88 after talking with @djtfmartin.
This includes:

- Deprecate use of set-env scripts that now can be also deleted
- now we can select between `run.platform` and `fs.platform` in yaml
- extra args in other steps more than dwca-avro
- License changed to Apache 2.0
- Validation of yaml configs
- Verification of jar and `inputPath` existence
- dwca-avro, sample and dump-dataset-size run always in local (and use local jar)
- Updated tests

Tested in local.