### PR TITLE
Configuration of scala compile cache directory to /var/tmp

### DIFF
--- a/gbif/pipelines/clustering-gbif/pom.xml
+++ b/gbif/pipelines/clustering-gbif/pom.xml
@@ -80,6 +80,9 @@
               <goal>testCompile</goal>
             </goals>
           </execution>
+          <configuration>
+              <secondaryCacheDir>/var/tmp/sbt</secondaryCacheDir>
+          </configuration>
         </executions>
       </plugin>
     </plugins>

--- a/gbif/pipelines/clustering-gbif/pom.xml
+++ b/gbif/pipelines/clustering-gbif/pom.xml
@@ -80,10 +80,10 @@
               <goal>testCompile</goal>
             </goals>
           </execution>
-          <configuration>
-              <secondaryCacheDir>/var/tmp/sbt</secondaryCacheDir>
-          </configuration>
         </executions>
+        <configuration>
+          <secondaryCacheDir>/var/tmp/sbt</secondaryCacheDir>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We have some issue building our la-pipelines debian package. This type of build is done in a chroot environment created on each build. 

Since the inclusion of the `scala-maven-plugin` our build started to fail. 

![2021-06-09-18-07-43-screenshot](https://user-images.githubusercontent.com/180085/110663486-c4313900-81c6-11eb-8fdc-be927dc2ffd6.png)

This PR setup the scala compile cache directory to a different location that works in that chroot environments.

That configuration option is documented here: https://davidb.github.io/scala-maven-plugin/compile-mojo.html