### PR TITLE
renamed isClustered to isInCluster

### DIFF
--- a/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverter.java
@@ -338,7 +338,7 @@ public class OccurrenceHdfsRecordConverter {
       hr.setSamplesizevalue(br.getSampleSizeValue());
       hr.setRelativeorganismquantity(br.getRelativeOrganismQuantity());
       hr.setOccurrencestatus(br.getOccurrenceStatus());
-      hr.setIsclustered(br.getIsClustered());
+      hr.setIsincluster(br.getIsClustered());
 
       Optional.ofNullable(br.getRecordedByIds())
           .ifPresent(

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverter.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -337,6 +338,7 @@ public class OccurrenceHdfsRecordConverter {
       hr.setSamplesizevalue(br.getSampleSizeValue());
       hr.setRelativeorganismquantity(br.getRelativeOrganismQuantity());
       hr.setOccurrencestatus(br.getOccurrenceStatus());
+      hr.setIsclustered(br.getIsClustered());
 
       Optional.ofNullable(br.getRecordedByIds())
           .ifPresent(
@@ -480,6 +482,13 @@ public class OccurrenceHdfsRecordConverter {
                                       });
                             }
                           }));
+
+      List<String> extensions =
+          er.getExtensions().entrySet().stream()
+              .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+              .map(Entry::getKey)
+              .collect(Collectors.toList());
+      hr.setExtensions(extensions);
     };
   }
 

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
@@ -278,7 +278,7 @@ public class OccurrenceHdfsRecordConverterTest {
     Assert.assertEquals(Double.valueOf(2d), hdfsRecord.getSamplesizevalue());
     Assert.assertEquals(Double.valueOf(2d), hdfsRecord.getRelativeorganismquantity());
     Assert.assertNull(hdfsRecord.getLicense());
-    Assert.assertTrue(hdfsRecord.getIsclustered());
+    Assert.assertTrue(hdfsRecord.getIsincluster());
   }
 
   @Test

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceHdfsRecordConverterTest.java
@@ -88,8 +88,20 @@ public class OccurrenceHdfsRecordConverterTest {
     coreTerms.put(DwcTerm.individualCount.simpleName(), "0");
     coreTerms.put(DwcTerm.eventDate.simpleName(), "2000/2010");
 
+    Map<String, List<Map<String, String>>> extensions = new HashMap<>();
+    extensions.put(
+        "http://rs.tdwg.org/ac/terms/Multimedia",
+        Collections.singletonList(Collections.singletonMap("key", "value")));
+    extensions.put(
+        "http://data.ggbn.org/schemas/ggbn/terms/Amplification",
+        Collections.singletonList(Collections.singletonMap("key", "value")));
+
     ExtendedRecord extendedRecord =
-        ExtendedRecord.newBuilder().setId("1").setCoreTerms(coreTerms).build();
+        ExtendedRecord.newBuilder()
+            .setId("1")
+            .setCoreTerms(coreTerms)
+            .setExtensions(extensions)
+            .build();
 
     MetadataRecord metadataRecord =
         MetadataRecord.newBuilder()
@@ -198,6 +210,15 @@ public class OccurrenceHdfsRecordConverterTest {
         hdfsRecord.getEventdate().longValue());
     Assert.assertEquals(
         metadataRecord.getHostingOrganizationKey(), hdfsRecord.getHostingorganizationkey());
+
+    // extensions
+    Assert.assertEquals(2, hdfsRecord.getExtensions().size());
+    Assert.assertTrue(
+        hdfsRecord.getExtensions().contains("http://rs.tdwg.org/ac/terms/Multimedia"));
+    Assert.assertTrue(
+        hdfsRecord
+            .getExtensions()
+            .contains("http://data.ggbn.org/schemas/ggbn/terms/Amplification"));
   }
 
   @Test
@@ -238,6 +259,7 @@ public class OccurrenceHdfsRecordConverterTest {
     basicRecord.setSampleSizeValue(2d);
     basicRecord.setRelativeOrganismQuantity(2d);
     basicRecord.setLicense(License.UNSPECIFIED.name());
+    basicRecord.setIsClustered(true);
 
     // When
     OccurrenceHdfsRecord hdfsRecord = toOccurrenceHdfsRecord(basicRecord);
@@ -256,6 +278,7 @@ public class OccurrenceHdfsRecordConverterTest {
     Assert.assertEquals(Double.valueOf(2d), hdfsRecord.getSamplesizevalue());
     Assert.assertEquals(Double.valueOf(2d), hdfsRecord.getRelativeorganismquantity());
     Assert.assertNull(hdfsRecord.getLicense());
+    Assert.assertTrue(hdfsRecord.getIsclustered());
   }
 
   @Test

--- a/sdks/models/src/main/avro/occurrence-hdfs-record.avsc
+++ b/sdks/models/src/main/avro/occurrence-hdfs-record.avsc
@@ -1458,7 +1458,7 @@
     "name" : "ext_multimedia",
     "type" : [ "string", "null" ]
   }, {
-    "name" : "isclustered",
+    "name" : "isincluster",
     "type" : [ "boolean", "null" ]
   }, {
     "name" : "extensions",

--- a/sdks/models/src/main/avro/occurrence-hdfs-record.avsc
+++ b/sdks/models/src/main/avro/occurrence-hdfs-record.avsc
@@ -1457,5 +1457,14 @@
   }, {
     "name" : "ext_multimedia",
     "type" : [ "string", "null" ]
+  }, {
+    "name" : "isclustered",
+    "type" : [ "boolean", "null" ]
+  }, {
+    "name" : "extensions",
+    "type" : [ {
+      "type" : "array",
+      "items" : [ "string", "null" ]
+    }, "null" ]
   } ]
 }


### PR DESCRIPTION
The term for the cluster field was named as isInCluster (https://github.com/gbif/dwc-api/pull/5) so the avro schema of the hdfs view has to match that name to create the Hive table (https://github.com/gbif/gbif-api/pull/77).

Maybe we should change the name in ES and in the BasicRecord too.