### PR TITLE
Some more work in LA debian package in order to use jenkins-debian-glue

### DIFF
--- a/livingatlas/debian/README.md
+++ b/livingatlas/debian/README.md
@@ -9,12 +9,23 @@ sudo apt install devscripts
 
 ## Build
 
-You can generate a non-signed debian package via:
+You need to create a link in the repository root like:
+```
+ln -s livingatlas/debian debian
+```
+because many build tools we use look for the debian directory in the root of the project.
+
+After that, you can generate a non-signed debian package via:
 
 ```bash
 debuild -us -uc -b
 ```
-in the parent of this directory. This will generate the deb file in the parent directory of this repository.
+in the root of this repository. This will generate the deb file in the parent directory of this repository.
+
+If you have build the jars in another tasks (for instance in another jenkins build), you can skip it with:
+```
+debuild -us -uc -b  --build-profiles=nobuildjar
+```
 
 You can increase changelog version and comments with `dch` utility, like with `dch -i` that increase minor version.
 
@@ -38,4 +49,3 @@ sudo piuparts -D ubuntu -d xenial -d bionic ../la-pipelines_1.0-SNAPSHOT_all.deb
 in this way you can also test it in different releases.
 
 Read `/usr/share/doc/piuparts/README.*` for more usage samples.
-

--- a/livingatlas/debian/control
+++ b/livingatlas/debian/control
@@ -5,7 +5,8 @@ Maintainer: GBIF and LivingAtlases Pipelines Team <pipelines@lists.gbif.org>
 Uploaders: GBIF and LivingAtlases Pipelines Team <pipelines@lists.gbif.org>
 Build-Depends:
  debhelper (>= 11),
- default-jdk
+ default-jdk,
+ maven
 Standards-Version: 4.2.1
 Homepage: https://github.com/gbif/pipelines
 Vcs-Browser: https://github.com/gbif/pipelines

--- a/livingatlas/debian/control
+++ b/livingatlas/debian/control
@@ -5,7 +5,7 @@ Maintainer: GBIF and LivingAtlases Pipelines Team <pipelines@lists.gbif.org>
 Uploaders: GBIF and LivingAtlases Pipelines Team <pipelines@lists.gbif.org>
 Build-Depends:
  debhelper (>= 11),
- default-jdk,
+ openjdk-8-jdk,
  maven
 Standards-Version: 4.2.1
 Homepage: https://github.com/gbif/pipelines

--- a/livingatlas/debian/la-pipelines.examples
+++ b/livingatlas/debian/la-pipelines.examples
@@ -1,0 +1,3 @@
+# https://www.debian.org/doc/manuals/maint-guide/dother.en.html#examples
+livingatlas/configs/la-pipelines.yaml
+livingatlas/configs/la-pipelines-local.yaml

--- a/livingatlas/debian/la-pipelines.examples
+++ b/livingatlas/debian/la-pipelines.examples
@@ -1,3 +1,0 @@
-# https://www.debian.org/doc/manuals/maint-guide/dother.en.html#examples
-livingatlas/configs/la-pipelines.yaml
-livingatlas/configs/la-pipelines-local.yaml

--- a/livingatlas/debian/la-pipelines.install
+++ b/livingatlas/debian/la-pipelines.install
@@ -6,4 +6,3 @@ livingatlas/pipelines/target/la-pipelines usr/share/bash-completion/completions/
 livingatlas/pipelines/src/main/resources/log4j-colorized.properties data/la-pipelines/config
 livingatlas/pipelines/src/main/resources/log4j.properties data/la-pipelines/config
 livingatlas/configs/la-pipelines.yaml data/la-pipelines/config
-livingatlas/configs/la-pipelines-local.yaml usr/share/doc/la-pipelines

--- a/livingatlas/debian/la-pipelines.install
+++ b/livingatlas/debian/la-pipelines.install
@@ -1,9 +1,9 @@
 # https://www.debian.org/doc/manuals/maint-guide/dother.en.html#install
-pipelines/target/la-pipelines.jar usr/share/la-pipelines/
-scripts/la-pipelines usr/bin
-scripts/logging_lib.sh usr/share/la-pipelines/
-pipelines/target/la-pipelines usr/share/bash-completion/completions/
-pipelines/src/main/resources/log4j-colorized.properties data/la-pipelines/config
-pipelines/src/main/resources/log4j.properties data/la-pipelines/config
-configs/la-pipelines.yaml data/la-pipelines/config
-configs/la-pipelines-local.yaml usr/share/doc/la-pipelines
+livingatlas/pipelines/target/la-pipelines.jar usr/share/la-pipelines/
+livingatlas/scripts/la-pipelines usr/bin
+livingatlas/scripts/logging_lib.sh usr/share/la-pipelines/
+livingatlas/pipelines/target/la-pipelines usr/share/bash-completion/completions/
+livingatlas/pipelines/src/main/resources/log4j-colorized.properties data/la-pipelines/config
+livingatlas/pipelines/src/main/resources/log4j.properties data/la-pipelines/config
+livingatlas/configs/la-pipelines.yaml data/la-pipelines/config
+livingatlas/configs/la-pipelines-local.yaml usr/share/doc/la-pipelines

