### PR TITLE
Issue 235

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/kvs/ALAPipelinesConfig.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/kvs/ALAPipelinesConfig.java
@@ -20,6 +20,7 @@ public class ALAPipelinesConfig implements Serializable {
   private WsConfig collectory;
   private WsConfig alaNameMatch;
   private WsConfig sds;
+  private String sensitivityVocabFile;
   private WsConfig speciesListService;
   private WsConfig imageService;
 

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
@@ -91,6 +91,7 @@ public class ALAInterpretedToSensitivePipeline {
     ALATaxonomyTransform alaTaxonomyTransform = ALATaxonomyTransform.builder().create();
     ALASensitiveDataRecordTransform alaSensitiveDataRecordTransform =
         ALASensitiveDataRecordTransform.builder()
+            .config(config)
             .datasetId(options.getDatasetId())
             .speciesStoreSupplier(SDSCheckKVStoreFactory.getInstanceSupplier(config))
             .reportStoreSupplier(SDSReportKVStoreFactory.getInstanceSupplier(config))

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
@@ -183,8 +183,8 @@ public class IndexRecordTransform implements Serializable, IndexFields {
     indexRecord.getDates().put(LAST_PROCESSED_DATE, lastProcessedDate);
 
     // If a sensitive record, construct new versions of the data with adjustments
-    boolean sensitive = sr != null && sr.getSensitive() != null && sr.getSensitive();
-    if (sensitive) {
+    boolean isSensitive = sr != null && sr.getIsSensitive() != null && sr.getIsSensitive();
+    if (isSensitive) {
       Set<Term> sensitiveTerms =
           sr.getAltered().keySet().stream().map(TERM_FACTORY::findTerm).collect(Collectors.toSet());
       if (mdr != null) {
@@ -290,12 +290,12 @@ public class IndexRecordTransform implements Serializable, IndexFields {
       addGBIFTaxonomy(txr, indexRecord, assertions);
     }
 
-    if (sensitive) {
-      indexRecord.getStrings().put(SENSITIVE, "generalised");
+    if (isSensitive) {
+      indexRecord.getStrings().put(SENSITIVE, sr.getSensitive());
     }
 
     // Sensitive (Original) data
-    if (sensitive) {
+    if (isSensitive) {
       if (sr.getDataGeneralizations() != null)
         indexRecord
             .getStrings()

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/Sensitivity.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/Sensitivity.java
@@ -1,0 +1,31 @@
+package au.org.ala.pipelines.vocabulary;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import org.elasticsearch.common.Strings;
+
+/** The vocabulary for sensitivity terms. */
+public class Sensitivity {
+  private static Vocab sensitivityVocab;
+
+  protected static void clear() {
+    sensitivityVocab = null;
+  }
+
+  public static Vocab getInstance(String stateVocabFile) throws FileNotFoundException {
+    InputStream is;
+    if (sensitivityVocab == null) {
+      if (Strings.isNullOrEmpty(stateVocabFile)) {
+        String sourceClasspathFile = "/sensitivities.txt";
+        is = Vocab.class.getResourceAsStream(sourceClasspathFile);
+      } else {
+        File externalFile = new File(stateVocabFile);
+        is = new FileInputStream(externalFile);
+      }
+      sensitivityVocab = Vocab.loadVocabFromStream(is);
+    }
+    return sensitivityVocab;
+  }
+}

--- a/livingatlas/pipelines/src/main/resources/sensitivities.txt
+++ b/livingatlas/pipelines/src/main/resources/sensitivities.txt
@@ -1,0 +1,2 @@
+alreadyGeneralised	Already Generalised	alreadyGeneralized	Already Generalized
+generalised	generalized

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/SensitiveDataPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/SensitiveDataPipelineTestIT.java
@@ -67,14 +67,15 @@ public class SensitiveDataPipelineTestIT {
             null, null, ALASensitivityRecord.class, ala_sensitive_data.getPath() + "/*.avro");
     ALASensitivityRecord sds1 = sds.get("not-an-uuid-1");
     assertNotNull(sds1);
-    assertTrue(sds1.getSensitive());
+    assertTrue(sds1.getIsSensitive());
+    assertEquals("generalised", sds1.getSensitive());
     assertEquals(
         "Record is Australia in Endangered. Generalised to 10km by Birds Australia.",
         sds1.getDataGeneralizations());
     assertEquals("149.4", sds1.getAltered().get("http://rs.tdwg.org/dwc/terms/decimalLongitude"));
     ALASensitivityRecord sds2 = sds.get("not-an-uuid-2");
     assertNotNull(sds2);
-    assertFalse(sds2.getSensitive());
+    assertFalse(sds2.getIsSensitive());
   }
 
   public void loadTestDataset(String datasetID, String inputPath) throws Exception {

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/vocabulary/SensitivityVocabTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/vocabulary/SensitivityVocabTest.java
@@ -1,0 +1,39 @@
+package au.org.ala.pipelines.vocabulary;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import org.junit.Test;
+
+public class SensitivityVocabTest {
+  @Test
+  public void testGenealised1() throws Exception {
+    Sensitivity.clear();
+    Vocab vocab = Sensitivity.getInstance(null);
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("generalised"));
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("Generalised"));
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("GeNeraLiseD"));
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("generalized"));
+    assertEquals(Optional.empty(), vocab.matchTerm("Nothing to see here"));
+  }
+
+  @Test
+  public void testGenealised2() throws Exception {
+    Sensitivity.clear();
+    String path = this.getClass().getResource("sensitivities-1.txt").getPath();
+    Vocab vocab = Sensitivity.getInstance(path);
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("generalised"));
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("Something"));
+    assertEquals(Optional.of("generalised"), vocab.matchTerm("Load of old rubbish"));
+    assertEquals(Optional.empty(), vocab.matchTerm("Nothing to see here"));
+  }
+
+  @Test
+  public void testAlreadyGenealised1() throws Exception {
+    Sensitivity.clear();
+    Vocab vocab = Sensitivity.getInstance(null);
+    assertEquals(Optional.of("alreadyGeneralised"), vocab.matchTerm("alreadyGeneralised"));
+    assertEquals(Optional.of("alreadyGeneralised"), vocab.matchTerm("Already Generalised"));
+    assertEquals(Optional.empty(), vocab.matchTerm("Blah de blah de blah"));
+  }
+}

--- a/livingatlas/pipelines/src/test/resources/au/org/ala/pipelines/vocabulary/sensitivities-1.txt
+++ b/livingatlas/pipelines/src/test/resources/au/org/ala/pipelines/vocabulary/sensitivities-1.txt
@@ -1,0 +1,2 @@
+alreadyGeneralised	Done it before	Go away
+generalised	Something	Load of old Rubbish	The head of a statue

--- a/sdks/models/src/main/avro/specific/ala-sensitivity-record.avsc
+++ b/sdks/models/src/main/avro/specific/ala-sensitivity-record.avsc
@@ -6,7 +6,8 @@
   "fields":[
       {"name" : "id", "type" : ["null", "string"], "default" : null, "doc" : "Pipelines identifier"},
       {"name" : "created", "type" : ["null", "long"], "default" : null, "doc" : "The timestamp the record was created"},
-      {"name" : "sensitive", "type" : [ "null", "boolean" ], "default" : null, "doc" : "Does this record have any sensitive data features" },
+      {"name" : "isSensitive", "type" : [ "null", "boolean" ], "default" : null, "doc" : "Does this record have any sensitive data features" },
+      {"name" : "sensitive", "type" : [ "null", "string" ], "default" : null, "doc" : "A text description of the sensitivity status, derived from a standard vocabulary" },
       {"name" : "dataGeneralizations", "type" : ["null", "string"], "default" : null, "doc" : "Description of any generalisations that have been applied"},
       {"name" : "informationWithheld", "type" : ["null", "string"], "default" : null, "doc" : "Description of any information that has been removed"},
       {"name" : "generalisationToApplyInMetres", "type" : ["null", "string"], "default" : null, "doc" : "Coordinate generalisation radius"},

--- a/tools/archives-converters/src/main/java/org/gbif/converters/parser/xml/OccurrenceParser.java
+++ b/tools/archives-converters/src/main/java/org/gbif/converters/parser/xml/OccurrenceParser.java
@@ -15,7 +15,6 @@
  */
 package org.gbif.converters.parser.xml;
 
-import com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,6 +36,7 @@ import javax.xml.transform.TransformerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.digester.Digester;
 import org.apache.commons.digester.NodeCreateRule;
+import org.apache.xerces.impl.io.MalformedByteSequenceException;
 import org.gbif.api.exception.ServiceUnavailableException;
 import org.gbif.converters.parser.xml.constants.ExtractionSimpleXPaths;
 import org.gbif.converters.parser.xml.model.RawOccurrenceRecord;


### PR DESCRIPTION
Fix for sun.com. import that doesn't work with non-oracle JVMs
Provide a vocabulary-checked sensitive term in the sensitive data and index for sensitive data. The sensitive flag still exists as isSensitive.