### PR TITLE
#498 grscicoll matching

### DIFF
--- a/gbif/pipelines/ingest-gbif-beam/src/main/java/org/gbif/pipelines/ingest/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-beam/src/main/java/org/gbif/pipelines/ingest/pipelines/VerbatimToInterpretedPipeline.java
@@ -174,6 +174,8 @@ public class VerbatimToInterpretedPipeline {
     GrscicollTransform grscicollTransform =
         GrscicollTransform.builder()
             .kvStoreSupplier(GrscicollLookupKvStoreFactory.createSupplier(config))
+            .erTag(verbatimTransform.getTag())
+            .brTag(basicTransform.getTag())
             .create();
 
     LocationTransform locationTransform =

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/metrics/IngestMetricsBuilder.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/metrics/IngestMetricsBuilder.java
@@ -46,7 +46,7 @@ import static org.gbif.pipelines.common.PipelinesVariables.Metrics.VERBATIM_RECO
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.gbif.pipelines.common.beam.metrics.IngestMetrics;
-import org.gbif.pipelines.transforms.common.FilterExtendedRecordTransform;
+import org.gbif.pipelines.transforms.common.FilterRecordsTransform;
 import org.gbif.pipelines.transforms.common.UniqueGbifIdTransform;
 import org.gbif.pipelines.transforms.common.UniqueIdTransform;
 import org.gbif.pipelines.transforms.converters.GbifJsonTransform;
@@ -104,7 +104,7 @@ public class IngestMetricsBuilder {
         .addMetric(ImageTransform.class, IMAGE_RECORDS_COUNT)
         .addMetric(MeasurementOrFactTransform.class, MEASUREMENT_OR_FACT_RECORDS_COUNT)
         .addMetric(MultimediaTransform.class, MULTIMEDIA_RECORDS_COUNT)
-        .addMetric(FilterExtendedRecordTransform.class, FILTER_ER_BASED_ON_GBIF_ID)
+        .addMetric(FilterRecordsTransform.class, FILTER_ER_BASED_ON_GBIF_ID)
         .addMetric(UniqueGbifIdTransform.class, UNIQUE_GBIF_IDS_COUNT)
         .addMetric(UniqueGbifIdTransform.class, DUPLICATE_GBIF_IDS_COUNT)
         .addMetric(UniqueGbifIdTransform.class, IDENTICAL_GBIF_OBJECTS_COUNT)

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -39,7 +39,6 @@ import org.gbif.pipelines.core.io.AvroReader;
 import org.gbif.pipelines.core.io.SyncDataFileWriter;
 import org.gbif.pipelines.core.utils.FsUtils;
 import org.gbif.pipelines.core.ws.metadata.MetadataServiceClient;
-import org.gbif.pipelines.core.ws.metadata.MetadataServiceClient;
 import org.gbif.pipelines.factory.ClusteringServiceFactory;
 import org.gbif.pipelines.factory.GeocodeKvStoreFactory;
 import org.gbif.pipelines.factory.GrscicollLookupKvStoreFactory;
@@ -233,7 +232,6 @@ public class VerbatimToInterpretedPipeline {
     GrscicollTransform grscicollTransform =
         GrscicollTransform.builder()
             .kvStoreSupplier(grscicollServiceSupplier)
-            .kvStoreSupplier(GrscicollLookupKvStoreFactory.getInstanceSupplier(config))
             .erTag(verbatimTransform.getTag())
             .brTag(basicTransform.getTag())
             .create()

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -324,7 +324,7 @@ public class VerbatimToInterpretedPipeline {
               imageTransform.processElement(er).ifPresent(imageWriter::append);
               audubonTransform.processElement(er).ifPresent(audubonWriter::append);
               taxonomyTransform.processElement(er).ifPresent(taxonWriter::append);
-              grscicollTransform.processElement(er, mdr).ifPresent(grscicollWriter::append);
+              grscicollTransform.processElement(er, br, mdr).ifPresent(grscicollWriter::append);
               locationTransform.processElement(er, mdr).ifPresent(locationWriter::append);
             } else {
               basicInvalidWriter.append(br);

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -344,7 +344,7 @@ public class VerbatimToInterpretedPipeline {
           er -> {
             BasicRecord brInvalid = gbifIdTransform.getBrInvalidMap().get(er.getId());
             if (brInvalid == null) {
-              BasicRecord brValid = gbifIdTransform.getBrMap().get(er.getId());
+              BasicRecord br = gbifIdTransform.getBrMap().get(er.getId());
 
               verbatimWriter.append(er);
               temporalTransform.processElement(er).ifPresent(temporalWriter::append);
@@ -352,7 +352,7 @@ public class VerbatimToInterpretedPipeline {
               imageTransform.processElement(er).ifPresent(imageWriter::append);
               audubonTransform.processElement(er).ifPresent(audubonWriter::append);
               taxonomyTransform.processElement(er).ifPresent(taxonWriter::append);
-              grscicollTransform.processElement(er, brValid, mdr).ifPresent(grscicollWriter::append);
+              grscicollTransform.processElement(er, br, mdr).ifPresent(grscicollWriter::append);
               locationTransform.processElement(er, mdr).ifPresent(locationWriter::append);
             } else {
               basicInvalidWriter.append(brInvalid);

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -342,18 +342,20 @@ public class VerbatimToInterpretedPipeline {
       // Create interpretation function
       Consumer<ExtendedRecord> interpretAllFn =
           er -> {
-            BasicRecord br = gbifIdTransform.getBrInvalidMap().get(er.getId());
-            if (br == null) {
+            BasicRecord brInvalid = gbifIdTransform.getBrInvalidMap().get(er.getId());
+            if (brInvalid == null) {
+              BasicRecord brValid = gbifIdTransform.getBrMap().get(er.getId());
+
               verbatimWriter.append(er);
               temporalTransform.processElement(er).ifPresent(temporalWriter::append);
               multimediaTransform.processElement(er).ifPresent(multimediaWriter::append);
               imageTransform.processElement(er).ifPresent(imageWriter::append);
               audubonTransform.processElement(er).ifPresent(audubonWriter::append);
               taxonomyTransform.processElement(er).ifPresent(taxonWriter::append);
-              grscicollTransform.processElement(er, br, mdr).ifPresent(grscicollWriter::append);
+              grscicollTransform.processElement(er, brValid, mdr).ifPresent(grscicollWriter::append);
               locationTransform.processElement(er, mdr).ifPresent(locationWriter::append);
             } else {
-              basicInvalidWriter.append(br);
+              basicInvalidWriter.append(brInvalid);
             }
           };
 

--- a/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
+++ b/gbif/pipelines/ingest-gbif-java/src/main/java/org/gbif/pipelines/ingest/java/pipelines/VerbatimToInterpretedPipeline.java
@@ -203,9 +203,13 @@ public class VerbatimToInterpretedPipeline {
             .counterFn(incMetricFn)
             .init();
 
+    VerbatimTransform verbatimTransform = VerbatimTransform.create().counterFn(incMetricFn);
+
     GrscicollTransform grscicollTransform =
         GrscicollTransform.builder()
             .kvStoreSupplier(GrscicollLookupKvStoreFactory.getInstanceSupplier(config))
+            .erTag(verbatimTransform.getTag())
+            .brTag(basicTransform.getTag())
             .create()
             .counterFn(incMetricFn)
             .init();
@@ -216,8 +220,6 @@ public class VerbatimToInterpretedPipeline {
             .create()
             .counterFn(incMetricFn)
             .init();
-
-    VerbatimTransform verbatimTransform = VerbatimTransform.create().counterFn(incMetricFn);
 
     TemporalTransform temporalTransform =
         TemporalTransform.builder()

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/java/IngestMetricsBuilder.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/java/IngestMetricsBuilder.java
@@ -5,7 +5,7 @@ import static org.gbif.pipelines.common.PipelinesVariables.Metrics.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.gbif.pipelines.common.beam.metrics.IngestMetrics;
-import org.gbif.pipelines.transforms.common.FilterExtendedRecordTransform;
+import org.gbif.pipelines.transforms.common.FilterRecordsTransform;
 import org.gbif.pipelines.transforms.common.UniqueGbifIdTransform;
 import org.gbif.pipelines.transforms.common.UniqueIdTransform;
 import org.gbif.pipelines.transforms.converters.GbifJsonTransform;
@@ -27,7 +27,7 @@ public class IngestMetricsBuilder {
         .addMetric(TemporalTransform.class, TEMPORAL_RECORDS_COUNT)
         .addMetric(VerbatimTransform.class, VERBATIM_RECORDS_COUNT)
         .addMetric(MultimediaTransform.class, MULTIMEDIA_RECORDS_COUNT)
-        .addMetric(FilterExtendedRecordTransform.class, FILTER_ER_BASED_ON_GBIF_ID)
+        .addMetric(FilterRecordsTransform.class, FILTER_ER_BASED_ON_GBIF_ID)
         .addMetric(UniqueGbifIdTransform.class, UNIQUE_GBIF_IDS_COUNT)
         .addMetric(UniqueGbifIdTransform.class, DUPLICATE_GBIF_IDS_COUNT)
         .addMetric(UniqueGbifIdTransform.class, IDENTICAL_GBIF_OBJECTS_COUNT)

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <gbif-api.version>0.141</gbif-api.version>
     <gbif-common.version>0.47</gbif-common.version>
     <dwc-api.version>1.32</dwc-api.version>
-    <kvs.version>1.17</kvs.version>
+    <kvs.version>1.19-SNAPSHOT</kvs.version>
     <hbase-utils.version>0.12</hbase-utils.version>
     <gbif-wrangler.version>0.3</gbif-wrangler.version>
     <gbif-occurrence.version>0.157</gbif-occurrence.version>

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
@@ -64,8 +64,11 @@ public abstract class Transform<R, T extends SpecificRecordBase & Record> extend
    * Checks if list contains {@link InterpretationType}, else returns empty {@link PCollection<T>}
    */
   public CheckTransforms<ExtendedRecord> check(Set<String> types) {
-    return CheckTransforms.create(
-        ExtendedRecord.class, CheckTransforms.checkRecordType(types, recordType));
+    return check(types, ExtendedRecord.class);
+  }
+
+  public <S> CheckTransforms<S> check(Set<String> types, Class<S> outputClass) {
+    return CheckTransforms.create(outputClass, CheckTransforms.checkRecordType(types, recordType));
   }
 
   /**

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
@@ -3,7 +3,14 @@ package org.gbif.pipelines.transforms;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
-import lombok.SneakyThrows;
+
+import org.gbif.pipelines.common.PipelinesVariables.Pipeline;
+import org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.InterpretationType;
+import org.gbif.pipelines.core.functions.SerializableConsumer;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.Record;
+import org.gbif.pipelines.transforms.common.CheckTransforms;
+
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.specific.SpecificRecordBase;
@@ -15,12 +22,8 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
-import org.gbif.pipelines.common.PipelinesVariables.Pipeline;
-import org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.InterpretationType;
-import org.gbif.pipelines.core.functions.SerializableConsumer;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-import org.gbif.pipelines.io.avro.Record;
-import org.gbif.pipelines.transforms.common.CheckTransforms;
+
+import lombok.SneakyThrows;
 
 /**
  * Common class for all transformations
@@ -61,12 +64,19 @@ public abstract class Transform<R, T extends SpecificRecordBase & Record> extend
   }
 
   /**
-   * Checks if list contains {@link InterpretationType}, else returns empty {@link PCollection<T>}
+   * Default {@link #check(Set, Class)} that returns a {@link CheckTransforms} of {@link
+   * ExtendedRecord}.
    */
   public CheckTransforms<ExtendedRecord> check(Set<String> types) {
     return check(types, ExtendedRecord.class);
   }
 
+  /**
+   * Checks if list contains {@link InterpretationType}, else returns empty {@link PCollection<T>}.
+   *
+   * <p>This method should be used only when the deafault {@link #check(Set)} doesn't fill the
+   * needs.
+   */
   public <S> CheckTransforms<S> check(Set<String> types, Class<S> outputClass) {
     return CheckTransforms.create(outputClass, CheckTransforms.checkRecordType(types, recordType));
   }

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/Transform.java
@@ -3,14 +3,7 @@ package org.gbif.pipelines.transforms;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
-
-import org.gbif.pipelines.common.PipelinesVariables.Pipeline;
-import org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.InterpretationType;
-import org.gbif.pipelines.core.functions.SerializableConsumer;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-import org.gbif.pipelines.io.avro.Record;
-import org.gbif.pipelines.transforms.common.CheckTransforms;
-
+import lombok.SneakyThrows;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.specific.SpecificRecordBase;
@@ -22,8 +15,12 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
-
-import lombok.SneakyThrows;
+import org.gbif.pipelines.common.PipelinesVariables.Pipeline;
+import org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.InterpretationType;
+import org.gbif.pipelines.core.functions.SerializableConsumer;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.Record;
+import org.gbif.pipelines.transforms.common.CheckTransforms;
 
 /**
  * Common class for all transformations

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterExtendedRecordTransform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterExtendedRecordTransform.java
@@ -1,10 +1,10 @@
 package org.gbif.pipelines.transforms.common;
 
-import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
-
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
+
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -13,8 +13,11 @@ import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
-import org.gbif.pipelines.io.avro.BasicRecord;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
 
 /** Filter uses invalid BasicRecord collection as a source to find and skip ExtendedRecord record */
 @SuppressWarnings("ConstantConditions")
@@ -27,10 +30,10 @@ public class FilterExtendedRecordTransform implements Serializable {
   @NonNull private final TupleTag<ExtendedRecord> erTag;
   @NonNull private final TupleTag<BasicRecord> brTag;
 
-  public SingleOutput<KV<String, CoGbkResult>, ExtendedRecord> filter() {
+  public SingleOutput<KV<String, CoGbkResult>, KV<String, CoGbkResult>> filter() {
 
-    DoFn<KV<String, CoGbkResult>, ExtendedRecord> fn =
-        new DoFn<KV<String, CoGbkResult>, ExtendedRecord>() {
+    DoFn<KV<String, CoGbkResult>, KV<String, CoGbkResult>> fn =
+        new DoFn<KV<String, CoGbkResult>, KV<String, CoGbkResult>>() {
 
           private final Counter counter =
               Metrics.counter(FilterExtendedRecordTransform.class, FILTER_ER_BASED_ON_GBIF_ID);
@@ -40,10 +43,9 @@ public class FilterExtendedRecordTransform implements Serializable {
             CoGbkResult v = c.element().getValue();
             String k = c.element().getKey();
 
-            ExtendedRecord er = v.getOnly(erTag, ExtendedRecord.newBuilder().setId(k).build());
             BasicRecord br = v.getOnly(brTag, BasicRecord.newBuilder().setId(k).build());
             if (br.getCreated() == null) {
-              c.output(er);
+              c.output(c.element());
               counter.inc();
             }
           }

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterExtendedRecordTransform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterExtendedRecordTransform.java
@@ -1,10 +1,10 @@
 package org.gbif.pipelines.transforms.common;
 
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
+
 import java.io.Serializable;
-
-import org.gbif.pipelines.io.avro.BasicRecord;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -13,11 +13,8 @@ import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
-
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
-
-import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
 
 /** Filter uses invalid BasicRecord collection as a source to find and skip ExtendedRecord record */
 @SuppressWarnings("ConstantConditions")

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterRecordsTransform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterRecordsTransform.java
@@ -1,10 +1,10 @@
 package org.gbif.pipelines.transforms.common;
 
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
+
 import java.io.Serializable;
-
-import org.gbif.pipelines.io.avro.BasicRecord;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -13,11 +13,8 @@ import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
-
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
-
-import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
 
 /** Filter uses invalid BasicRecord collection as a source to find and skip ExtendedRecord record */
 @AllArgsConstructor(staticName = "create")
@@ -54,9 +51,7 @@ public class FilterRecordsTransform implements Serializable {
     return ParDo.of(fn);
   }
 
-  /**
-   * It extracts the {@link ExtendedRecord} from a {@link CoGbkResult}.
-   */
+  /** It extracts the {@link ExtendedRecord} from a {@link CoGbkResult}. */
   public SingleOutput<CoGbkResult, ExtendedRecord> extractExtendedRecords() {
     DoFn<CoGbkResult, ExtendedRecord> fn =
         new DoFn<CoGbkResult, ExtendedRecord>() {

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterRecordsTransform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/common/FilterRecordsTransform.java
@@ -1,10 +1,10 @@
 package org.gbif.pipelines.transforms.common;
 
-import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
-
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.NonNull;
+
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -13,8 +13,11 @@ import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
-import org.gbif.pipelines.io.avro.BasicRecord;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.FILTER_ER_BASED_ON_GBIF_ID;
 
 /** Filter uses invalid BasicRecord collection as a source to find and skip ExtendedRecord record */
 @AllArgsConstructor(staticName = "create")
@@ -26,6 +29,7 @@ public class FilterRecordsTransform implements Serializable {
   @NonNull private final TupleTag<ExtendedRecord> erTag;
   @NonNull private final TupleTag<BasicRecord> brTag;
 
+  /** Filters the records by discarding the results that have an invalid {@link BasicRecord} */
   public SingleOutput<KV<String, CoGbkResult>, CoGbkResult> filter() {
 
     DoFn<KV<String, CoGbkResult>, CoGbkResult> fn =
@@ -50,6 +54,9 @@ public class FilterRecordsTransform implements Serializable {
     return ParDo.of(fn);
   }
 
+  /**
+   * It extracts the {@link ExtendedRecord} from a {@link CoGbkResult}.
+   */
   public SingleOutput<CoGbkResult, ExtendedRecord> extractExtendedRecords() {
     DoFn<CoGbkResult, ExtendedRecord> fn =
         new DoFn<CoGbkResult, ExtendedRecord>() {

--- a/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/core/GrscicollTransform.java
+++ b/sdks/beam-transforms/src/main/java/org/gbif/pipelines/transforms/core/GrscicollTransform.java
@@ -119,15 +119,15 @@ public class GrscicollTransform extends Transform<CoGbkResult, GrscicollRecord> 
     ExtendedRecord er = v.getOnly(erTag, null);
     BasicRecord br = v.getOnly(brTag, null);
 
-    if (er == null || br == null) {
-      return;
-    }
-
     processElement(er, br, c.sideInput(metadataView)).ifPresent(c::output);
   }
 
   public Optional<GrscicollRecord> processElement(
       ExtendedRecord source, BasicRecord br, MetadataRecord mdr) {
+    if (source == null) {
+      return Optional.empty();
+    }
+
     return Interpretation.from(source)
         .to(GrscicollRecord.newBuilder().setCreated(Instant.now().toEpochMilli()).build())
         .when(er -> !er.getCoreTerms().isEmpty())

--- a/sdks/beam-transforms/src/test/java/org/gbif/pipelines/transforms/core/GrscicollTransformTest.java
+++ b/sdks/beam-transforms/src/test/java/org/gbif/pipelines/transforms/core/GrscicollTransformTest.java
@@ -1,28 +1,16 @@
 package org.gbif.pipelines.transforms.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import org.gbif.api.model.collections.lookup.Match.MatchType;
-import org.gbif.api.vocabulary.BasisOfRecord;
-import org.gbif.api.vocabulary.Country;
-import org.gbif.dwc.terms.DwcTerm;
-import org.gbif.dwc.terms.GbifTerm;
-import org.gbif.kvs.KeyValueStore;
-import org.gbif.kvs.grscicoll.GrscicollLookupRequest;
-import org.gbif.pipelines.core.functions.SerializableSupplier;
-import org.gbif.pipelines.io.avro.BasicRecord;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-import org.gbif.pipelines.io.avro.MetadataRecord;
-import org.gbif.pipelines.io.avro.grscicoll.GrscicollRecord;
-import org.gbif.rest.client.grscicoll.GrscicollLookupResponse;
-import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.EntityMatchedResponse;
-import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.Match;
-
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -38,16 +26,26 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.gbif.api.model.collections.lookup.Match.MatchType;
+import org.gbif.api.vocabulary.BasisOfRecord;
+import org.gbif.api.vocabulary.Country;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.kvs.KeyValueStore;
+import org.gbif.kvs.grscicoll.GrscicollLookupRequest;
+import org.gbif.pipelines.core.functions.SerializableSupplier;
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.MetadataRecord;
+import org.gbif.pipelines.io.avro.grscicoll.GrscicollRecord;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.EntityMatchedResponse;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.Match;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /** Tests the {@link GrscicollTransform}. */
 @RunWith(JUnit4.class)

--- a/sdks/beam-transforms/src/test/java/org/gbif/pipelines/transforms/core/GrscicollTransformTest.java
+++ b/sdks/beam-transforms/src/test/java/org/gbif/pipelines/transforms/core/GrscicollTransformTest.java
@@ -1,0 +1,288 @@
+package org.gbif.pipelines.transforms.core;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.gbif.api.model.collections.lookup.Match.MatchType;
+import org.gbif.api.vocabulary.BasisOfRecord;
+import org.gbif.api.vocabulary.Country;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.kvs.KeyValueStore;
+import org.gbif.kvs.grscicoll.GrscicollLookupRequest;
+import org.gbif.pipelines.core.functions.SerializableSupplier;
+import org.gbif.pipelines.io.avro.BasicRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.MetadataRecord;
+import org.gbif.pipelines.io.avro.grscicoll.GrscicollRecord;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.EntityMatchedResponse;
+import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.Match;
+
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests the {@link GrscicollTransform}. */
+@RunWith(JUnit4.class)
+@Category(NeedsRunner.class)
+public class GrscicollTransformTest {
+
+  private static final UUID DATASET_KEY = UUID.fromString("08f7aaa6-8113-43ef-9ac6-a70cbc48079f");
+  private static final Country COUNTRY = Country.DENMARK;
+  private static final UUID INSTITUTION_KEY =
+      UUID.fromString("18f7aaa6-8113-43ef-9ac6-a70cbc48079f");
+  private static final UUID COLLECTION_KEY =
+      UUID.fromString("28f7aaa6-8113-43ef-9ac6-a70cbc48079f");
+  private static final String INSTITUTION_CODE = "i1";
+  private static final String COLLECTION_CODE = "c1";
+  private static final String FAKE_INSTITUTION_CODE = "fake";
+
+  private static final SerializableSupplier<
+          KeyValueStore<GrscicollLookupRequest, GrscicollLookupResponse>>
+      KV_STORE = createKvStore();
+
+  private static class ExtractCoGbkResult extends DoFn<KV<String, CoGbkResult>, CoGbkResult>
+      implements Serializable {
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      CoGbkResult v = c.element().getValue();
+      c.output(v);
+    }
+  }
+
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+
+  @Test
+  public void whenSpecimenRecordThenRecordsFlag() {
+    // State
+    final String[] verbatim = {"1", INSTITUTION_CODE, "", "", COLLECTION_CODE, ""};
+
+    BasicRecord basicRecord =
+        BasicRecord.newBuilder()
+            .setId("1")
+            .setBasisOfRecord(BasisOfRecord.PRESERVED_SPECIMEN.name())
+            .build();
+
+    // When
+    PCollection<GrscicollRecord> recordCollection = transformRecords(basicRecord, verbatim);
+
+    // Should
+    PAssert.that(recordCollection)
+        .satisfies(
+            r -> {
+              GrscicollRecord rec = r.iterator().next();
+              assertNotNull(rec.getId());
+              assertEquals(1, rec.getIssues().getIssueList().size());
+              assertNotNull(rec.getInstitutionMatch().getKey());
+              assertNotNull(rec.getCollectionMatch().getKey());
+              return null;
+            });
+
+    // run pipeline with the options required
+    p.run();
+  }
+
+  @Test
+  public void whenNonSpecimenRecordThenRecordsNotFlag() {
+    // State
+    final String[] verbatim = {"1", INSTITUTION_CODE, "", "", COLLECTION_CODE, ""};
+
+    BasicRecord basicRecord =
+        BasicRecord.newBuilder()
+            .setId("1")
+            .setBasisOfRecord(BasisOfRecord.OBSERVATION.name())
+            .build();
+
+    // When
+    PCollection<GrscicollRecord> recordCollection = transformRecords(basicRecord, verbatim);
+
+    // Should
+    PAssert.that(recordCollection)
+        .satisfies(
+            r -> {
+              GrscicollRecord rec = r.iterator().next();
+              assertNotNull(rec.getId());
+              assertTrue(rec.getIssues().getIssueList().isEmpty());
+              assertNotNull(rec.getInstitutionMatch().getKey());
+              assertNotNull(rec.getCollectionMatch().getKey());
+              return null;
+            });
+
+    // run pipeline with the options required
+    p.run();
+  }
+
+  @Test
+  public void whenInstitutionMatchNoneThenCollectionsSkipped() {
+    // State
+    final String[] verbatim = {"1", FAKE_INSTITUTION_CODE, "", "", COLLECTION_CODE, ""};
+
+    BasicRecord basicRecord =
+        BasicRecord.newBuilder()
+            .setId("1")
+            .setBasisOfRecord(BasisOfRecord.PRESERVED_SPECIMEN.name())
+            .build();
+
+    // When
+    PCollection<GrscicollRecord> recordCollection = transformRecords(basicRecord, verbatim);
+
+    // Should
+    PAssert.that(recordCollection)
+        .satisfies(
+            r -> {
+              GrscicollRecord rec = r.iterator().next();
+              assertNotNull(rec.getId());
+              assertEquals(1, rec.getIssues().getIssueList().size());
+              assertNull(rec.getInstitutionMatch());
+              assertNull(rec.getCollectionMatch());
+              return null;
+            });
+
+    // run pipeline with the options required
+    p.run();
+  }
+
+  private PCollection<GrscicollRecord> transformRecords(
+      BasicRecord basicRecord, String... verbatimRecords) {
+
+    final MetadataRecord mdr =
+        MetadataRecord.newBuilder()
+            .setId("1")
+            .setDatasetPublishingCountry(COUNTRY.getIso2LetterCode())
+            .setDatasetKey(DATASET_KEY.toString())
+            .build();
+
+    final List<ExtendedRecord> records = createExtendedRecordList(mdr, verbatimRecords);
+
+    PCollectionView<MetadataRecord> metadataView =
+        p.apply("Create test metadata", Create.of(mdr))
+            .apply("Convert into view", View.asSingleton());
+
+    VerbatimTransform verbatimTransform = VerbatimTransform.create();
+    BasicTransform basicTransform = BasicTransform.builder().create();
+
+    PCollection<KV<String, ExtendedRecord>> extendedRecordsKv =
+        p.apply("er", Create.of(records))
+            .apply(
+                "er to kv",
+                MapElements.into(new TypeDescriptor<KV<String, ExtendedRecord>>() {})
+                    .via((ExtendedRecord er) -> KV.of(er.getId(), er)));
+
+    PCollection<KV<String, BasicRecord>> basicRecordsKv =
+        p.apply("br", Create.of(basicRecord))
+            .apply(
+                "br to kv",
+                MapElements.into(new TypeDescriptor<KV<String, BasicRecord>>() {})
+                    .via((BasicRecord br) -> KV.of(br.getId(), br)));
+
+    PCollection<CoGbkResult> filteredErBr =
+        KeyedPCollectionTuple
+            // Core
+            .of(verbatimTransform.getTag(), extendedRecordsKv)
+            .and(basicTransform.getTag(), basicRecordsKv)
+            // Apply
+            .apply("Grouping objects", CoGroupByKey.create())
+            .apply("Extract CoGbkResult", ParDo.of(new ExtractCoGbkResult()));
+
+    return filteredErBr.apply(
+        "grscicoll transform",
+        GrscicollTransform.builder()
+            .kvStoreSupplier(KV_STORE)
+            .erTag(verbatimTransform.getTag())
+            .brTag(basicTransform.getTag())
+            .metadataView(metadataView)
+            .create()
+            .interpret());
+  }
+
+  private List<ExtendedRecord> createExtendedRecordList(
+      MetadataRecord metadataRecord, String[]... records) {
+    return Arrays.stream(records)
+        .map(
+            x -> {
+              ExtendedRecord record = ExtendedRecord.newBuilder().setId(x[0]).build();
+              Map<String, String> terms = record.getCoreTerms();
+              terms.put(DwcTerm.institutionCode.qualifiedName(), x[1]);
+              terms.put(DwcTerm.institutionID.qualifiedName(), x[2]);
+              terms.put(DwcTerm.ownerInstitutionCode.qualifiedName(), x[3]);
+              terms.put(DwcTerm.collectionCode.qualifiedName(), x[4]);
+              terms.put(DwcTerm.collectionID.qualifiedName(), x[5]);
+              terms.put(
+                  GbifTerm.publishingCountry.qualifiedName(),
+                  metadataRecord.getDatasetPublishingCountry());
+              return record;
+            })
+        .collect(Collectors.toList());
+  }
+
+  private static SerializableSupplier<
+          KeyValueStore<GrscicollLookupRequest, GrscicollLookupResponse>>
+      createKvStore() {
+    GrscicollLookupRequest request1 = new GrscicollLookupRequest();
+    request1.setInstitutionCode(INSTITUTION_CODE);
+    request1.setCollectionCode(COLLECTION_CODE);
+    request1.setDatasetKey(DATASET_KEY.toString());
+    request1.setCountry(COUNTRY.getIso2LetterCode());
+
+    GrscicollLookupResponse response1 = new GrscicollLookupResponse();
+    Match institutionMatch = new Match();
+    institutionMatch.setMatchType(MatchType.EXACT);
+    EntityMatchedResponse instMatchResponse1 = new EntityMatchedResponse();
+    instMatchResponse1.setKey(INSTITUTION_KEY);
+    institutionMatch.setEntityMatched(instMatchResponse1);
+    response1.setInstitutionMatch(institutionMatch);
+
+    Match collectionMatch = new Match();
+    collectionMatch.setMatchType(MatchType.FUZZY);
+    EntityMatchedResponse collMatchResponse1 = new EntityMatchedResponse();
+    collMatchResponse1.setKey(COLLECTION_KEY);
+    collectionMatch.setEntityMatched(collMatchResponse1);
+    response1.setCollectionMatch(collectionMatch);
+
+    GrscicollLookupRequest request2 = new GrscicollLookupRequest();
+    request2.setInstitutionCode(FAKE_INSTITUTION_CODE);
+    request2.setCollectionCode(COLLECTION_CODE);
+    request2.setDatasetKey(DATASET_KEY.toString());
+    request2.setCountry(COUNTRY.getIso2LetterCode());
+
+    GrscicollLookupResponse response2 = new GrscicollLookupResponse();
+    Match institutionMatch2 = new Match();
+    institutionMatch2.setMatchType(MatchType.NONE);
+    response2.setInstitutionMatch(institutionMatch2);
+
+    KeyValueTestStoreStub<GrscicollLookupRequest, GrscicollLookupResponse> kvStore =
+        new KeyValueTestStoreStub<>();
+    kvStore.put(request1, response1);
+    kvStore.put(request2, response2);
+
+    return () -> kvStore;
+  }
+}

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/factory/FileVocabularyFactory.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/factory/FileVocabularyFactory.java
@@ -32,8 +32,8 @@ public class FileVocabularyFactory {
    * lookup:
    *
    * <ul>
-   *   <li>LifeStage uses a {@link PreFilters#REMOVE_NUMERIC_PREFIX} filter. This filter removes all the
-   *       number characters that are present at the beginning of the value.</li>
+   *   <li>LifeStage uses a {@link PreFilters#REMOVE_NUMERIC_PREFIX} filter. This filter removes all
+   *       the number characters that are present at the beginning of the value.
    * </ul>
    *
    * @param config pipelines config that contains specific config for the vocabularies

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/factory/FileVocabularyFactory.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/factory/FileVocabularyFactory.java
@@ -32,11 +32,11 @@ public class FileVocabularyFactory {
    * lookup:
    *
    * <ul>
-   *   <li>LifeStage uses a {@link PreFilters#REMOVE_NUMERIC_PREFIX}. This filter removes all the
-   *       number characters that are present at the beginning of the value.
+   *   <li>LifeStage uses a {@link PreFilters#REMOVE_NUMERIC_PREFIX} filter. This filter removes all the
+   *       number characters that are present at the beginning of the value.</li>
    * </ul>
    *
-   * @param config pipelines config that contains specif config for the vocabularies
+   * @param config pipelines config that contains specific config for the vocabularies
    * @param hdfsSiteConfig HDFS site config file
    * @param coreSiteConfig HDFS core site config file
    * @param vocabularyBackedTerm term that we are creating the vocabulary lookup instance for

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/GrscicollInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/GrscicollInterpreter.java
@@ -35,7 +35,7 @@ public class GrscicollInterpreter {
       MetadataRecord mdr,
       BasicRecord br) {
     return (er, gr) -> {
-      if (kvStore == null) {
+      if (kvStore == null || mdr == null || br == null) {
         return;
       }
 

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/GrscicollInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/GrscicollInterpreter.java
@@ -7,16 +7,19 @@ import static org.gbif.pipelines.core.utils.ModelUtils.extractNullAwareValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gbif.api.model.collections.lookup.Match.MatchType;
 import org.gbif.api.model.collections.lookup.Match.Status;
+import org.gbif.api.vocabulary.BasisOfRecord;
 import org.gbif.api.vocabulary.OccurrenceIssue;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.kvs.KeyValueStore;
 import org.gbif.kvs.grscicoll.GrscicollLookupRequest;
 import org.gbif.pipelines.core.converters.GrscicollRecordConverter;
+import org.gbif.pipelines.io.avro.BasicRecord;
 import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.gbif.pipelines.io.avro.MetadataRecord;
 import org.gbif.pipelines.io.avro.grscicoll.GrscicollRecord;
@@ -28,7 +31,9 @@ import org.gbif.rest.client.grscicoll.GrscicollLookupResponse.Match;
 public class GrscicollInterpreter {
 
   public static BiConsumer<ExtendedRecord, GrscicollRecord> grscicollInterpreter(
-      KeyValueStore<GrscicollLookupRequest, GrscicollLookupResponse> kvStore, MetadataRecord mdr) {
+      KeyValueStore<GrscicollLookupRequest, GrscicollLookupResponse> kvStore,
+      MetadataRecord mdr,
+      BasicRecord br) {
     return (er, gr) -> {
       if (kvStore == null) {
         return;
@@ -70,37 +75,50 @@ public class GrscicollInterpreter {
 
       gr.setId(er.getId());
 
+      boolean isSpecimen = isSpecimenRecord(br);
+      Consumer<OccurrenceIssue> flagRecord =
+          i -> {
+            // we only flag records that are specimens
+            if (isSpecimen) {
+              addIssue(gr, i);
+            }
+          };
+
       // institution match
       Match institutionMatchResponse = lookupResponse.getInstitutionMatch();
       if (institutionMatchResponse.getMatchType() == MatchType.NONE) {
-        OccurrenceIssue noneInstitutionIssue =
-            getInstitutionMatchNoneIssue(institutionMatchResponse.getStatus());
-        addIssue(gr, noneInstitutionIssue);
+        flagRecord.accept(getInstitutionMatchNoneIssue(institutionMatchResponse.getStatus()));
 
-        if (noneInstitutionIssue == OccurrenceIssue.DIFFERENT_OWNER_INSTITUTION) {
-          // skipping collections since we don't link records with different owner
-          return;
-        }
-      } else {
-        gr.setInstitutionMatch(GrscicollRecordConverter.convertMatch(institutionMatchResponse));
+        // we skip the collections when there is no institution match
+        return;
+      }
 
-        if (institutionMatchResponse.getMatchType() == MatchType.FUZZY) {
-          addIssue(gr, OccurrenceIssue.INSTITUTION_MATCH_FUZZY);
-        }
+      gr.setInstitutionMatch(GrscicollRecordConverter.convertMatch(institutionMatchResponse));
+
+      if (institutionMatchResponse.getMatchType() == MatchType.FUZZY) {
+        flagRecord.accept(OccurrenceIssue.INSTITUTION_MATCH_FUZZY);
       }
 
       // collection match
       Match collectionMatchResponse = lookupResponse.getCollectionMatch();
       if (collectionMatchResponse.getMatchType() == MatchType.NONE) {
-        addIssue(gr, getCollectionMatchNoneIssue(collectionMatchResponse.getStatus()));
+        flagRecord.accept(getCollectionMatchNoneIssue(collectionMatchResponse.getStatus()));
       } else {
         gr.setCollectionMatch(GrscicollRecordConverter.convertMatch(collectionMatchResponse));
 
         if (collectionMatchResponse.getMatchType() == MatchType.FUZZY) {
-          addIssue(gr, OccurrenceIssue.COLLECTION_MATCH_FUZZY);
+          flagRecord.accept(OccurrenceIssue.COLLECTION_MATCH_FUZZY);
         }
       }
     };
+  }
+
+  private static boolean isSpecimenRecord(BasicRecord br) {
+    BasisOfRecord bor = BasisOfRecord.valueOf(br.getBasisOfRecord());
+    return bor == BasisOfRecord.PRESERVED_SPECIMEN
+        || bor == BasisOfRecord.FOSSIL_SPECIMEN
+        || bor == BasisOfRecord.LIVING_SPECIMEN
+        || bor == BasisOfRecord.MATERIAL_SAMPLE;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This is still a work in progress but I want it to check it with you already before going further.

I had to change the grscicoll transform to receive as input both the extendedRecord and the basicRecord since I have to use the basis of record in the grscicoll interpreter.

I've put a ToDo in a couple of places where I had to do a workaround. To avoid this workaround I was thinking to change the `check` method in the `Transform` class to sth like this:

```
  public CheckTransforms<R> check(Set<String> types) {
    return CheckTransforms.create(
        classInput, CheckTransforms.checkRecordType(types, recordType));
  }
```
Being `classInput` a `Class<R>` that should be passed in the constructor so we'd have to change all transforms.

What do you think? any other ideas?

(I haven't run any pipeline with this code yet so there might be issues)
