### PR TITLE
Fix broken build caused by git-commit-id and shallow clones

### DIFF
--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -263,7 +263,7 @@
         <format>json</format>
         <gitDescribe>
           <skip>false</skip>
-          <always>false</always>
+          <always>true</always>
           <dirty>-dirty</dirty>
         </gitDescribe>
       </configuration>


### PR DESCRIPTION
I'm currently creating a debian package of the `la-pipelines` part but after switching to the `dev` branch I get this error caused by the mvn plugin we are using to get runtime build info:

```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.2.4:revision (get-the-git-infos) on project pipelines: Could not complete Mojo execution...: Unable to find commits until some tag: Walk failure. Missing commit 7391aff50c1919ef2034d8c1201ac66ee63724f7 
```
I added a workaround described:
https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/61#issuecomment-68037525

and the build ended correctly:
https://apt.gbif.es/pool/main/l/la-pipelines/
