### PR TITLE
Move the Antarctic check before the geocode lookup.

### DIFF
--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/parser/LocationMatcher.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/parser/LocationMatcher.java
@@ -109,18 +109,17 @@ public class LocationMatcher {
 
   private Optional<List<Country>> getCountryFromCoordinates(LatLng latLng) {
     if (latLng.isValid()) {
-      GeocodeResponse geocodeResponse = null;
-      geocodeResponse = geocodeKvStore.get(latLng);
+      if (isAntarctica(latLng.getLatitude(), this.country)) {
+        return Optional.of(Collections.singletonList(Country.ANTARCTICA));
+      }
 
+      GeocodeResponse geocodeResponse = geocodeKvStore.get(latLng);
       if (geocodeResponse != null && !geocodeResponse.getLocations().isEmpty()) {
         return Optional.of(
             geocodeResponse.getLocations().stream()
                 .map(Location::getIsoCountryCode2Digit)
                 .map(Country::fromIsoCode)
                 .collect(Collectors.toList()));
-      }
-      if (isAntarctica(latLng.getLatitude(), this.country)) {
-        return Optional.of(Collections.singletonList(Country.ANTARCTICA));
       }
     }
     return Optional.empty();

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/location/LocationMatcherTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/location/LocationMatcherTest.java
@@ -29,12 +29,19 @@ public class LocationMatcherTest {
     store.put(new LatLng(71.7d, -42.6d), toGeocodeResponse(Country.GREENLAND));
     store.put(new LatLng(-17.65, -149.46), toGeocodeResponse(Country.FRENCH_POLYNESIA));
     store.put(new LatLng(27.15, -13.20), toGeocodeResponse(Country.MOROCCO));
+    store.put(new LatLng(-61d, -130d), toGeocodeNonISOResponse("Southern Ocean"));
     GEOCODE_KV_STORE = GeocodeKvStore.create(store);
   }
 
   private static GeocodeResponse toGeocodeResponse(Country country) {
     Location location = new Location();
     location.setIsoCountryCode2Digit(country.getIso2LetterCode());
+    return new GeocodeResponse(Collections.singletonList(location));
+  }
+
+  private static GeocodeResponse toGeocodeNonISOResponse(String title) {
+    Location location = new Location();
+    location.setName(title);
     return new GeocodeResponse(Collections.singletonList(location));
   }
 


### PR DESCRIPTION
Geocode lookup now returns seas/oceans (e.g. "Southern Ocean"), but the previous behaviour relied on an empty response.

This will fix the many reported mismatches for occurrences in the Southern Ocean, and the lack of marine occurrences on the map on https://www.gbif.org/country/AQ/summary