--- a/livingatlas/debian/la-pipelines.install
+++ b/livingatlas/debian/la-pipelines.install
@@ -6,3 +6,4 @@ livingatlas/pipelines/target/la-pipelines usr/share/bash-completion/completions/
 livingatlas/pipelines/src/main/resources/log4j-colorized.properties data/la-pipelines/config
 livingatlas/pipelines/src/main/resources/log4j.properties data/la-pipelines/config
 livingatlas/configs/la-pipelines.yaml data/la-pipelines/config
+livingatlas/pipelines/target/la-pipelines-local.yaml.sample data/la-pipelines/config

--- a/livingatlas/debian/la-pipelines.lintian-overrides
+++ b/livingatlas/debian/la-pipelines.lintian-overrides
@@ -5,4 +5,4 @@ la-pipelines: script-not-executable usr/share/la-pipelines/logging_lib.sh
 la-pipelines: debian-changelog-line-too-long line *
 la-pipelines: file-in-unusual-dir data/la-pipelines/*
 la-pipelines: spelling-error-in-changelog *
-la-pipelines: jar-contains-source usr/share/la-pipelines/la-pipelines.jar
+la-pipelines: jar-contains-source usr/share/la-pipelines/la-pipelines.jar *

--- a/livingatlas/debian/la-pipelines.postinst
+++ b/livingatlas/debian/la-pipelines.postinst
@@ -21,7 +21,7 @@ case "$1" in
     configure)
         # create la-pipelines-local.yaml only if doesn't exist
         if [ ! -f /data/la-pipelines/config/la-pipelines-local.yaml ] ; then
-            cp /usr/share/doc/la-pipelines/la-pipelines-local.yaml /data/la-pipelines/config/la-pipelines-local.yaml
+            cp /usr/share/doc/la-pipelines/examples/la-pipelines-local.yaml /data/la-pipelines/config/la-pipelines-local.yaml
         fi
     ;;
 esac

--- a/livingatlas/debian/la-pipelines.postinst
+++ b/livingatlas/debian/la-pipelines.postinst
@@ -20,8 +20,8 @@ set -e
 case "$1" in
     configure)
         # create la-pipelines-local.yaml only if doesn't exist
-        if [ ! -f /data/la-pipelines/config/la-pipelines-local.yaml ] ; then
-            cp /usr/share/doc/la-pipelines/examples/la-pipelines-local.yaml /data/la-pipelines/config/la-pipelines-local.yaml
+        if [ ! -f /data/la-pipelines/config/la-pipelines-local.yaml ]  ; then
+            cp /data/la-pipelines/config/la-pipelines-local.yaml.sample /data/la-pipelines/config/la-pipelines-local.yaml
         fi
     ;;
 esac

--- a/livingatlas/debian/la-pipelines.postinst
+++ b/livingatlas/debian/la-pipelines.postinst
@@ -19,12 +19,11 @@ set -e
 
 case "$1" in
     configure)
+        # create la-pipelines-local.yaml only if doesn't exist
+        if [ ! -f /data/la-pipelines/config/la-pipelines-local.yaml ] ; then
+            cp /usr/share/doc/la-pipelines/la-pipelines-local.yaml /data/la-pipelines/config/la-pipelines-local.yaml
+        fi
     ;;
 esac
-
-# create la-pipelines-local.yaml only if doesn't exist
-if [ ! -f /data/la-pipelines/config/la-pipelines-local.yaml ] ; then
-   cp /usr/share/doc/la-pipelines/la-pipelines-local.yaml /data/la-pipelines/config/la-pipelines-local.yaml
-fi
 
 echo la-pipelines installed

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -21,7 +21,7 @@ DESTDIR=$(CURDIR)/pipelines/target
 
 override_dh_auto_build:
 # Also we can -DskipITs
-	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests -X
 
 override_dh_auto_clean:
 #	rm -rf m2

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -11,7 +11,7 @@
 
 # $(CURDIR) is the repository directory
 
-CURVERSION=$(shell grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")
+CURVERSION=$(shell grep -oPm1 "(?<=<version>)[^<]+" "livingatlas/pom.xml")
 # Set the m2 repo local for fakeroot
 M2_REPO=/tmp/m2
 DESTDIR=$(CURDIR)/livingatlas/pipelines/target

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -14,7 +14,7 @@
 CURVERSION=$(shell grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")
 # Set the m2 repo local for fakeroot
 M2_REPO=/tmp/m2
-DESTDIR=$(CURDIR)/pipelines/target
+DESTDIR=$(CURDIR)/livingatlas/pipelines/target
 
 %:
 	dh $@
@@ -24,7 +24,7 @@ ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
 # Also we can -DskipITs tests
-	(cd ..; mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests)
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests
 endif
 
 override_dh_auto_clean:
@@ -32,8 +32,8 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 #	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
-	cp $(CURDIR)/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines.jar
-	cp $(CURDIR)/scripts/la-pipelines-bash-completion.sh $(DESTDIR)/la-pipelines
+	cp $(CURDIR)/livingatlas/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines.jar
+	cp $(CURDIR)/livingatlas/scripts/la-pipelines-bash-completion.sh $(DESTDIR)/la-pipelines
 	dh_auto_install
 
 #override_dh_fixperms:

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -21,7 +21,7 @@ DESTDIR=$(CURDIR)/pipelines/target
 
 override_dh_auto_build:
 # Also we can -DskipITs
-	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests -X
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests -X -Djava.net.preferIPv4Stack=true 
 
 override_dh_auto_clean:
 #	rm -rf m2

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -20,8 +20,12 @@ DESTDIR=$(CURDIR)/pipelines/target
 	dh $@
 
 override_dh_auto_build:
-# Also we can -DskipITs
-	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests -X -Djava.net.preferIPv4Stack=true 
+ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
+# This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
+# for instance with debuild -us -uc -b --build-profiles=nobuildjar
+# Also we can -DskipITs tests
+	(cd ..; mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests)
+endif
 
 override_dh_auto_clean:
 #	rm -rf m2

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -34,6 +34,7 @@ override_dh_auto_install:
 #	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
 	cp $(CURDIR)/livingatlas/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines.jar
 	cp $(CURDIR)/livingatlas/scripts/la-pipelines-bash-completion.sh $(DESTDIR)/la-pipelines
+	cp $(CURDIR)/livingatlas/configs/la-pipelines-local.yaml $(DESTDIR)/la-pipelines-local.yaml.sample
 	dh_auto_install
 
 #override_dh_fixperms:

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -13,27 +13,35 @@
 
 CURVERSION=$(shell grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")
 # Set the m2 repo local for fakeroot
-M2_REPO = $(CURDIR)/debian/maven-repo-local
+M2_REPO=/tmp/m2
+DESTDIR=$(CURDIR)/pipelines/target
 
 %:
 	dh $@
 
-build:
+override_dh_auto_build:
 # Also we can -DskipITs
-	(cd .. ; mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests)
-#	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
-	cp $(CURDIR)/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(CURDIR)/pipelines/target/la-pipelines.jar
-	cp $(CURDIR)/scripts/la-pipelines-bash-completion.sh $(CURDIR)/pipelines/target/la-pipelines
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests
 
-override_dh_fixperms:
-	dh_fixperms
+override_dh_auto_clean:
+#	rm -rf m2
+
+override_dh_auto_install:
+#	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
+	cp $(CURDIR)/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines.jar
+	cp $(CURDIR)/scripts/la-pipelines-bash-completion.sh $(DESTDIR)/la-pipelines
+	dh_auto_install
+
+#override_dh_fixperms:
+#	dh_fixperms
 #	If we need to set some special perms to a file
 #	chmod 4755 debian/ala-foo/opt/atlas/ala-foo/foo.jar
 #	Also we use postinstall for this
 
-override_dh_install:
-	dh_install # calls default *.install and *.dirs installation
+#override_dh_install:
+#	dh_install # calls default *.install and *.dirs installation
 #	man install
 
 override_dh_strip_nondeterminism:
-	# this takes to much time because debian/maven-repo-local so skip it for now
+# this takes to much time because debian/maven-repo-local so skip it for now
+# dh_strip_nondeterminism --verbose

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -13,7 +13,7 @@
 
 CURVERSION=$(shell grep -oPm1 "(?<=<version>)[^<]+" "livingatlas/pom.xml")
 # Set the m2 repo local for fakeroot
-M2_REPO=/tmp/m2
+M2_REPO=/var/tmp/m2
 DESTDIR=$(CURDIR)/livingatlas/pipelines/target
 
 %:


### PR DESCRIPTION
Some more work in `livingatlas/debian` package in order to use:
https://jenkins-debian-glue.org/
and
https://wiki.debian.org/PackagingWithGit
instead of using a self-made build script in a jenkins job.

PS: Dave, in order to install new versions of la-pipelines if you installed it previously you have to use:
```
apt install la-pipelines=2.5.5-SNAPSHOT+0~20200811193326.81~1.gbp9acadb
```
only one time. This is because I'm generating incremental versions with the date + build + commit and I published other package with a version that is interpreted as a higger version.