### PR TITLE
Fix LayerCrawler usage in tests

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/sampling/LayerCrawler.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/sampling/LayerCrawler.java
@@ -62,6 +62,13 @@ public class LayerCrawler {
     MDC.put("attempt", options.getAttempt().toString());
     MDC.put("step", "SAMPLING");
 
+    init(conf);
+    run(options);
+    // FIXME: Issue logged here: https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/105
+    System.exit(0);
+  }
+
+  public static void init(CombinedYamlConfiguration conf) {
     String baseUrl = (String) conf.get("layerCrawler.baseUrl");
     batchSize = (Integer) conf.get("layerCrawler.batchSize");
     batchStatusSleepTime = (Integer) conf.get("layerCrawler.batchStatusSleepTime");
@@ -73,9 +80,6 @@ public class LayerCrawler {
             .addConverterFactory(JacksonConverterFactory.create())
             .validateEagerly(true)
             .build();
-    run(options);
-    // FIXME: Issue logged here: https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/105
-    System.exit(0);
   }
 
   public static void run(InterpretationPipelineOptions options) throws Exception {

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
@@ -7,6 +7,7 @@ import au.org.ala.pipelines.options.UUIDPipelineOptions;
 import au.org.ala.sampling.LayerCrawler;
 import au.org.ala.util.SolrUtils;
 import au.org.ala.util.TestUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import au.org.ala.utils.ValidationUtils;
 import java.io.File;
 import java.util.UUID;
@@ -173,6 +174,16 @@ public class CompleteIngestPipelineTestIT {
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
     // sample
+    LayerCrawler.init(
+        (new CombinedYamlConfiguration(
+            new String[] {
+              "--datasetId=" + datasetID,
+              "--attempt=1",
+              "--runner=DirectRunner",
+              "--targetPath=/tmp/la-pipelines-test/complete-pipeline-java",
+              "--inputPath=/tmp/la-pipelines-test/complete-pipeline-java",
+              "--config=" + TestUtils.getPipelinesConfigFile()
+            })));
     LayerCrawler.run(latLngOptions);
 
     // sample -> avro

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
@@ -11,6 +11,7 @@ import au.org.ala.pipelines.options.UUIDPipelineOptions;
 import au.org.ala.sampling.LayerCrawler;
 import au.org.ala.util.SolrUtils;
 import au.org.ala.util.TestUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import au.org.ala.utils.ValidationUtils;
 import java.io.File;
 import java.util.UUID;
@@ -151,6 +152,16 @@ public class CompleteIngestJavaPipelineTestIT {
     ALAInterpretedToLatLongCSVPipeline.run(latLngOptions);
 
     // sample
+    LayerCrawler.init(
+        (new CombinedYamlConfiguration(
+            new String[] {
+              "--datasetId=" + datasetID,
+              "--attempt=1",
+              "--runner=DirectRunner",
+              "--targetPath=/tmp/la-pipelines-test/complete-pipeline-java",
+              "--inputPath=/tmp/la-pipelines-test/complete-pipeline-java",
+              "--config=" + TestUtils.getPipelinesConfigFile()
+            })));
     LayerCrawler.run(latLngOptions);
 
     // sample -> avro

--- a/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
@@ -63,6 +63,14 @@ sample:
     inputPath: /data/pipelines-data
     metaFileName: indexing-metrics.yml
 
+# LayerCrawler specific configuration
+layerCrawler:
+  # baseUrl: https://spatial.your-l-a.site/ws/
+  baseUrl: https://sampling.ala.org.au/sampling-service/
+  batchSize: 25000
+  batchStatusSleepTime: 1000
+  downloadRetries: 5
+
 migrate-uuids:
   default:
     runner: SparkRunner

--- a/livingatlas/pipelines/src/test/resources/pipelines.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines.yaml
@@ -116,6 +116,14 @@ sample:
   runner: SparkRunner
   # TODO improve/move this
 
+# LayerCrawler specific configuration
+layerCrawler:
+  # baseUrl: https://spatial.your-l-a.site/ws/
+  baseUrl: https://sampling.ala.org.au/sampling-service/
+  batchSize: 25000
+  batchStatusSleepTime: 1000
+  downloadRetries: 5
+
 # class: au.org.ala.pipelines.beam.ALASamplingToAvroPipeline
 sample-avro:
   inputPath: '{fsPath}/pipelines-data'


### PR DESCRIPTION
As I commented in https://github.com/gbif/pipelines/pull/412#issuecomment-717879792 this PR fix the tests broken by my PR 
 #402 .

PS: I thought all the time that the `TemporalParserTest` tests were broken, so I was skipping the tests. But I just discovered that it's a locale issue in my environment (I'm using `es_ES.UTF-8`). As a workaround I'm using:
```
$ LANG=en_US.UTF-8 .buildSrc/mvnw test
```
We have to find some way to specify the default locale in the code, like in:
https://github.com/AtlasOfLivingAustralia/biocache-service/issues/417
but I didn't find yet were the date parse or format problem is.