### PR TITLE
23 ALA export to GBIF

### DIFF
--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -895,5 +895,10 @@
         <artifactId>checker-qual</artifactId>
         <version>${checker-qual.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/livingatlas/pipelines/src/main/java/au/org/ala/kvs/client/retrofit/ALACollectoryRetrofitService.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/kvs/client/retrofit/ALACollectoryRetrofitService.java
@@ -21,4 +21,7 @@ public interface ALACollectoryRetrofitService {
 
   @GET("dataResource")
   Call<List<EntityReference>> lookupDataResources();
+
+  @GET("eml/{dataResourceUid}")
+  Call<String> lookupEML(@Path("dataResourceUid") String dataResourceUid);
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToDwcaPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToDwcaPipeline.java
@@ -13,6 +13,7 @@ import au.org.ala.pipelines.util.VersionInfo;
 import au.org.ala.utils.ALAFsUtils;
 import au.org.ala.utils.CombinedYamlConfiguration;
 import au.org.ala.utils.ValidationUtils;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
@@ -102,11 +103,12 @@ public class IndexRecordToDwcaPipeline {
             options.getHdfsSiteConfig(), options.getCoreSiteConfig(), options.getInputPath());
 
     String url = config.getCollectory().getWsUrl() + "/eml/" + options.getDatasetId();
-    String out = new Scanner(new URL(url).openStream(), "UTF-8").useDelimiter("\\A").next();
-    OutputStream output = ALAFsUtils.openOutputStream(fs, pathFn.apply("eml.xml"));
-    OutputStreamWriter writer = new OutputStreamWriter(output);
-    writer.write(out);
-    writer.flush();
-    writer.close();
+    URL emlUrl = new URL(url);
+    try (InputStream input = emlUrl.openStream();
+        OutputStream output = ALAFsUtils.openOutputStream(fs, pathFn.apply("eml.xml"));
+        OutputStreamWriter writer = new OutputStreamWriter(output); ) {
+      String out = new Scanner(input, "UTF-8").useDelimiter("\\A").next();
+      writer.write(out);
+    }
   }
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToDwcaPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToDwcaPipeline.java
@@ -1,0 +1,112 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.beam.utils.PathBuilder.buildDatasetAttemptPath;
+import static org.gbif.pipelines.common.beam.utils.PathBuilder.buildPath;
+
+import au.org.ala.kvs.ALAPipelinesConfig;
+import au.org.ala.kvs.ALAPipelinesConfigFactory;
+import au.org.ala.pipelines.converters.CoreCsvConverter;
+import au.org.ala.pipelines.converters.MultimediaCsvConverter;
+import au.org.ala.pipelines.options.SolrPipelineOptions;
+import au.org.ala.pipelines.util.DwcaMetaXml;
+import au.org.ala.pipelines.util.VersionInfo;
+import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
+import au.org.ala.utils.ValidationUtils;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.URL;
+import java.util.Scanner;
+import java.util.function.UnaryOperator;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.hadoop.fs.FileSystem;
+import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
+import org.gbif.pipelines.core.utils.FsUtils;
+import org.gbif.pipelines.io.avro.IndexRecord;
+import org.slf4j.MDC;
+
+@Slf4j
+public class IndexRecordToDwcaPipeline {
+
+  public static void main(String[] args) throws Exception {
+    MDC.put("step", "INDEX_RECORD_TO_DWCA");
+    VersionInfo.print();
+    String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "solr");
+    SolrPipelineOptions options =
+        PipelinesOptionsFactory.create(SolrPipelineOptions.class, combinedArgs);
+    MDC.put("datasetId", options.getDatasetId() != null ? options.getDatasetId() : "ALL_RECORDS");
+    options.setMetaFileName(ValidationUtils.VERBATIM_METRICS);
+    PipelinesOptionsFactory.registerHdfs(options);
+    run(options);
+  }
+
+  @SneakyThrows
+  public static void run(SolrPipelineOptions options) {
+
+    UnaryOperator<String> pathFn =
+        fileName -> buildPath(buildDatasetAttemptPath(options, "dwca", false), fileName).toString();
+
+    Pipeline p = Pipeline.create(options);
+
+    // Load IndexRecords - keyed on UUID
+    PCollection<IndexRecord> indexRecordPCollection = ALAFsUtils.loadIndexRecords(options, p);
+
+    indexRecordPCollection
+        .apply(
+            "Convert to core csv string",
+            MapElements.into(TypeDescriptors.strings()).via(CoreCsvConverter::convert))
+        .apply(
+            "Write core csv file",
+            TextIO.write().to(pathFn.apply("occurrence")).withoutSharding().withSuffix(".csv"));
+
+    indexRecordPCollection
+        .apply(
+            "Convert to image csv string",
+            MapElements.into(TypeDescriptors.strings()).via(MultimediaCsvConverter::convert))
+        .apply(
+            "Write image csv file",
+            TextIO.write().to(pathFn.apply("image")).withoutSharding().withSuffix(".csv"));
+
+    PipelineResult result = p.run();
+    result.waitUntilFinish();
+
+    // write the meta.xml
+    DwcaMetaXml.builder()
+        .coreTerms(CoreCsvConverter.getTerms())
+        .multimediaTerms(MultimediaCsvConverter.getTerms())
+        .pathToWrite(pathFn.apply("meta.xml"))
+        .coreSiteConfig(options.getCoreSiteConfig())
+        .hdfsSiteConfig(options.getHdfsSiteConfig())
+        .create()
+        .write();
+
+    // Write the eml.xml
+    writeEML(options, pathFn);
+  }
+
+  @SneakyThrows
+  private static void writeEML(SolrPipelineOptions options, UnaryOperator<String> pathFn) {
+    ALAPipelinesConfig config =
+        ALAPipelinesConfigFactory.getInstance(
+                options.getHdfsSiteConfig(), options.getCoreSiteConfig(), options.getProperties())
+            .get();
+    FileSystem fs =
+        FsUtils.getFileSystem(
+            options.getHdfsSiteConfig(), options.getCoreSiteConfig(), options.getInputPath());
+
+    String url = config.getCollectory().getWsUrl() + "/eml/" + options.getDatasetId();
+    String out = new Scanner(new URL(url).openStream(), "UTF-8").useDelimiter("\\A").next();
+    OutputStream output = ALAFsUtils.openOutputStream(fs, pathFn.apply("eml.xml"));
+    OutputStreamWriter writer = new OutputStreamWriter(output);
+    writer.write(out);
+    writer.flush();
+    writer.close();
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/CoreCsvConverter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/CoreCsvConverter.java
@@ -1,0 +1,289 @@
+package au.org.ala.pipelines.converters;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.gbif.dwc.terms.DcTerm;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.dwc.terms.Term;
+import org.gbif.pipelines.io.avro.IndexRecord;
+
+public class CoreCsvConverter {
+
+  private static final String RAW = "raw_";
+
+  private static final CsvConverter<IndexRecord> CONVERTER =
+      CsvConverter.<IndexRecord>create()
+          // DWC Terms
+          .addKeyTermFn(DwcTerm.occurrenceID, ir -> Optional.of(ir.getId()))
+          .addKeyTermFn(DwcTerm.catalogNumber, getString(DwcTerm.catalogNumber))
+          .addKeyTermFn(DwcTerm.collectionCode, getString(DwcTerm.collectionCode))
+          .addKeyTermFn(DwcTerm.institutionCode, getString(DwcTerm.institutionCode))
+          .addKeyTermFn(DwcTerm.recordNumber, getString(DwcTerm.recordNumber))
+          .addKeyTermFn(DwcTerm.basisOfRecord, getString(DwcTerm.basisOfRecord), "HumanObservation")
+          .addKeyTermFn(DwcTerm.recordedBy, getMultivalue(DwcTerm.recordedBy))
+          .addKeyTermFn(DwcTerm.occurrenceStatus, getString(DwcTerm.occurrenceStatus))
+          .addKeyTermFn(DwcTerm.individualCount, getInt(DwcTerm.individualCount))
+          .addKeyTermFn(DwcTerm.scientificName, getString(DwcTerm.scientificName))
+          .addKeyTermFn(DwcTerm.taxonConceptID, getString(DwcTerm.taxonConceptID))
+          .addKeyTermFn(DwcTerm.taxonRank, getString(DwcTerm.taxonRank))
+          .addKeyTermFn(DwcTerm.kingdom, getString(DwcTerm.kingdom))
+          .addKeyTermFn(DwcTerm.phylum, getString(DwcTerm.phylum))
+          .addKeyTermFn(DwcTerm.class_, getString(DwcTerm.class_))
+          .addKeyTermFn(DwcTerm.order, getString(DwcTerm.order))
+          .addKeyTermFn(DwcTerm.family, getString(DwcTerm.family))
+          .addKeyTermFn(DwcTerm.genus, getString(DwcTerm.genus))
+          .addKeyTermFn(DwcTerm.vernacularName, getString(DwcTerm.vernacularName))
+          .addKeyTermFn(DwcTerm.decimalLatitude, getDouble(DwcTerm.decimalLatitude))
+          .addKeyTermFn(DwcTerm.decimalLongitude, getDouble(DwcTerm.decimalLongitude))
+          .addKeyTermFn(DwcTerm.geodeticDatum, getString(DwcTerm.geodeticDatum))
+          .addKeyTermFn(
+              DwcTerm.coordinateUncertaintyInMeters,
+              getDouble(DwcTerm.coordinateUncertaintyInMeters))
+          .addKeyTermFn(
+              DwcTerm.maximumElevationInMeters, getDouble(DwcTerm.maximumElevationInMeters))
+          .addKeyTermFn(
+              DwcTerm.minimumElevationInMeters, getDouble(DwcTerm.minimumElevationInMeters))
+          .addKeyTermFn(DwcTerm.minimumDepthInMeters, getDouble(DwcTerm.minimumDepthInMeters))
+          .addKeyTermFn(DwcTerm.maximumDepthInMeters, getDouble(DwcTerm.maximumDepthInMeters))
+          .addKeyTermFn(DwcTerm.country, getString(DwcTerm.country))
+          .addKeyTermFn(DwcTerm.stateProvince, getString(DwcTerm.stateProvince))
+          .addKeyTermFn(DwcTerm.locality, getString(DwcTerm.locality))
+          .addKeyTermFn(DwcTerm.locationRemarks, getString(DwcTerm.locationRemarks))
+          .addKeyTermFn(DwcTerm.year, getInt(DwcTerm.year))
+          .addKeyTermFn(DwcTerm.month, getInt(DwcTerm.month))
+          .addKeyTermFn(DwcTerm.day, getInt(DwcTerm.day))
+          .addKeyTermFn(DwcTerm.eventDate, getRawString(DwcTerm.eventDate))
+          .addKeyTermFn(DwcTerm.eventID, getString(DwcTerm.eventID))
+          .addKeyTermFn(DwcTerm.identifiedBy, getString(DwcTerm.identifiedBy))
+          .addKeyTermFn(DwcTerm.occurrenceRemarks, getString(DwcTerm.occurrenceRemarks))
+          .addKeyTermFn(DwcTerm.dataGeneralizations, getString(DwcTerm.dataGeneralizations))
+          .addKeyTermFn(DwcTerm.otherCatalogNumbers, getString(DwcTerm.otherCatalogNumbers))
+          .addKeyTermFn(DwcTerm.acceptedNameUsage, getString(DwcTerm.acceptedNameUsage))
+          .addKeyTermFn(DwcTerm.acceptedNameUsageID, getString(DwcTerm.acceptedNameUsageID))
+          .addKeyTermFn(DwcTerm.associatedOccurrences, getString(DwcTerm.associatedOccurrences))
+          .addKeyTermFn(DwcTerm.associatedReferences, getString(DwcTerm.associatedReferences))
+          .addKeyTermFn(DwcTerm.associatedSequences, getString(DwcTerm.associatedSequences))
+          .addKeyTermFn(DwcTerm.associatedTaxa, getString(DwcTerm.associatedTaxa))
+          .addKeyTermFn(DwcTerm.behavior, getString(DwcTerm.behavior))
+          .addKeyTermFn(DwcTerm.collectionID, getString(DwcTerm.collectionID))
+          .addKeyTermFn(DwcTerm.continent, getString(DwcTerm.continent))
+          .addKeyTermFn(DwcTerm.coordinatePrecision, getDouble(DwcTerm.coordinatePrecision))
+          .addKeyTermFn(DwcTerm.countryCode, getString(DwcTerm.countryCode))
+          .addKeyTermFn(DwcTerm.county, getString(DwcTerm.county))
+          .addKeyTermFn(DwcTerm.datasetID, getString(DwcTerm.datasetID))
+          .addKeyTermFn(DwcTerm.datasetName, getString(DwcTerm.datasetName))
+          .addKeyTermFn(DwcTerm.dateIdentified, getString(DwcTerm.dateIdentified))
+          .addKeyTermFn(DwcTerm.disposition, getString(DwcTerm.disposition))
+          .addKeyTermFn(DwcTerm.dynamicProperties, getString(DwcTerm.dynamicProperties))
+          .addKeyTermFn(DwcTerm.endDayOfYear, getInt(DwcTerm.endDayOfYear))
+          .addKeyTermFn(DwcTerm.establishmentMeans, getString(DwcTerm.establishmentMeans))
+          .addKeyTermFn(DwcTerm.eventRemarks, getString(DwcTerm.eventRemarks))
+          .addKeyTermFn(DwcTerm.eventTime, getString(DwcTerm.eventTime))
+          .addKeyTermFn(DwcTerm.fieldNotes, getString(DwcTerm.fieldNotes))
+          .addKeyTermFn(DwcTerm.fieldNumber, getString(DwcTerm.fieldNumber))
+          .addKeyTermFn(DwcTerm.footprintSpatialFit, getString(DwcTerm.footprintSpatialFit))
+          .addKeyTermFn(DwcTerm.footprintSRS, getString(DwcTerm.footprintSRS))
+          .addKeyTermFn(DwcTerm.footprintWKT, getString(DwcTerm.footprintWKT))
+          .addKeyTermFn(DwcTerm.georeferencedBy, getString(DwcTerm.georeferencedBy))
+          .addKeyTermFn(DwcTerm.georeferencedDate, getString(DwcTerm.georeferencedDate))
+          .addKeyTermFn(DwcTerm.georeferenceProtocol, getString(DwcTerm.georeferenceProtocol))
+          .addKeyTermFn(DwcTerm.georeferenceRemarks, getString(DwcTerm.georeferenceRemarks))
+          .addKeyTermFn(DwcTerm.georeferenceSources, getString(DwcTerm.georeferenceSources))
+          .addKeyTermFn(
+              DwcTerm.georeferenceVerificationStatus,
+              getString(DwcTerm.georeferenceVerificationStatus))
+          .addKeyTermFn(DwcTerm.habitat, getString(DwcTerm.habitat))
+          .addKeyTermFn(DwcTerm.higherClassification, getString(DwcTerm.higherClassification))
+          .addKeyTermFn(DwcTerm.higherGeography, getString(DwcTerm.higherGeography))
+          .addKeyTermFn(DwcTerm.higherGeographyID, getString(DwcTerm.higherGeographyID))
+          .addKeyTermFn(DwcTerm.identificationID, getString(DwcTerm.identificationID))
+          .addKeyTermFn(DwcTerm.identificationQualifier, getString(DwcTerm.identificationQualifier))
+          .addKeyTermFn(
+              DwcTerm.identificationReferences, getString(DwcTerm.identificationReferences))
+          .addKeyTermFn(DwcTerm.identificationRemarks, getString(DwcTerm.identificationRemarks))
+          .addKeyTermFn(
+              DwcTerm.identificationVerificationStatus,
+              getString(DwcTerm.identificationVerificationStatus))
+          .addKeyTermFn(DwcTerm.informationWithheld, getString(DwcTerm.informationWithheld))
+          .addKeyTermFn(DwcTerm.infraspecificEpithet, getString(DwcTerm.infraspecificEpithet))
+          .addKeyTermFn(DwcTerm.institutionID, getString(DwcTerm.institutionID))
+          .addKeyTermFn(DwcTerm.island, getString(DwcTerm.island))
+          .addKeyTermFn(DwcTerm.islandGroup, getString(DwcTerm.islandGroup))
+          .addKeyTermFn(DwcTerm.lifeStage, getString(DwcTerm.lifeStage))
+          .addKeyTermFn(DwcTerm.locationAccordingTo, getString(DwcTerm.locationAccordingTo))
+          .addKeyTermFn(DwcTerm.locationID, getString(DwcTerm.locationID))
+          .addKeyTermFn(
+              DwcTerm.maximumDistanceAboveSurfaceInMeters,
+              getDouble(DwcTerm.maximumDistanceAboveSurfaceInMeters))
+          .addKeyTermFn(DwcTerm.measurementAccuracy, getString(DwcTerm.measurementAccuracy))
+          .addKeyTermFn(DwcTerm.measurementDeterminedBy, getString(DwcTerm.measurementDeterminedBy))
+          .addKeyTermFn(
+              DwcTerm.measurementDeterminedDate, getString(DwcTerm.measurementDeterminedDate))
+          .addKeyTermFn(DwcTerm.measurementID, getString(DwcTerm.measurementID))
+          .addKeyTermFn(DwcTerm.measurementMethod, getString(DwcTerm.measurementMethod))
+          .addKeyTermFn(DwcTerm.measurementRemarks, getString(DwcTerm.measurementRemarks))
+          .addKeyTermFn(DwcTerm.measurementType, getString(DwcTerm.measurementType))
+          .addKeyTermFn(DwcTerm.measurementUnit, getString(DwcTerm.measurementUnit))
+          .addKeyTermFn(DwcTerm.measurementValue, getString(DwcTerm.measurementValue))
+          .addKeyTermFn(DwcTerm.municipality, getString(DwcTerm.municipality))
+          .addKeyTermFn(DwcTerm.nameAccordingTo, getString(DwcTerm.nameAccordingTo))
+          .addKeyTermFn(DwcTerm.nameAccordingToID, getString(DwcTerm.nameAccordingToID))
+          .addKeyTermFn(DwcTerm.namePublishedIn, getString(DwcTerm.namePublishedIn))
+          .addKeyTermFn(DwcTerm.namePublishedInID, getString(DwcTerm.namePublishedInID))
+          .addKeyTermFn(DwcTerm.namePublishedInYear, getString(DwcTerm.namePublishedInYear))
+          .addKeyTermFn(DwcTerm.nomenclaturalCode, getString(DwcTerm.nomenclaturalCode))
+          .addKeyTermFn(DwcTerm.nomenclaturalStatus, getString(DwcTerm.nomenclaturalStatus))
+          .addKeyTermFn(DwcTerm.organismID, getString(DwcTerm.organismID))
+          .addKeyTermFn(DwcTerm.organismQuantity, getDouble(DwcTerm.organismQuantity))
+          .addKeyTermFn(DwcTerm.organismQuantityType, getString(DwcTerm.organismQuantityType))
+          .addKeyTermFn(DwcTerm.originalNameUsage, getString(DwcTerm.originalNameUsage))
+          .addKeyTermFn(DwcTerm.originalNameUsageID, getString(DwcTerm.originalNameUsageID))
+          .addKeyTermFn(DwcTerm.ownerInstitutionCode, getString(DwcTerm.ownerInstitutionCode))
+          .addKeyTermFn(DwcTerm.parentNameUsage, getString(DwcTerm.parentNameUsage))
+          .addKeyTermFn(DwcTerm.parentNameUsageID, getString(DwcTerm.parentNameUsageID))
+          .addKeyTermFn(DwcTerm.pointRadiusSpatialFit, getString(DwcTerm.pointRadiusSpatialFit))
+          .addKeyTermFn(DwcTerm.preparations, getString(DwcTerm.preparations))
+          .addKeyTermFn(DwcTerm.previousIdentifications, getString(DwcTerm.previousIdentifications))
+          .addKeyTermFn(DwcTerm.relatedResourceID, getString(DwcTerm.relatedResourceID))
+          .addKeyTermFn(DwcTerm.relationshipAccordingTo, getString(DwcTerm.relationshipAccordingTo))
+          .addKeyTermFn(
+              DwcTerm.minimumDistanceAboveSurfaceInMeters,
+              getDouble(DwcTerm.minimumDistanceAboveSurfaceInMeters))
+          .addKeyTermFn(
+              DwcTerm.relationshipEstablishedDate, getString(DwcTerm.relationshipEstablishedDate))
+          .addKeyTermFn(DwcTerm.relationshipOfResource, getString(DwcTerm.relationshipOfResource))
+          .addKeyTermFn(DwcTerm.relationshipRemarks, getString(DwcTerm.relationshipRemarks))
+          .addKeyTermFn(DwcTerm.reproductiveCondition, getString(DwcTerm.reproductiveCondition))
+          .addKeyTermFn(DwcTerm.resourceID, getString(DwcTerm.resourceID))
+          .addKeyTermFn(DwcTerm.resourceRelationshipID, getString(DwcTerm.resourceRelationshipID))
+          .addKeyTermFn(DwcTerm.samplingEffort, getString(DwcTerm.samplingEffort))
+          .addKeyTermFn(DwcTerm.samplingProtocol, getString(DwcTerm.samplingProtocol))
+          .addKeyTermFn(
+              DwcTerm.scientificNameAuthorship, getString(DwcTerm.scientificNameAuthorship))
+          .addKeyTermFn(DwcTerm.scientificNameID, getString(DwcTerm.scientificNameID))
+          .addKeyTermFn(DwcTerm.sex, getString(DwcTerm.sex))
+          .addKeyTermFn(DwcTerm.specificEpithet, getString(DwcTerm.specificEpithet))
+          .addKeyTermFn(DwcTerm.startDayOfYear, getInt(DwcTerm.startDayOfYear))
+          .addKeyTermFn(DwcTerm.subgenus, getString(DwcTerm.subgenus))
+          .addKeyTermFn(DwcTerm.taxonID, getString(DwcTerm.taxonID))
+          .addKeyTermFn(DwcTerm.taxonomicStatus, getString(DwcTerm.taxonomicStatus))
+          .addKeyTermFn(DwcTerm.taxonRemarks, getString(DwcTerm.taxonRemarks))
+          .addKeyTermFn(DwcTerm.typeStatus, getString(DwcTerm.typeStatus))
+          .addKeyTermFn(DwcTerm.verbatimCoordinates, getString(DwcTerm.verbatimCoordinates))
+          .addKeyTermFn(
+              DwcTerm.verbatimCoordinateSystem, getString(DwcTerm.verbatimCoordinateSystem))
+          .addKeyTermFn(DwcTerm.verbatimDepth, getString(DwcTerm.verbatimDepth))
+          .addKeyTermFn(DwcTerm.verbatimElevation, getString(DwcTerm.verbatimElevation))
+          .addKeyTermFn(DwcTerm.verbatimEventDate, getString(DwcTerm.verbatimEventDate))
+          .addKeyTermFn(DwcTerm.verbatimLatitude, getString(DwcTerm.verbatimLatitude))
+          .addKeyTermFn(DwcTerm.verbatimLocality, getString(DwcTerm.verbatimLocality))
+          .addKeyTermFn(DwcTerm.verbatimLongitude, getString(DwcTerm.verbatimLongitude))
+          .addKeyTermFn(DwcTerm.verbatimSRS, getString(DwcTerm.verbatimSRS))
+          .addKeyTermFn(DwcTerm.verbatimTaxonRank, getString(DwcTerm.verbatimTaxonRank))
+          .addKeyTermFn(DwcTerm.waterBody, getString(DwcTerm.waterBody))
+          .addKeyTermFn(
+              "http://rs.tdwg.org/dwc/terms/occurrenceAttributes",
+              getString("occurrenceAttributes"))
+          // DC Terms
+          .addKeyTermFn(DcTerm.references, getString(DcTerm.references))
+          .addKeyTermFn(DcTerm.accessRights, getString(DcTerm.accessRights))
+          .addKeyTermFn(DcTerm.bibliographicCitation, getString(DcTerm.bibliographicCitation))
+          .addKeyTermFn(DcTerm.language, getString(DcTerm.language))
+          .addKeyTermFn(DcTerm.license, getString(DcTerm.license))
+          .addKeyTermFn(DcTerm.modified, getString(DcTerm.modified))
+          .addKeyTermFn(DcTerm.rights, getString(DcTerm.rights))
+          .addKeyTermFn(DcTerm.rightsHolder, getString(DcTerm.rightsHolder))
+          .addKeyTermFn(DcTerm.source, getString(DcTerm.source))
+          .addKeyTermFn(DcTerm.type, getString(DcTerm.type))
+          // ALA Terms
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/photographer", getString("photographer"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/northing", getString("northing"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/easting", getString("easting"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/species", getString("species"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/subfamily", getString("subfamily"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/subspecies", getString("subspecies"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/superfamily", getString("superfamily"))
+          .addKeyTermFn("http://rs.ala.org.au/terms/1.0/zone", getString("zone"))
+          // ABCD Terms
+          .addKeyTermFn(
+              "http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifier",
+              getString("abcdIdentificationQualifier"))
+          .addKeyTermFn(
+              "http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifierInsertionPoint",
+              getString("abcdIdentificationQualifierInsertionPoint"))
+          .addKeyTermFn("http://rs.tdwg.org/abcd/terms/abcdTypeStatus", getString("abcdTypeStatus"))
+          .addKeyTermFn("http://rs.tdwg.org/abcd/terms/typifiedName", getString("typifiedName"))
+          // HISPID Terms
+          .addKeyTermFn(
+              "http://hiscom.chah.org.au/hispid/terms/secondaryCollectors",
+              getString("secondaryCollectors"))
+          .addKeyTermFn(
+              "http://hiscom.chah.org.au/hispid/terms/identifierRole", getString("identifierRole"))
+          // GGBN Terms
+          .addKeyTermFn("http://data.ggbn.org/schemas/ggbn/terms/loanDate", getString("loanDate"))
+          .addKeyTermFn(
+              "http://data.ggbn.org/schemas/ggbn/terms/loanDestination",
+              getString("loanDestination"))
+          .addKeyTermFn(
+              "http://data.ggbn.org/schemas/ggbn/terms/loanIdentifier", getString("loanIdentifier"))
+          .addKeyTermFn(
+              "http://rs.tdwg.org/dwc/terms/locationAttributes", getString("locationAttributes"))
+          .addKeyTermFn(
+              "http://rs.tdwg.org/dwc/terms/eventAttributes", getString("eventAttributes"))
+          // Other Terms
+          .addKeyTermFn("taxonRankID", getInt("taxonRankID"))
+          // GBIF Terms
+          .addKeyTermFn(GbifTerm.recordedByID, getString(GbifTerm.recordedByID));
+
+  public static String convert(IndexRecord indexRecord) {
+    return CONVERTER.converter(indexRecord);
+  }
+
+  public static List<String> getTerms() {
+    return CONVERTER.getTerms();
+  }
+
+  private static Function<IndexRecord, Optional<String>> getRawString(Term term) {
+    return getString(RAW + term.simpleName());
+  }
+
+  private static Function<IndexRecord, Optional<String>> getString(Term term) {
+    return getString(term.simpleName());
+  }
+
+  private static Function<IndexRecord, Optional<String>> getString(String key) {
+    return ir -> Optional.ofNullable(ir.getStrings().get(key));
+  }
+
+  private static Function<IndexRecord, Optional<String>> getDouble(Term term) {
+    return ir -> {
+      Double d = ir.getDoubles().get(term.simpleName());
+      String result = null;
+      if (d != null) {
+        result = d.toString();
+      }
+      return Optional.ofNullable(result);
+    };
+  }
+
+  private static Function<IndexRecord, Optional<String>> getInt(String term) {
+    return ir -> {
+      Integer d = ir.getInts().get(term);
+      String result = null;
+      if (d != null) {
+        result = d.toString();
+      }
+      return Optional.ofNullable(result);
+    };
+  }
+
+  private static Function<IndexRecord, Optional<String>> getInt(Term term) {
+    return getInt(term.simpleName());
+  }
+
+  private static Function<IndexRecord, Optional<String>> getMultivalue(Term term) {
+    return ir -> Optional.of(String.join("|", ir.getMultiValues().get(term.simpleName())));
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/CsvConverter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/CsvConverter.java
@@ -1,0 +1,66 @@
+package au.org.ala.pipelines.converters;
+
+import com.beust.jcommander.Strings;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.gbif.dwc.terms.Term;
+
+@NoArgsConstructor(staticName = "create")
+public class CsvConverter<T> {
+
+  private final List<KeyTermFn<T>> keyTermFnList = new LinkedList<>();
+
+  public final CsvConverter<T> addKeyTermFn(
+      String term, Function<T, Optional<String>> fn, String defaultValue) {
+    keyTermFnList.add(KeyTermFn.create(term, fn, defaultValue));
+    return this;
+  }
+
+  public final CsvConverter<T> addKeyTermFn(
+      Term term, Function<T, Optional<String>> fn, String defaultValue) {
+    return addKeyTermFn(term.qualifiedName(), fn, defaultValue);
+  }
+
+  public final CsvConverter<T> addKeyTermFn(String term, Function<T, Optional<String>> fn) {
+    keyTermFnList.add(KeyTermFn.create(term, fn, ""));
+    return this;
+  }
+
+  public final CsvConverter<T> addKeyTermFn(Term term, Function<T, Optional<String>> fn) {
+    return addKeyTermFn(term.qualifiedName(), fn);
+  }
+
+  public String converter(T source) {
+    final Map<String, String> resultMap = new LinkedHashMap<>();
+    keyTermFnList.forEach(
+        keyTermFn -> {
+          String value = keyTermFn.getFn().apply(source).orElse(keyTermFn.getDefaultValue());
+          value = "\"" + value + "\"";
+          resultMap.put(keyTermFn.getTerm(), value);
+        });
+    return Strings.join(",", resultMap.values().toArray(new String[0]));
+  }
+
+  public List<String> getTerms() {
+    return keyTermFnList.stream()
+        .sequential()
+        .map(KeyTermFn::getTerm)
+        .collect(Collectors.toCollection(LinkedList::new));
+  }
+
+  @Getter
+  @AllArgsConstructor(staticName = "create")
+  public static class KeyTermFn<T> {
+    private final String term;
+    private final Function<T, Optional<String>> fn;
+    private final String defaultValue;
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/MultimediaCsvConverter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/MultimediaCsvConverter.java
@@ -1,0 +1,40 @@
+package au.org.ala.pipelines.converters;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.gbif.dwc.terms.DcTerm;
+import org.gbif.dwc.terms.Term;
+import org.gbif.pipelines.io.avro.IndexRecord;
+
+public class MultimediaCsvConverter {
+
+  private static final CsvConverter<IndexRecord> CONVERTER =
+      CsvConverter.<IndexRecord>create()
+          .addKeyTermFn("id", ir -> Optional.of(ir.getId()))
+          .addKeyTermFn(DcTerm.identifier, ir -> Optional.of(ir.getId()))
+          .addKeyTermFn(DcTerm.creator, getString(DcTerm.creator))
+          .addKeyTermFn(DcTerm.created, getString(DcTerm.created))
+          .addKeyTermFn(DcTerm.title, getString(DcTerm.title))
+          .addKeyTermFn(DcTerm.format, getString(DcTerm.format))
+          .addKeyTermFn(DcTerm.license, getString(DcTerm.license))
+          .addKeyTermFn(DcTerm.rights, getString(DcTerm.rights))
+          .addKeyTermFn(DcTerm.rightsHolder, getString(DcTerm.rightsHolder))
+          .addKeyTermFn(DcTerm.references, getString(DcTerm.references));
+
+  public static String convert(IndexRecord indexRecord) {
+    return CONVERTER.converter(indexRecord);
+  }
+
+  public static List<String> getTerms() {
+    return CONVERTER.getTerms();
+  }
+
+  private static Function<IndexRecord, Optional<String>> getString(Term term) {
+    return getString(term.simpleName());
+  }
+
+  private static Function<IndexRecord, Optional<String>> getString(String key) {
+    return ir -> Optional.ofNullable(ir.getStrings().get(key));
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/util/DwcaMetaXml.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/util/DwcaMetaXml.java
@@ -1,0 +1,94 @@
+package au.org.ala.pipelines.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import au.org.ala.utils.ALAFsUtils;
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapperBuilder;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.io.Writer;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.FileSystem;
+import org.gbif.pipelines.core.utils.FsUtils;
+
+@Builder(buildMethodName = "create")
+public class DwcaMetaXml {
+
+  private static final String META =
+      "<?xml version=\"1.0\"?>\n"
+          + "<archive metadata=\"eml.xml\" xmlns=\"http://rs.tdwg.org/dwc/text/\">\n"
+          + "  <core encoding=\"UTF-8\" linesTerminatedBy=\"\\r\\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.tdwg.org/dwc/terms/Occurrence\">\n"
+          + "    <files>\n"
+          + "      <location>occurrence.csv</location>\n"
+          + "    </files>\n"
+          + "    <id index=\"0\"/>\n"
+          + "    <#list coreTerms as coreTerm>\n"
+          + "    <field index=\"${coreTerm?counter - 1}\" term=\"${coreTerm}\"/>\n"
+          + "    </#list>\n"
+          + "  </core>\n"
+          + "  <#list multimediaTerms>\n"
+          + "  <extension encoding=\"UTF-8\" linesTerminatedBy=\"\\r\\n\" fieldsTerminatedBy=\",\" fieldsEnclosedBy=\"&quot;\" ignoreHeaderLines=\"0\" rowType=\"http://rs.gbif.org/terms/1.0/Multimedia\">\n"
+          + "    <files>\n"
+          + "      <location>image.csv</location>\n"
+          + "    </files>\n"
+          + "    <coreid index=\"0\"/>\n"
+          + "    <#items as multimediaTerm>\n"
+          + "    <field index=\"${multimediaTerm?counter - 1}\" term=\"${multimediaTerm}\"/>\n"
+          + "    </#items>\n"
+          + "  </extension>\n"
+          + "  </#list>\n"
+          + "</archive>";
+
+  private final List<String> coreTerms;
+  private final List<String> multimediaTerms;
+  private final String pathToWrite;
+  private final String hdfsSiteConfig;
+  private final String coreSiteConfig;
+
+  @SneakyThrows
+  public void write() {
+    Template temp = new Template("meta", new StringReader(META), createConfig());
+
+    Writer out;
+    if (hdfsSiteConfig == null || hdfsSiteConfig.isEmpty()) {
+      out = new OutputStreamWriter(new FileOutputStream(pathToWrite));
+    } else {
+      FileSystem fs = FsUtils.getFileSystem(hdfsSiteConfig, coreSiteConfig, pathToWrite);
+      out = new OutputStreamWriter(ALAFsUtils.openOutputStream(fs, pathToWrite));
+    }
+
+    temp.process(TemplatePojo.create(coreTerms, multimediaTerms), out);
+  }
+
+  /** Create Freemarker config */
+  private Configuration createConfig() {
+    Configuration cfg = new Configuration(Configuration.VERSION_2_3_31);
+    cfg.setDefaultEncoding(UTF_8.toString());
+    cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+    cfg.setLogTemplateExceptions(false);
+    cfg.setWrapUncheckedExceptions(true);
+    cfg.setFallbackOnNullLoopVariable(false);
+    cfg.setTabSize(1);
+
+    DefaultObjectWrapperBuilder owb = new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_31);
+    owb.setIterableSupport(true);
+    cfg.setObjectWrapper(owb.build());
+
+    return cfg;
+  }
+
+  @Getter
+  @Data(staticConstructor = "create")
+  public static class TemplatePojo {
+    private final List<String> coreTerms;
+    private final List<String> multimediaTerms;
+  }
+}

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreCsvConverterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreCsvConverterTest.java
@@ -60,11 +60,11 @@ public class CoreCsvConverterTest {
       "\"raw_er_eventID\"", // DwcTerm.eventID
       "\"raw_er_identifiedBy\"", // DwcTerm.identifiedBy
       "\"raw_er_occurrenceRemarks\"", // DwcTerm.occurrenceRemarks
-      "\"raw_er_dataGeneralizations\"", // DwcTerm.dataGeneralizations
+      "\"\"", // DwcTerm.dataGeneralizations
       "\"raw_er_otherCatalogNumbers\"", // DwcTerm.otherCatalogNumbers
       "\"raw_er_acceptedNameUsage\"", // DwcTerm.acceptedNameUsage
       "\"raw_er_acceptedNameUsageID\"", // DwcTerm.acceptedNameUsageID
-      "\"raw_er_associatedOccurrences\"", // DwcTerm.associatedOccurrences
+      "\"\"", // DwcTerm.associatedOccurrences
       "\"raw_er_associatedReferences\"", // DwcTerm.associatedReferences
       "\"raw_er_associatedSequences\"", // DwcTerm.associatedSequences
       "\"raw_er_associatedTaxa\"", // DwcTerm.associatedTaxa
@@ -103,7 +103,7 @@ public class CoreCsvConverterTest {
       "\"raw_er_identificationReferences\"", // DwcTerm.identificationReferences
       "\"raw_er_identificationRemarks\"", // DwcTerm.identificationRemarks
       "\"raw_er_identificationVerificationStatus\"", // DwcTerm.identificationVerificationStatus
-      "\"raw_er_informationWithheld\"", // DwcTerm.informationWithheld
+      "\"\"", // DwcTerm.informationWithheld
       "\"raw_er_infraspecificEpithet\"", // DwcTerm.infraspecificEpithet
       "\"raw_er_institutionID\"", // DwcTerm.institutionID
       "\"raw_er_island\"", // DwcTerm.island
@@ -138,7 +138,7 @@ public class CoreCsvConverterTest {
       "\"raw_er_parentNameUsage\"", // DwcTerm.parentNameUsage
       "\"raw_er_parentNameUsageID\"", // DwcTerm.parentNameUsageID
       "\"raw_er_pointRadiusSpatialFit\"", // DwcTerm.pointRadiusSpatialFit
-      "\"raw_er_preparations\"", // DwcTerm.preparations
+      "\"\"", // DwcTerm.preparations
       "\"raw_er_previousIdentifications\"", // DwcTerm.previousIdentifications
       "\"raw_er_relatedResourceID\"", // DwcTerm.relatedResourceID
       "\"raw_er_relationshipAccordingTo\"", // DwcTerm.relationshipAccordingTo
@@ -848,7 +848,7 @@ public class CoreCsvConverterTest {
   public void converterDefualtTest() {
     // Expected
     // tr = 1, br = 2, lr = 3, trx = 4, atxr = 5, aur = 6, ir = 7, asr = 8
-    String[] expectet = {
+    String[] expected = {
       // DWC Terms
       "\"aur_uuid\"", // DwcTerm.occurrenceID
       "\"raw_er_catalogNumber\"", // DwcTerm.catalogNumber
@@ -888,7 +888,7 @@ public class CoreCsvConverterTest {
       "\"raw_er_eventID\"", // DwcTerm.eventID
       "\"raw_er_identifiedBy\"", // DwcTerm.identifiedBy
       "\"raw_er_occurrenceRemarks\"", // DwcTerm.occurrenceRemarks
-      "\"raw_er_dataGeneralizations\"", // DwcTerm.dataGeneralizations
+      "\"\"", // DwcTerm.dataGeneralizations
       "\"raw_er_otherCatalogNumbers\"", // DwcTerm.otherCatalogNumbers
       "\"\"", // DwcTerm.acceptedNameUsage
       "\"\"", // DwcTerm.acceptedNameUsageID
@@ -1166,7 +1166,7 @@ public class CoreCsvConverterTest {
     String result = CoreCsvConverter.convert(source);
 
     // Should
-    Assert.assertEquals(String.join(",", expectet), result);
+    Assert.assertEquals(String.join(",", expected), result);
   }
 
   @Test

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreCsvConverterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreCsvConverterTest.java
@@ -1,0 +1,1376 @@
+package au.org.ala.pipelines.converters;
+
+import au.org.ala.pipelines.transforms.IndexRecordTransform;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.gbif.dwc.terms.DcTerm;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.pipelines.io.avro.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CoreCsvConverterTest {
+
+  @Test
+  public void converterTest() {
+    // Expected
+    // tr = 1, br = 2, lr = 3, trx = 4, atxr = 5, aur = 6, ir = 7, asr = 8
+    String[] expectet = {
+      // DWC Terms
+      "\"aur_uuid\"", // DwcTerm.occurrenceID
+      "\"raw_er_catalogNumber\"", // DwcTerm.catalogNumber
+      "\"raw_er_collectionCode\"", // DwcTerm.collectionCode
+      "\"raw_er_institutionCode\"", // DwcTerm.institutionCode
+      "\"raw_er_recordNumber\"", // DwcTerm.recordNumber
+      "\"br_basisOfRecord\"", // DwcTerm.basisOfRecord
+      "\"br_recordedBy_1|br_recordedBy_2\"", // DwcTerm.recordedBy
+      "\"br_occurrenceStatus\"", // DwcTerm.occurrenceStatus
+      "\"222\"", // DwcTerm.individualCount
+      "\"atxr_ScientificName\"", // DwcTerm.scientificName
+      "\"atxr_TaxonConceptID\"", // DwcTerm.taxonConceptID
+      "\"atxr_taxonrank\"", // DwcTerm.taxonRank
+      "\"atxr_Kingdom\"", // DwcTerm.kingdom
+      "\"atxr_Phylum\"", // DwcTerm.phylum
+      "\"atxr_Classs\"", // DwcTerm.class_
+      "\"atxr_Order\"", // DwcTerm.order
+      "\"atxr_Family\"", // DwcTerm.family
+      "\"atxr_Genus\"", // DwcTerm.genus
+      "\"atxr_VernacularName\"", // DwcTerm.vernacularName
+      "\"3.33333333333E11\"", // DwcTerm.decimalLatitude
+      "\"3.333333333333E12\"", // DwcTerm.decimalLongitude
+      "\"EPSG:4326\"", // DwcTerm.geodeticDatum
+      "\"3.3333333333333E13\"", // DwcTerm.coordinateUncertaintyInMeters
+      "\"333.0\"", // DwcTerm.maximumElevationInMeters
+      "\"33.0\"", // DwcTerm.minimumElevationInMeters
+      "\"33333.0\"", // DwcTerm.minimumDepthInMeters
+      "\"333333.0\"", // DwcTerm.maximumDepthInMeters
+      "\"lr_country\"", // DwcTerm.country
+      "\"lr_stateProvince\"", // DwcTerm.stateProvince
+      "\"lr_locality\"", // DwcTerm.locality
+      "\"raw_er_locationRemarks\"", // DwcTerm.locationRemarks
+      "\"111\"", // DwcTerm.year
+      "\"1111\"", // DwcTerm.month
+      "\"11111\"", // DwcTerm.day
+      "\"raw_er_eventDate\"", // DwcTerm.eventDate
+      "\"raw_er_eventID\"", // DwcTerm.eventID
+      "\"raw_er_identifiedBy\"", // DwcTerm.identifiedBy
+      "\"raw_er_occurrenceRemarks\"", // DwcTerm.occurrenceRemarks
+      "\"raw_er_dataGeneralizations\"", // DwcTerm.dataGeneralizations
+      "\"raw_er_otherCatalogNumbers\"", // DwcTerm.otherCatalogNumbers
+      "\"raw_er_acceptedNameUsage\"", // DwcTerm.acceptedNameUsage
+      "\"raw_er_acceptedNameUsageID\"", // DwcTerm.acceptedNameUsageID
+      "\"raw_er_associatedOccurrences\"", // DwcTerm.associatedOccurrences
+      "\"raw_er_associatedReferences\"", // DwcTerm.associatedReferences
+      "\"raw_er_associatedSequences\"", // DwcTerm.associatedSequences
+      "\"raw_er_associatedTaxa\"", // DwcTerm.associatedTaxa
+      "\"raw_er_behavior\"", // DwcTerm.behavior
+      "\"raw_er_collectionID\"", // DwcTerm.collectionID
+      "\"lr_continent\"", // DwcTerm.continent
+      "\"3.33333333333333E14\"", // DwcTerm.coordinatePrecision
+      "\"lr_countryCode\"", // DwcTerm.countryCode
+      "\"raw_er_county\"", // DwcTerm.county
+      "\"raw_er_datasetID\"", // DwcTerm.datasetID
+      "\"raw_er_datasetName\"", // DwcTerm.datasetName
+      "\"2002\"", // DwcTerm.dateIdentified
+      "\"raw_er_disposition\"", // DwcTerm.disposition
+      "\"raw_er_dynamicProperties\"", // DwcTerm.dynamicProperties
+      "\"1111111\"", // DwcTerm.endDayOfYear
+      "\"br_establishmentMeans\"", // DwcTerm.establishmentMeans
+      "\"raw_er_eventRemarks\"", // DwcTerm.eventRemarks
+      "\"raw_er_eventTime\"", // DwcTerm.eventTime
+      "\"raw_er_fieldNotes\"", // DwcTerm.fieldNotes
+      "\"raw_er_fieldNumber\"", // DwcTerm.fieldNumber
+      "\"raw_er_footprintSpatialFit\"", // DwcTerm.footprintSpatialFit
+      "\"raw_er_footprintSRS\"", // DwcTerm.footprintSRS
+      "\"lr_footprintWKT\"", // DwcTerm.footprintWKT
+      "\"raw_er_georeferencedBy\"", // DwcTerm.georeferencedBy
+      "\"lr_georeferencedDate\"", // DwcTerm.georeferencedDate
+      "\"raw_er_georeferenceProtocol\"", // DwcTerm.georeferenceProtocol
+      "\"raw_er_georeferenceRemarks\"", // DwcTerm.georeferenceRemarks
+      "\"raw_er_georeferenceSources\"", // DwcTerm.georeferenceSources
+      "\"raw_er_georeferenceVerificationStatus\"", // DwcTerm.georeferenceVerificationStatus
+      "\"raw_er_habitat\"", // DwcTerm.habitat
+      "\"raw_er_higherClassification\"", // DwcTerm.higherClassification
+      "\"raw_er_higherGeography\"", // DwcTerm.higherGeography
+      "\"raw_er_higherGeographyID\"", // DwcTerm.higherGeographyID
+      "\"raw_er_identificationID\"", // DwcTerm.identificationID
+      "\"raw_er_identificationQualifier\"", // DwcTerm.identificationQualifier
+      "\"raw_er_identificationReferences\"", // DwcTerm.identificationReferences
+      "\"raw_er_identificationRemarks\"", // DwcTerm.identificationRemarks
+      "\"raw_er_identificationVerificationStatus\"", // DwcTerm.identificationVerificationStatus
+      "\"raw_er_informationWithheld\"", // DwcTerm.informationWithheld
+      "\"raw_er_infraspecificEpithet\"", // DwcTerm.infraspecificEpithet
+      "\"raw_er_institutionID\"", // DwcTerm.institutionID
+      "\"raw_er_island\"", // DwcTerm.island
+      "\"raw_er_islandGroup\"", // DwcTerm.islandGroup
+      "\"br_lifeStage\"", // DwcTerm.lifeStage
+      "\"raw_er_locationAccordingTo\"", // DwcTerm.locationAccordingTo
+      "\"raw_er_locationID\"", // DwcTerm.locationID
+      "\"3.3333333333E10\"", // DwcTerm.maximumDistanceAboveSurfaceInMeters
+      "\"raw_er_measurementAccuracy\"", // DwcTerm.measurementAccuracy
+      "\"raw_er_measurementDeterminedBy\"", // DwcTerm.measurementDeterminedBy
+      "\"raw_er_measurementDeterminedDate\"", // DwcTerm.measurementDeterminedDate
+      "\"raw_er_measurementID\"", // DwcTerm.measurementID
+      "\"raw_er_measurementMethod\"", // DwcTerm.measurementMethod
+      "\"raw_er_measurementRemarks\"", // DwcTerm.measurementRemarks
+      "\"raw_er_measurementType\"", // DwcTerm.measurementType
+      "\"raw_er_measurementUnit\"", // DwcTerm.measurementUnit
+      "\"raw_er_measurementValue\"", // DwcTerm.measurementValue
+      "\"raw_er_municipality\"", // DwcTerm.municipality
+      "\"raw_er_nameAccordingTo\"", // DwcTerm.nameAccordingTo
+      "\"raw_er_nameAccordingToID\"", // DwcTerm.nameAccordingToID
+      "\"raw_er_namePublishedIn\"", // DwcTerm.namePublishedIn
+      "\"raw_er_namePublishedInID\"", // DwcTerm.namePublishedInID
+      "\"raw_er_namePublishedInYear\"", // DwcTerm.namePublishedInYear
+      "\"raw_er_nomenclaturalCode\"", // DwcTerm.nomenclaturalCode
+      "\"raw_er_nomenclaturalStatus\"", // DwcTerm.nomenclaturalStatus
+      "\"raw_er_organismID\"", // DwcTerm.organismID
+      "\"2222.0\"", // DwcTerm.organismQuantity
+      "\"br_organismQuantityType\"", // DwcTerm.organismQuantityType
+      "\"raw_er_originalNameUsage\"", // DwcTerm.originalNameUsage
+      "\"raw_er_originalNameUsageID\"", // DwcTerm.originalNameUsageID
+      "\"raw_er_ownerInstitutionCode\"", // DwcTerm.ownerInstitutionCode
+      "\"raw_er_parentNameUsage\"", // DwcTerm.parentNameUsage
+      "\"raw_er_parentNameUsageID\"", // DwcTerm.parentNameUsageID
+      "\"raw_er_pointRadiusSpatialFit\"", // DwcTerm.pointRadiusSpatialFit
+      "\"raw_er_preparations\"", // DwcTerm.preparations
+      "\"raw_er_previousIdentifications\"", // DwcTerm.previousIdentifications
+      "\"raw_er_relatedResourceID\"", // DwcTerm.relatedResourceID
+      "\"raw_er_relationshipAccordingTo\"", // DwcTerm.relationshipAccordingTo
+      "\"3.333333333E9\"", // DwcTerm.minimumDistanceAboveSurfaceInMeters
+      "\"raw_er_relationshipEstablishedDate\"", // DwcTerm.relationshipEstablishedDate
+      "\"raw_er_relationshipOfResource\"", // DwcTerm.relationshipOfResource
+      "\"raw_er_relationshipRemarks\"", // DwcTerm.relationshipRemarks
+      "\"raw_er_reproductiveCondition\"", // DwcTerm.reproductiveCondition
+      "\"raw_er_resourceID\"", // DwcTerm.resourceID
+      "\"raw_er_resourceRelationshipID\"", // DwcTerm.resourceRelationshipID
+      "\"raw_er_samplingEffort\"", // DwcTerm.samplingEffort
+      "\"raw_er_samplingProtocol\"", // DwcTerm.samplingProtocol
+      "\"atxr_ScientificNameAuthorship\"", // DwcTerm.scientificNameAuthorship
+      "\"raw_er_scientificNameID\"", // DwcTerm.scientificNameID
+      "\"br_sex\"", // DwcTerm.sex
+      "\"raw_er_specificEpithet\"", // DwcTerm.specificEpithet
+      "\"111111\"", // DwcTerm.startDayOfYear
+      "\"raw_er_subgenus\"", // DwcTerm.subgenus
+      "\"raw_er_taxonID\"", // DwcTerm.taxonID
+      "\"raw_er_taxonomicStatus\"", // DwcTerm.taxonomicStatus
+      "\"raw_er_taxonRemarks\"", // DwcTerm.taxonRemarks
+      "\"br_typeStatus\"", // DwcTerm.typeStatus
+      "\"raw_er_verbatimCoordinates\"", // DwcTerm.verbatimCoordinates
+      "\"raw_er_verbatimCoordinateSystem\"", // DwcTerm.verbatimCoordinateSystem
+      "\"raw_er_verbatimDepth\"", // DwcTerm.verbatimDepth
+      "\"raw_er_verbatimElevation\"", // DwcTerm.verbatimElevation
+      "\"raw_er_verbatimEventDate\"", // DwcTerm.verbatimEventDate
+      "\"raw_er_verbatimLatitude\"", // DwcTerm.verbatimLatitude
+      "\"raw_er_verbatimLocality\"", // DwcTerm.verbatimLocality
+      "\"raw_er_verbatimLongitude\"", // DwcTerm.verbatimLongitude
+      "\"raw_er_verbatimSRS\"", // DwcTerm.verbatimSRS
+      "\"raw_er_verbatimTaxonRank\"", // DwcTerm.verbatimTaxonRank
+      "\"lr_waterBody\"", // DwcTerm.waterBody
+      "\"raw_er_occurrenceAttributes\"", // http://rs.tdwg.org/dwc/terms/occurrenceAttributes
+      // DC Terms
+      "\"br_References\"", // DcTerm.references
+      "\"raw_er_accessRights\"", // DcTerm.accessRights
+      "\"raw_er_bibliographicCitation\"", // DcTerm.bibliographicCitation
+      "\"raw_er_language\"", // DcTerm.language
+      "\"br_license\"", // DcTerm.license
+      "\"2001\"", // DcTerm.modified
+      "\"raw_er_rights\"", // DcTerm.rights
+      "\"raw_er_rightsHolder\"", // DcTerm.rightsHolder
+      "\"raw_er_source\"", // DcTerm.source
+      "\"raw_er_type\"", // DcTerm.type
+      // ALA Terms
+      "\"raw_er_photographer\"", // http://rs.ala.org.au/terms/1.0/photographer
+      "\"raw_er_northing\"", // http://rs.ala.org.au/terms/1.0/northing
+      "\"raw_er_easting\"", // http://rs.ala.org.au/terms/1.0/easting
+      "\"atxr_Species\"", // http://rs.ala.org.au/terms/1.0/species
+      "\"raw_er_subfamily\"", // http://rs.ala.org.au/terms/1.0/subfamily
+      "\"raw_er_subspecies\"", // http://rs.ala.org.au/terms/1.0/subspecies
+      "\"raw_er_superfamily\"", // http://rs.ala.org.au/terms/1.0/superfamily
+      "\"raw_er_zone\"", // http://rs.ala.org.au/terms/1.0/zone
+      // ABCD Terms
+      "\"raw_er_abcdIdentificationQualifier\"", // http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifier
+      "\"raw_er_abcdIdentificationQualifierInsertionPoint\"", // http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifierInsertionPoint
+      "\"raw_er_abcdTypeStatus\"", // http://rs.tdwg.org/abcd/terms/abcdTypeStatus
+      "\"br_typifiedName\"", // http://rs.tdwg.org/abcd/terms/typifiedName
+      // HISPID Terms
+      "\"raw_er_secondaryCollectors\"", // http://hiscom.chah.org.au/hispid/terms/secondaryCollectors
+      "\"raw_er_identifierRole\"", // http://hiscom.chah.org.au/hispid/terms/identifierRole
+      // GGBN Terms
+      "\"raw_er_loanDate\"", // http://data.ggbn.org/schemas/ggbn/terms/loanDate
+      "\"raw_er_loanDestination\"", // http://data.ggbn.org/schemas/ggbn/terms/loanDestination
+      "\"raw_er_loanIdentifier\"", // http://data.ggbn.org/schemas/ggbn/terms/loanIdentifier
+      "\"raw_er_locationAttributes\"", // http://rs.tdwg.org/dwc/terms/locationAttributes
+      "\"raw_er_eventAttributes\"", // http://rs.tdwg.org/dwc/terms/eventAttributes
+      // Other Terms
+      "\"5\"", // taxonRankID
+      // GBIF Terms
+      "\"raw_er_recordedByID\"" // GbifTerm.recordedByID
+    };
+
+    // State
+    Map<String, String> core = new HashMap<>();
+    // DWC Terms
+    core.put(DwcTerm.occurrenceID.qualifiedName(), "raw_er_" + DwcTerm.occurrenceID.simpleName());
+    core.put(DwcTerm.catalogNumber.qualifiedName(), "raw_er_" + DwcTerm.catalogNumber.simpleName());
+    core.put(
+        DwcTerm.collectionCode.qualifiedName(), "raw_er_" + DwcTerm.collectionCode.simpleName());
+    core.put(
+        DwcTerm.institutionCode.qualifiedName(), "raw_er_" + DwcTerm.institutionCode.simpleName());
+    core.put(DwcTerm.recordNumber.qualifiedName(), "raw_er_" + DwcTerm.recordNumber.simpleName());
+    core.put(DwcTerm.basisOfRecord.qualifiedName(), "raw_er_" + DwcTerm.basisOfRecord.simpleName());
+    core.put(DwcTerm.recordedBy.qualifiedName(), "raw_er_" + DwcTerm.recordedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceStatus.qualifiedName(),
+        "raw_er_" + DwcTerm.occurrenceStatus.simpleName());
+    core.put(
+        DwcTerm.individualCount.qualifiedName(), "raw_er_" + DwcTerm.individualCount.simpleName());
+    core.put(
+        DwcTerm.scientificName.qualifiedName(), "raw_er_" + DwcTerm.scientificName.simpleName());
+    core.put(
+        DwcTerm.taxonConceptID.qualifiedName(), "raw_er_" + DwcTerm.taxonConceptID.simpleName());
+    core.put(DwcTerm.taxonRank.qualifiedName(), "raw_er_" + DwcTerm.taxonRank.simpleName());
+    core.put(DwcTerm.kingdom.qualifiedName(), "raw_er_" + DwcTerm.kingdom.simpleName());
+    core.put(DwcTerm.phylum.qualifiedName(), "raw_er_" + DwcTerm.phylum.simpleName());
+    core.put(DwcTerm.class_.qualifiedName(), "raw_er_" + DwcTerm.class_.simpleName());
+    core.put(DwcTerm.order.qualifiedName(), "raw_er_" + DwcTerm.order.simpleName());
+    core.put(DwcTerm.family.qualifiedName(), "raw_er_" + DwcTerm.family.simpleName());
+    core.put(DwcTerm.genus.qualifiedName(), "raw_er_" + DwcTerm.genus.simpleName());
+    core.put(
+        DwcTerm.vernacularName.qualifiedName(), "raw_er_" + DwcTerm.vernacularName.simpleName());
+    core.put(
+        DwcTerm.decimalLatitude.qualifiedName(), "raw_er_" + DwcTerm.decimalLatitude.simpleName());
+    core.put(
+        DwcTerm.decimalLongitude.qualifiedName(),
+        "raw_er_" + DwcTerm.decimalLongitude.simpleName());
+    core.put(DwcTerm.geodeticDatum.qualifiedName(), "raw_er_" + DwcTerm.geodeticDatum.simpleName());
+    core.put(
+        DwcTerm.coordinateUncertaintyInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.coordinateUncertaintyInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumElevationInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.maximumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumElevationInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.minimumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumDepthInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.minimumDepthInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumDepthInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.maximumDepthInMeters.simpleName());
+    core.put(DwcTerm.country.qualifiedName(), "raw_er_" + DwcTerm.country.simpleName());
+    core.put(DwcTerm.stateProvince.qualifiedName(), "raw_er_" + DwcTerm.stateProvince.simpleName());
+    core.put(DwcTerm.locality.qualifiedName(), "raw_er_" + DwcTerm.locality.simpleName());
+    core.put(
+        DwcTerm.locationRemarks.qualifiedName(), "raw_er_" + DwcTerm.locationRemarks.simpleName());
+    core.put(DwcTerm.year.qualifiedName(), "raw_er_" + DwcTerm.year.simpleName());
+    core.put(DwcTerm.month.qualifiedName(), "raw_er_" + DwcTerm.month.simpleName());
+    core.put(DwcTerm.day.qualifiedName(), "raw_er_" + DwcTerm.day.simpleName());
+    core.put(DwcTerm.eventDate.qualifiedName(), "raw_er_" + DwcTerm.eventDate.simpleName());
+    core.put(DwcTerm.eventID.qualifiedName(), "raw_er_" + DwcTerm.eventID.simpleName());
+    core.put(DwcTerm.identifiedBy.qualifiedName(), "raw_er_" + DwcTerm.identifiedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceRemarks.qualifiedName(),
+        "raw_er_" + DwcTerm.occurrenceRemarks.simpleName());
+    core.put(
+        DwcTerm.dataGeneralizations.qualifiedName(),
+        "raw_er_" + DwcTerm.dataGeneralizations.simpleName());
+    core.put(
+        DwcTerm.otherCatalogNumbers.qualifiedName(),
+        "raw_er_" + DwcTerm.otherCatalogNumbers.simpleName());
+    core.put(
+        DwcTerm.acceptedNameUsage.qualifiedName(),
+        "raw_er_" + DwcTerm.acceptedNameUsage.simpleName());
+    core.put(
+        DwcTerm.acceptedNameUsageID.qualifiedName(),
+        "raw_er_" + DwcTerm.acceptedNameUsageID.simpleName());
+    core.put(
+        DwcTerm.associatedOccurrences.qualifiedName(),
+        "raw_er_" + DwcTerm.associatedOccurrences.simpleName());
+    core.put(
+        DwcTerm.associatedReferences.qualifiedName(),
+        "raw_er_" + DwcTerm.associatedReferences.simpleName());
+    core.put(
+        DwcTerm.associatedSequences.qualifiedName(),
+        "raw_er_" + DwcTerm.associatedSequences.simpleName());
+    core.put(
+        DwcTerm.associatedTaxa.qualifiedName(), "raw_er_" + DwcTerm.associatedTaxa.simpleName());
+    core.put(DwcTerm.behavior.qualifiedName(), "raw_er_" + DwcTerm.behavior.simpleName());
+    core.put(DwcTerm.collectionID.qualifiedName(), "raw_er_" + DwcTerm.collectionID.simpleName());
+    core.put(DwcTerm.continent.qualifiedName(), "raw_er_" + DwcTerm.continent.simpleName());
+    core.put(
+        DwcTerm.coordinatePrecision.qualifiedName(),
+        "raw_er_" + DwcTerm.coordinatePrecision.simpleName());
+    core.put(DwcTerm.countryCode.qualifiedName(), "raw_er_" + DwcTerm.countryCode.simpleName());
+    core.put(DwcTerm.county.qualifiedName(), "raw_er_" + DwcTerm.county.simpleName());
+    core.put(DwcTerm.datasetID.qualifiedName(), "raw_er_" + DwcTerm.datasetID.simpleName());
+    core.put(DwcTerm.datasetName.qualifiedName(), "raw_er_" + DwcTerm.datasetName.simpleName());
+    core.put(
+        DwcTerm.dateIdentified.qualifiedName(), "raw_er_" + DwcTerm.dateIdentified.simpleName());
+    core.put(DwcTerm.disposition.qualifiedName(), "raw_er_" + DwcTerm.disposition.simpleName());
+    core.put(
+        DwcTerm.dynamicProperties.qualifiedName(),
+        "raw_er_" + DwcTerm.dynamicProperties.simpleName());
+    core.put(DwcTerm.endDayOfYear.qualifiedName(), "raw_er_" + DwcTerm.endDayOfYear.simpleName());
+    core.put(
+        DwcTerm.establishmentMeans.qualifiedName(),
+        "raw_er_" + DwcTerm.establishmentMeans.simpleName());
+    core.put(DwcTerm.eventRemarks.qualifiedName(), "raw_er_" + DwcTerm.eventRemarks.simpleName());
+    core.put(DwcTerm.eventTime.qualifiedName(), "raw_er_" + DwcTerm.eventTime.simpleName());
+    core.put(DwcTerm.fieldNotes.qualifiedName(), "raw_er_" + DwcTerm.fieldNotes.simpleName());
+    core.put(DwcTerm.fieldNumber.qualifiedName(), "raw_er_" + DwcTerm.fieldNumber.simpleName());
+    core.put(
+        DwcTerm.footprintSpatialFit.qualifiedName(),
+        "raw_er_" + DwcTerm.footprintSpatialFit.simpleName());
+    core.put(DwcTerm.footprintSRS.qualifiedName(), "raw_er_" + DwcTerm.footprintSRS.simpleName());
+    core.put(DwcTerm.footprintWKT.qualifiedName(), "raw_er_" + DwcTerm.footprintWKT.simpleName());
+    core.put(
+        DwcTerm.georeferencedBy.qualifiedName(), "raw_er_" + DwcTerm.georeferencedBy.simpleName());
+    core.put(
+        DwcTerm.georeferencedDate.qualifiedName(),
+        "raw_er_" + DwcTerm.georeferencedDate.simpleName());
+    core.put(
+        DwcTerm.georeferenceProtocol.qualifiedName(),
+        "raw_er_" + DwcTerm.georeferenceProtocol.simpleName());
+    core.put(
+        DwcTerm.georeferenceRemarks.qualifiedName(),
+        "raw_er_" + DwcTerm.georeferenceRemarks.simpleName());
+    core.put(
+        DwcTerm.georeferenceSources.qualifiedName(),
+        "raw_er_" + DwcTerm.georeferenceSources.simpleName());
+    core.put(
+        DwcTerm.georeferenceVerificationStatus.qualifiedName(),
+        "raw_er_" + DwcTerm.georeferenceVerificationStatus.simpleName());
+    core.put(DwcTerm.habitat.qualifiedName(), "raw_er_" + DwcTerm.habitat.simpleName());
+    core.put(
+        DwcTerm.higherClassification.qualifiedName(),
+        "raw_er_" + DwcTerm.higherClassification.simpleName());
+    core.put(
+        DwcTerm.higherGeography.qualifiedName(), "raw_er_" + DwcTerm.higherGeography.simpleName());
+    core.put(
+        DwcTerm.higherGeographyID.qualifiedName(),
+        "raw_er_" + DwcTerm.higherGeographyID.simpleName());
+    core.put(
+        DwcTerm.identificationID.qualifiedName(),
+        "raw_er_" + DwcTerm.identificationID.simpleName());
+    core.put(
+        DwcTerm.identificationQualifier.qualifiedName(),
+        "raw_er_" + DwcTerm.identificationQualifier.simpleName());
+    core.put(
+        DwcTerm.identificationReferences.qualifiedName(),
+        "raw_er_" + DwcTerm.identificationReferences.simpleName());
+    core.put(
+        DwcTerm.identificationRemarks.qualifiedName(),
+        "raw_er_" + DwcTerm.identificationRemarks.simpleName());
+    core.put(
+        DwcTerm.identificationVerificationStatus.qualifiedName(),
+        "raw_er_" + DwcTerm.identificationVerificationStatus.simpleName());
+    core.put(
+        DwcTerm.informationWithheld.qualifiedName(),
+        "raw_er_" + DwcTerm.informationWithheld.simpleName());
+    core.put(
+        DwcTerm.infraspecificEpithet.qualifiedName(),
+        "raw_er_" + DwcTerm.infraspecificEpithet.simpleName());
+    core.put(DwcTerm.institutionID.qualifiedName(), "raw_er_" + DwcTerm.institutionID.simpleName());
+    core.put(DwcTerm.island.qualifiedName(), "raw_er_" + DwcTerm.island.simpleName());
+    core.put(DwcTerm.islandGroup.qualifiedName(), "raw_er_" + DwcTerm.islandGroup.simpleName());
+    core.put(DwcTerm.lifeStage.qualifiedName(), "raw_er_" + DwcTerm.lifeStage.simpleName());
+    core.put(
+        DwcTerm.locationAccordingTo.qualifiedName(),
+        "raw_er_" + DwcTerm.locationAccordingTo.simpleName());
+    core.put(DwcTerm.locationID.qualifiedName(), "raw_er_" + DwcTerm.locationID.simpleName());
+    core.put(
+        DwcTerm.maximumDistanceAboveSurfaceInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.maximumDistanceAboveSurfaceInMeters.simpleName());
+    core.put(
+        DwcTerm.measurementAccuracy.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementAccuracy.simpleName());
+    core.put(
+        DwcTerm.measurementDeterminedBy.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementDeterminedBy.simpleName());
+    core.put(
+        DwcTerm.measurementDeterminedDate.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementDeterminedDate.simpleName());
+    core.put(DwcTerm.measurementID.qualifiedName(), "raw_er_" + DwcTerm.measurementID.simpleName());
+    core.put(
+        DwcTerm.measurementMethod.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementMethod.simpleName());
+    core.put(
+        DwcTerm.measurementRemarks.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementRemarks.simpleName());
+    core.put(
+        DwcTerm.measurementType.qualifiedName(), "raw_er_" + DwcTerm.measurementType.simpleName());
+    core.put(
+        DwcTerm.measurementUnit.qualifiedName(), "raw_er_" + DwcTerm.measurementUnit.simpleName());
+    core.put(
+        DwcTerm.measurementValue.qualifiedName(),
+        "raw_er_" + DwcTerm.measurementValue.simpleName());
+    core.put(DwcTerm.municipality.qualifiedName(), "raw_er_" + DwcTerm.municipality.simpleName());
+    core.put(
+        DwcTerm.nameAccordingTo.qualifiedName(), "raw_er_" + DwcTerm.nameAccordingTo.simpleName());
+    core.put(
+        DwcTerm.nameAccordingToID.qualifiedName(),
+        "raw_er_" + DwcTerm.nameAccordingToID.simpleName());
+    core.put(
+        DwcTerm.namePublishedIn.qualifiedName(), "raw_er_" + DwcTerm.namePublishedIn.simpleName());
+    core.put(
+        DwcTerm.namePublishedInID.qualifiedName(),
+        "raw_er_" + DwcTerm.namePublishedInID.simpleName());
+    core.put(
+        DwcTerm.namePublishedInYear.qualifiedName(),
+        "raw_er_" + DwcTerm.namePublishedInYear.simpleName());
+    core.put(
+        DwcTerm.nomenclaturalCode.qualifiedName(),
+        "raw_er_" + DwcTerm.nomenclaturalCode.simpleName());
+    core.put(
+        DwcTerm.nomenclaturalStatus.qualifiedName(),
+        "raw_er_" + DwcTerm.nomenclaturalStatus.simpleName());
+    core.put(DwcTerm.organismID.qualifiedName(), "raw_er_" + DwcTerm.organismID.simpleName());
+    core.put(
+        DwcTerm.organismQuantity.qualifiedName(),
+        "raw_er_" + DwcTerm.organismQuantity.simpleName());
+    core.put(
+        DwcTerm.organismQuantityType.qualifiedName(),
+        "raw_er_" + DwcTerm.organismQuantityType.simpleName());
+    core.put(
+        DwcTerm.originalNameUsage.qualifiedName(),
+        "raw_er_" + DwcTerm.originalNameUsage.simpleName());
+    core.put(
+        DwcTerm.originalNameUsageID.qualifiedName(),
+        "raw_er_" + DwcTerm.originalNameUsageID.simpleName());
+    core.put(
+        DwcTerm.ownerInstitutionCode.qualifiedName(),
+        "raw_er_" + DwcTerm.ownerInstitutionCode.simpleName());
+    core.put(
+        DwcTerm.parentNameUsage.qualifiedName(), "raw_er_" + DwcTerm.parentNameUsage.simpleName());
+    core.put(
+        DwcTerm.parentNameUsageID.qualifiedName(),
+        "raw_er_" + DwcTerm.parentNameUsageID.simpleName());
+    core.put(
+        DwcTerm.pointRadiusSpatialFit.qualifiedName(),
+        "raw_er_" + DwcTerm.pointRadiusSpatialFit.simpleName());
+    core.put(DwcTerm.preparations.qualifiedName(), "raw_er_" + DwcTerm.preparations.simpleName());
+    core.put(
+        DwcTerm.previousIdentifications.qualifiedName(),
+        "raw_er_" + DwcTerm.previousIdentifications.simpleName());
+    core.put(
+        DwcTerm.relatedResourceID.qualifiedName(),
+        "raw_er_" + DwcTerm.relatedResourceID.simpleName());
+    core.put(
+        DwcTerm.relationshipAccordingTo.qualifiedName(),
+        "raw_er_" + DwcTerm.relationshipAccordingTo.simpleName());
+    core.put(
+        DwcTerm.minimumDistanceAboveSurfaceInMeters.qualifiedName(),
+        "raw_er_" + DwcTerm.minimumDistanceAboveSurfaceInMeters.simpleName());
+    core.put(
+        DwcTerm.relationshipEstablishedDate.qualifiedName(),
+        "raw_er_" + DwcTerm.relationshipEstablishedDate.simpleName());
+    core.put(
+        DwcTerm.relationshipOfResource.qualifiedName(),
+        "raw_er_" + DwcTerm.relationshipOfResource.simpleName());
+    core.put(
+        DwcTerm.relationshipRemarks.qualifiedName(),
+        "raw_er_" + DwcTerm.relationshipRemarks.simpleName());
+    core.put(
+        DwcTerm.reproductiveCondition.qualifiedName(),
+        "raw_er_" + DwcTerm.reproductiveCondition.simpleName());
+    core.put(DwcTerm.resourceID.qualifiedName(), "raw_er_" + DwcTerm.resourceID.simpleName());
+    core.put(
+        DwcTerm.resourceRelationshipID.qualifiedName(),
+        "raw_er_" + DwcTerm.resourceRelationshipID.simpleName());
+    core.put(
+        DwcTerm.samplingEffort.qualifiedName(), "raw_er_" + DwcTerm.samplingEffort.simpleName());
+    core.put(
+        DwcTerm.samplingProtocol.qualifiedName(),
+        "raw_er_" + DwcTerm.samplingProtocol.simpleName());
+    core.put(
+        DwcTerm.scientificNameAuthorship.qualifiedName(),
+        "raw_er_" + DwcTerm.scientificNameAuthorship.simpleName());
+    core.put(
+        DwcTerm.scientificNameID.qualifiedName(),
+        "raw_er_" + DwcTerm.scientificNameID.simpleName());
+    core.put(DwcTerm.sex.qualifiedName(), "raw_er_" + DwcTerm.sex.simpleName());
+    core.put(
+        DwcTerm.specificEpithet.qualifiedName(), "raw_er_" + DwcTerm.specificEpithet.simpleName());
+    core.put(
+        DwcTerm.startDayOfYear.qualifiedName(), "raw_er_" + DwcTerm.startDayOfYear.simpleName());
+    core.put(DwcTerm.subgenus.qualifiedName(), "raw_er_" + DwcTerm.subgenus.simpleName());
+    core.put(DwcTerm.taxonID.qualifiedName(), "raw_er_" + DwcTerm.taxonID.simpleName());
+    core.put(
+        DwcTerm.taxonomicStatus.qualifiedName(), "raw_er_" + DwcTerm.taxonomicStatus.simpleName());
+    core.put(DwcTerm.taxonRemarks.qualifiedName(), "raw_er_" + DwcTerm.taxonRemarks.simpleName());
+    core.put(DwcTerm.typeStatus.qualifiedName(), "raw_er_" + DwcTerm.typeStatus.simpleName());
+    core.put(
+        DwcTerm.verbatimCoordinates.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimCoordinates.simpleName());
+    core.put(
+        DwcTerm.verbatimCoordinateSystem.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimCoordinateSystem.simpleName());
+    core.put(DwcTerm.verbatimDepth.qualifiedName(), "raw_er_" + DwcTerm.verbatimDepth.simpleName());
+    core.put(
+        DwcTerm.verbatimElevation.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimElevation.simpleName());
+    core.put(
+        DwcTerm.verbatimEventDate.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimEventDate.simpleName());
+    core.put(
+        DwcTerm.verbatimLatitude.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimLatitude.simpleName());
+    core.put(
+        DwcTerm.verbatimLocality.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimLocality.simpleName());
+    core.put(
+        DwcTerm.verbatimLongitude.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimLongitude.simpleName());
+    core.put(DwcTerm.verbatimSRS.qualifiedName(), "raw_er_" + DwcTerm.verbatimSRS.simpleName());
+    core.put(
+        DwcTerm.verbatimTaxonRank.qualifiedName(),
+        "raw_er_" + DwcTerm.verbatimTaxonRank.simpleName());
+    core.put(DwcTerm.waterBody.qualifiedName(), "raw_er_" + DwcTerm.waterBody.simpleName());
+    core.put("http://rs.tdwg.org/dwc/terms/occurrenceAttributes", "raw_er_occurrenceAttributes");
+    // DC Terms
+    core.put(DcTerm.references.qualifiedName(), "raw_er_" + DcTerm.references.simpleName());
+    core.put(DcTerm.accessRights.qualifiedName(), "raw_er_" + DcTerm.accessRights.simpleName());
+    core.put(
+        DcTerm.bibliographicCitation.qualifiedName(),
+        "raw_er_" + DcTerm.bibliographicCitation.simpleName());
+    core.put(DcTerm.language.qualifiedName(), "raw_er_" + DcTerm.language.simpleName());
+    core.put(DcTerm.license.qualifiedName(), "raw_er_" + DcTerm.license.simpleName());
+    core.put(DcTerm.modified.qualifiedName(), "raw_er_" + DcTerm.modified.simpleName());
+    core.put(DcTerm.rights.qualifiedName(), "raw_er_" + DcTerm.rights.simpleName());
+    core.put(DcTerm.rightsHolder.qualifiedName(), "raw_er_" + DcTerm.rightsHolder.simpleName());
+    core.put(DcTerm.source.qualifiedName(), "raw_er_" + DcTerm.source.simpleName());
+    core.put(DcTerm.type.qualifiedName(), "raw_er_" + DcTerm.type.simpleName());
+    // ALA Terms
+    core.put("http://rs.ala.org.au/terms/1.0/photographer", "raw_er_photographer");
+    core.put("http://rs.ala.org.au/terms/1.0/northing", "raw_er_northing");
+    core.put("http://rs.ala.org.au/terms/1.0/easting", "raw_er_easting");
+    core.put("http://rs.ala.org.au/terms/1.0/species", "raw_er_species");
+    core.put("http://rs.ala.org.au/terms/1.0/subfamily", "raw_er_subfamily");
+    core.put("http://rs.ala.org.au/terms/1.0/subspecies", "raw_er_subspecies");
+    core.put("http://rs.ala.org.au/terms/1.0/superfamily", "raw_er_superfamily");
+    core.put("http://rs.ala.org.au/terms/1.0/zone", "raw_er_zone");
+    // ABCD Terms
+    core.put(
+        "http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifier",
+        "raw_er_abcdIdentificationQualifier");
+    core.put(
+        "http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifierInsertionPoint",
+        "raw_er_abcdIdentificationQualifierInsertionPoint");
+    core.put("http://rs.tdwg.org/abcd/terms/abcdTypeStatus", "raw_er_abcdTypeStatus");
+    core.put("http://rs.tdwg.org/abcd/terms/typifiedName", "raw_er_typifiedName");
+    // HISPID Terms
+    core.put(
+        "http://hiscom.chah.org.au/hispid/terms/secondaryCollectors", "raw_er_secondaryCollectors");
+    core.put("http://hiscom.chah.org.au/hispid/terms/identifierRole", "raw_er_identifierRole");
+    // GGBN Terms
+    core.put("http://data.ggbn.org/schemas/ggbn/terms/loanDate", "raw_er_loanDate");
+    core.put("http://data.ggbn.org/schemas/ggbn/terms/loanDestination", "raw_er_loanDestination");
+    core.put("http://data.ggbn.org/schemas/ggbn/terms/loanIdentifier", "raw_er_loanIdentifier");
+    core.put("http://rs.tdwg.org/dwc/terms/locationAttributes", "raw_er_locationAttributes");
+    core.put("http://rs.tdwg.org/dwc/terms/eventAttributes", "raw_er_eventAttributes");
+    // Other Terms
+    core.put("taxonRankID", "raw_er_taxonRankID");
+    // GBIF Terms
+    core.put(GbifTerm.recordedByID.qualifiedName(), "raw_er_" + GbifTerm.recordedByID.simpleName());
+
+    ExtendedRecord er =
+        ExtendedRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCoreTerms(core)
+            .build();
+
+    TemporalRecord tr =
+        TemporalRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(1L)
+            .setDateIdentified("")
+            .setCreated(11L)
+            .setYear(111)
+            .setMonth(1111)
+            .setDay(11111)
+            .setEventDate(EventDate.newBuilder().setGte("1999").setLte("2000").build())
+            .setStartDayOfYear(111111)
+            .setEndDayOfYear(1111111)
+            .setModified("2001")
+            .setDateIdentified("2002")
+            .setDatePrecision("2003")
+            .build();
+
+    BasicRecord br =
+        BasicRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(2L)
+            .setGbifId(22L)
+            .setBasisOfRecord("br_basisOfRecord")
+            .setSex("br_sex")
+            .setLifeStage("br_lifeStage")
+            .setLifeStageLineage(Collections.singletonList("br_lifeStageLineage"))
+            .setEstablishmentMeans("br_establishmentMeans")
+            .setIndividualCount(222)
+            .setTypeStatus("br_typeStatus")
+            .setTypifiedName("br_typifiedName")
+            .setSampleSizeValue(222d)
+            .setSampleSizeUnit("br_sampleSizeUnit")
+            .setOrganismQuantity(2222d)
+            .setOrganismQuantityType("br_organismQuantityType")
+            .setRelativeOrganismQuantity(22222d)
+            .setReferences("br_References")
+            .setLicense("br_license")
+            .setIdentifiedByIds(
+                Collections.singletonList(
+                    AgentIdentifier.newBuilder()
+                        .setType("br_agent_type")
+                        .setValue("br_agent_value")
+                        .build()))
+            .setRecordedByIds(
+                Collections.singletonList(
+                    AgentIdentifier.newBuilder()
+                        .setType("br_agent_type_rb")
+                        .setValue("br_agent_value_rb")
+                        .build()))
+            .setRecordedBy(Arrays.asList("br_recordedBy_1", "br_recordedBy_2"))
+            .setOccurrenceStatus("br_occurrenceStatus")
+            .setIsClustered(true)
+            .build();
+
+    LocationRecord lr =
+        LocationRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setId("lr_id")
+            .setCreated(3L)
+            .setContinent("lr_continent")
+            .setWaterBody("lr_waterBody")
+            .setCountry("lr_country")
+            .setCountryCode("lr_countryCode")
+            .setPublishingCountry("lr_publishingCountry")
+            .setStateProvince("lr_stateProvince")
+            .setMinimumElevationInMeters(33d)
+            .setMaximumElevationInMeters(333d)
+            .setElevation(3333d)
+            .setElevationAccuracy(33333d)
+            .setMinimumDepthInMeters(33333d)
+            .setMaximumDepthInMeters(333333d)
+            .setDepth(33333333d)
+            .setDepthAccuracy(333333333d)
+            .setMinimumDistanceAboveSurfaceInMeters(3333333333d)
+            .setMaximumDistanceAboveSurfaceInMeters(33333333333d)
+            .setDecimalLatitude(333333333333d)
+            .setDecimalLongitude(3333333333333d)
+            .setCoordinateUncertaintyInMeters(33333333333333d)
+            .setCoordinatePrecision(333333333333333d)
+            .setHasCoordinate(true)
+            .setRepatriated(true)
+            .setHasGeospatialIssue(false)
+            .setLocality("lr_locality")
+            .setGeoreferencedDate("lr_georeferencedDate")
+            .setFootprintWKT("lr_footprintWKT")
+            .setBiome("lr_biome")
+            .build();
+
+    TaxonRecord txr =
+        TaxonRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setSynonym(false)
+            .setUsage(
+                RankedName.newBuilder()
+                    .setRank(Rank.SPECIES)
+                    .setName("txr_Usage_name")
+                    .setKey(4)
+                    .build())
+            .setClassification(
+                Arrays.asList(
+                    RankedName.newBuilder()
+                        .setRank(Rank.SPECIES)
+                        .setName("txr_Classification_SPECIES_name")
+                        .setKey(44)
+                        .build(),
+                    RankedName.newBuilder()
+                        .setRank(Rank.CLASS)
+                        .setName("txr_Classification_CLASS_name")
+                        .setKey(444)
+                        .build()))
+            .setAcceptedUsage(
+                RankedName.newBuilder()
+                    .setRank(Rank.SPECIES)
+                    .setName("txr_Usage_name")
+                    .setKey(4444)
+                    .build())
+            .setNomenclature(
+                Nomenclature.newBuilder()
+                    .setId("txr_Nomenclature_id")
+                    .setSource("txr_Nomenclature_Source")
+                    .build())
+            .setDiagnostics(
+                Diagnostic.newBuilder()
+                    .setConfidence(44444)
+                    .setStatus(Status.ACCEPTED)
+                    .setNote("txr_Diagnostic_Note")
+                    .setMatchType(MatchType.EXACT)
+                    .setLineage(Collections.singletonList("txr_Diagnostic_Lineage"))
+                    .build())
+            .setUsageParsedName(ParsedName.newBuilder().build())
+            .setIucnRedListCategoryCode("txr_IucnRedListCategoryCode")
+            .build();
+
+    ALATaxonRecord atxr =
+        ALATaxonRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setScientificName("atxr_ScientificName")
+            .setScientificNameAuthorship("atxr_ScientificNameAuthorship")
+            .setTaxonConceptID("atxr_TaxonConceptID")
+            .setTaxonRank("atxr_TaxonRank")
+            .setTaxonRankID(5)
+            .setLft(55)
+            .setRgt(555)
+            .setMatchType("atxr_MatchType")
+            .setNameType("atxr_NameType")
+            .setKingdom("atxr_Kingdom")
+            .setKingdomID("atxr_KingdomID")
+            .setPhylum("atxr_Phylum")
+            .setPhylumID("atxr_PhylumID")
+            .setClasss("atxr_Classs")
+            .setClassID("atxr_ClassID")
+            .setOrder("atxr_Order")
+            .setOrderID("atxr_OrderID")
+            .setFamily("atxr_Family")
+            .setFamilyID("atxr_FamilyID")
+            .setGenus("atxr_Genus")
+            .setGenusID("atxr_GenusID")
+            .setSpecies("atxr_Species")
+            .setSpeciesID("atxr_SpeciesID")
+            .setVernacularName("atxr_VernacularName")
+            .setSpeciesGroup(Collections.singletonList("atxr_SpeciesGroup"))
+            .setSpeciesSubgroup(Collections.singletonList("atxr_SpeciesSubgroup"))
+            .setDiagnostics(
+                Diagnostic.newBuilder()
+                    .setConfidence(5555)
+                    .setStatus(Status.ACCEPTED)
+                    .setNote("atxr_Diagnostic_Note")
+                    .setMatchType(MatchType.EXACT)
+                    .setLineage(Collections.singletonList("atxr_Diagnostic_Lineage"))
+                    .build())
+            .build();
+
+    ALAAttributionRecord aar =
+        ALAAttributionRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setDataResourceUid("aar_DataResourceUid")
+            .setDataResourceName("aar_DataResourceName")
+            .setDataProviderUid("aar_DataProviderUid")
+            .setDataProviderName("aar_DataProviderName")
+            .setCollectionUid("aar_CollectionUid")
+            .setCollectionName("aar_CollectionName")
+            .setInstitutionUid("aar_InstitutionUid")
+            .setInstitutionName("aar_InstitutionName")
+            .setLicenseType("aar_LicenseType")
+            .setLicenseVersion("aar_LicenseVersion")
+            .setProvenance("aar_Provenance")
+            .setHasDefaultValues(false)
+            .setHubMembership(
+                Collections.singletonList(
+                    EntityReference.newBuilder()
+                        .setName("aar_EntityReference_name")
+                        .setUid("aar_EntityReference_uuid")
+                        .setUri("aar_EntityReference_uri")
+                        .build()))
+            .build();
+
+    ALAUUIDRecord aur =
+        ALAUUIDRecord.newBuilder()
+            .setId("aur_id")
+            .setUuid("aur_uuid")
+            .setUniqueKey("aur_uniqueKey")
+            .setFirstLoaded(6L)
+            .build();
+
+    ImageRecord ir =
+        ImageRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(7L)
+            .setImageItems(
+                Collections.singletonList(
+                    Image.newBuilder()
+                        .setCreated("ir_Image")
+                        .setAudience("ir_Audienc")
+                        .setCreator("ir_Creator")
+                        .setContributor("ir_Contributor")
+                        .setDatasetId("ir_DatasetId")
+                        .setLicense("ir_License")
+                        .setLatitude(77d)
+                        .setLongitude(777d)
+                        .setSpatial("ir_Spatial")
+                        .setTitle("ir_Title")
+                        .setRightsHolder("ir_RightsHolder")
+                        .setIdentifier("ir_Identifier")
+                        .build()))
+            .build();
+
+    TaxonProfile tp = TaxonProfile.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+    MultimediaRecord mr =
+        MultimediaRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    ALASensitivityRecord asr =
+        ALASensitivityRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(8L)
+            .setIsSensitive(false)
+            .setSensitive("asr_Sensitive")
+            .setDataGeneralizations("asr_DataGeneralizations")
+            .setInformationWithheld("asr_InformationWithheld")
+            .setGeneralisationToApplyInMetres("asr_GeneralisationToApplyInMetres")
+            .setGeneralisationInMetres("asr_GeneralisationInMetres")
+            .setOriginal(Collections.singletonMap("asr_Original_key", "asr_Original_value"))
+            .setAltered(Collections.singletonMap("asr_Altered_key", "asr_Altered_value"))
+            .build();
+
+    Long lastLoadDate = 9L;
+    Long lastProcessedDate = 10L;
+
+    IndexRecord source =
+        IndexRecordTransform.createIndexRecord(
+            br, tr, lr, txr, atxr, er, aar, aur, ir, tp, asr, mr, lastLoadDate, lastProcessedDate);
+
+    // When
+    String result = CoreCsvConverter.convert(source);
+
+    // Should
+    Assert.assertEquals(String.join(",", expectet), result);
+  }
+
+  @Test
+  public void converterDefualtTest() {
+    // Expected
+    // tr = 1, br = 2, lr = 3, trx = 4, atxr = 5, aur = 6, ir = 7, asr = 8
+    String[] expectet = {
+      // DWC Terms
+      "\"aur_uuid\"", // DwcTerm.occurrenceID
+      "\"raw_er_catalogNumber\"", // DwcTerm.catalogNumber
+      "\"raw_er_collectionCode\"", // DwcTerm.collectionCode
+      "\"raw_er_institutionCode\"", // DwcTerm.institutionCode
+      "\"raw_er_recordNumber\"", // DwcTerm.recordNumber
+      "\"HumanObservation\"", // DwcTerm.basisOfRecord
+      "\"\"", // DwcTerm.recordedBy
+      "\"\"", // DwcTerm.occurrenceStatus
+      "\"\"", // DwcTerm.individualCount
+      "\"\"", // DwcTerm.scientificName
+      "\"\"", // DwcTerm.taxonConceptID
+      "\"\"", // DwcTerm.taxonRank
+      "\"\"", // DwcTerm.kingdom
+      "\"\"", // DwcTerm.phylum
+      "\"\"", // DwcTerm.class_
+      "\"\"", // DwcTerm.order
+      "\"\"", // DwcTerm.family
+      "\"\"", // DwcTerm.genus
+      "\"\"", // DwcTerm.vernacularName
+      "\"\"", // DwcTerm.decimalLatitude
+      "\"\"", // DwcTerm.decimalLongitude
+      "\"\"", // DwcTerm.geodeticDatum
+      "\"\"", // DwcTerm.coordinateUncertaintyInMeters
+      "\"\"", // DwcTerm.maximumElevationInMeters
+      "\"\"", // DwcTerm.minimumElevationInMeters
+      "\"\"", // DwcTerm.minimumDepthInMeters
+      "\"\"", // DwcTerm.maximumDepthInMeters
+      "\"\"", // DwcTerm.country
+      "\"\"", // DwcTerm.stateProvince
+      "\"\"", // DwcTerm.locality
+      "\"raw_er_locationRemarks\"", // DwcTerm.locationRemarks
+      "\"\"", // DwcTerm.year
+      "\"\"", // DwcTerm.month
+      "\"\"", // DwcTerm.day
+      "\"raw_er_eventDate\"", // DwcTerm.eventDate
+      "\"raw_er_eventID\"", // DwcTerm.eventID
+      "\"raw_er_identifiedBy\"", // DwcTerm.identifiedBy
+      "\"raw_er_occurrenceRemarks\"", // DwcTerm.occurrenceRemarks
+      "\"raw_er_dataGeneralizations\"", // DwcTerm.dataGeneralizations
+      "\"raw_er_otherCatalogNumbers\"", // DwcTerm.otherCatalogNumbers
+      "\"\"", // DwcTerm.acceptedNameUsage
+      "\"\"", // DwcTerm.acceptedNameUsageID
+      "\"\"", // DwcTerm.associatedOccurrences
+      "\"\"", // DwcTerm.associatedReferences
+      "\"\"", // DwcTerm.associatedSequences
+      "\"\"", // DwcTerm.associatedTaxa
+      "\"\"", // DwcTerm.behavior
+      "\"\"", // DwcTerm.collectionID
+      "\"\"", // DwcTerm.continent
+      "\"\"", // DwcTerm.coordinatePrecision
+      "\"\"", // DwcTerm.countryCode
+      "\"\"", // DwcTerm.county
+      "\"\"", // DwcTerm.datasetID
+      "\"\"", // DwcTerm.datasetName
+      "\"\"", // DwcTerm.dateIdentified
+      "\"\"", // DwcTerm.disposition
+      "\"\"", // DwcTerm.dynamicProperties
+      "\"\"", // DwcTerm.endDayOfYear
+      "\"\"", // DwcTerm.establishmentMeans
+      "\"\"", // DwcTerm.eventRemarks
+      "\"\"", // DwcTerm.eventTime
+      "\"\"", // DwcTerm.fieldNotes
+      "\"\"", // DwcTerm.fieldNumber
+      "\"\"", // DwcTerm.footprintSpatialFit
+      "\"\"", // DwcTerm.footprintSRS
+      "\"\"", // DwcTerm.footprintWKT
+      "\"\"", // DwcTerm.georeferencedBy
+      "\"\"", // DwcTerm.georeferencedDate
+      "\"\"", // DwcTerm.georeferenceProtocol
+      "\"\"", // DwcTerm.georeferenceRemarks
+      "\"\"", // DwcTerm.georeferenceSources
+      "\"\"", // DwcTerm.georeferenceVerificationStatus
+      "\"\"", // DwcTerm.habitat
+      "\"\"", // DwcTerm.higherClassification
+      "\"\"", // DwcTerm.higherGeography
+      "\"\"", // DwcTerm.higherGeographyID
+      "\"\"", // DwcTerm.identificationID
+      "\"\"", // DwcTerm.identificationQualifier
+      "\"\"", // DwcTerm.identificationReferences
+      "\"\"", // DwcTerm.identificationRemarks
+      "\"\"", // DwcTerm.identificationVerificationStatus
+      "\"\"", // DwcTerm.informationWithheld
+      "\"\"", // DwcTerm.infraspecificEpithet
+      "\"\"", // DwcTerm.institutionID
+      "\"\"", // DwcTerm.island
+      "\"\"", // DwcTerm.islandGroup
+      "\"\"", // DwcTerm.lifeStage
+      "\"\"", // DwcTerm.locationAccordingTo
+      "\"\"", // DwcTerm.locationID
+      "\"\"", // DwcTerm.maximumDistanceAboveSurfaceInMeters
+      "\"\"", // DwcTerm.measurementAccuracy
+      "\"\"", // DwcTerm.measurementDeterminedBy
+      "\"\"", // DwcTerm.measurementDeterminedDate
+      "\"\"", // DwcTerm.measurementID
+      "\"\"", // DwcTerm.measurementMethod
+      "\"\"", // DwcTerm.measurementRemarks
+      "\"\"", // DwcTerm.measurementType
+      "\"\"", // DwcTerm.measurementUnit
+      "\"\"", // DwcTerm.measurementValue
+      "\"\"", // DwcTerm.municipality
+      "\"\"", // DwcTerm.nameAccordingTo
+      "\"\"", // DwcTerm.nameAccordingToID
+      "\"\"", // DwcTerm.namePublishedIn
+      "\"\"", // DwcTerm.namePublishedInID
+      "\"\"", // DwcTerm.namePublishedInYear
+      "\"\"", // DwcTerm.nomenclaturalCode
+      "\"\"", // DwcTerm.nomenclaturalStatus
+      "\"\"", // DwcTerm.organismID
+      "\"\"", // DwcTerm.organismQuantity
+      "\"\"", // DwcTerm.organismQuantityType
+      "\"\"", // DwcTerm.originalNameUsage
+      "\"\"", // DwcTerm.originalNameUsageID
+      "\"\"", // DwcTerm.ownerInstitutionCode
+      "\"\"", // DwcTerm.parentNameUsage
+      "\"\"", // DwcTerm.parentNameUsageID
+      "\"\"", // DwcTerm.pointRadiusSpatialFit
+      "\"\"", // DwcTerm.preparations
+      "\"\"", // DwcTerm.previousIdentifications
+      "\"\"", // DwcTerm.relatedResourceID
+      "\"\"", // DwcTerm.relationshipAccordingTo
+      "\"\"", // DwcTerm.minimumDistanceAboveSurfaceInMeters
+      "\"\"", // DwcTerm.relationshipEstablishedDate
+      "\"\"", // DwcTerm.relationshipOfResource
+      "\"\"", // DwcTerm.relationshipRemarks
+      "\"\"", // DwcTerm.reproductiveCondition
+      "\"\"", // DwcTerm.resourceID
+      "\"\"", // DwcTerm.resourceRelationshipID
+      "\"\"", // DwcTerm.samplingEffort
+      "\"\"", // DwcTerm.samplingProtocol
+      "\"\"", // DwcTerm.scientificNameAuthorship
+      "\"\"", // DwcTerm.scientificNameID
+      "\"\"", // DwcTerm.sex
+      "\"\"", // DwcTerm.specificEpithet
+      "\"\"", // DwcTerm.startDayOfYear
+      "\"\"", // DwcTerm.subgenus
+      "\"\"", // DwcTerm.taxonID
+      "\"\"", // DwcTerm.taxonomicStatus
+      "\"\"", // DwcTerm.taxonRemarks
+      "\"\"", // DwcTerm.typeStatus
+      "\"\"", // DwcTerm.verbatimCoordinates
+      "\"\"", // DwcTerm.verbatimCoordinateSystem
+      "\"\"", // DwcTerm.verbatimDepth
+      "\"\"", // DwcTerm.verbatimElevation
+      "\"\"", // DwcTerm.verbatimEventDate
+      "\"\"", // DwcTerm.verbatimLatitude
+      "\"\"", // DwcTerm.verbatimLocality
+      "\"\"", // DwcTerm.verbatimLongitude
+      "\"\"", // DwcTerm.verbatimSRS
+      "\"\"", // DwcTerm.verbatimTaxonRank
+      "\"\"", // DwcTerm.waterBody
+      "\"\"", // http://rs.tdwg.org/dwc/terms/occurrenceAttributes
+      // DC Terms
+      "\"\"", // DcTerm.references
+      "\"\"", // DcTerm.accessRights
+      "\"\"", // DcTerm.bibliographicCitation
+      "\"\"", // DcTerm.language
+      "\"\"", // DcTerm.license
+      "\"\"", // DcTerm.modified
+      "\"\"", // DcTerm.rights
+      "\"\"", // DcTerm.rightsHolder
+      "\"\"", // DcTerm.source
+      "\"\"", // DcTerm.type
+      // ALA Terms
+      "\"\"", // http://rs.ala.org.au/terms/1.0/photographer
+      "\"\"", // http://rs.ala.org.au/terms/1.0/northing
+      "\"\"", // http://rs.ala.org.au/terms/1.0/easting
+      "\"\"", // http://rs.ala.org.au/terms/1.0/species
+      "\"\"", // http://rs.ala.org.au/terms/1.0/subfamily
+      "\"\"", // http://rs.ala.org.au/terms/1.0/subspecies
+      "\"\"", // http://rs.ala.org.au/terms/1.0/superfamily
+      "\"\"", // http://rs.ala.org.au/terms/1.0/zone
+      // ABCD Terms
+      "\"\"", // http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifier
+      "\"\"", // http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifierInsertionPoint
+      "\"\"", // http://rs.tdwg.org/abcd/terms/abcdTypeStatus
+      "\"\"", // http://rs.tdwg.org/abcd/terms/typifiedName
+      // HISPID Terms
+      "\"\"", // http://hiscom.chah.org.au/hispid/terms/secondaryCollectors
+      "\"\"", // http://hiscom.chah.org.au/hispid/terms/identifierRole
+      // GGBN Terms
+      "\"\"", // http://data.ggbn.org/schemas/ggbn/terms/loanDate
+      "\"\"", // http://data.ggbn.org/schemas/ggbn/terms/loanDestination
+      "\"\"", // http://data.ggbn.org/schemas/ggbn/terms/loanIdentifier
+      "\"\"", // http://rs.tdwg.org/dwc/terms/locationAttributes
+      "\"\"", // http://rs.tdwg.org/dwc/terms/eventAttributes
+      // Other Terms
+      "\"\"", // taxonRankID
+      // GBIF Terms
+      "\"\"" // GbifTerm.recordedByID
+    };
+
+    // State
+    Map<String, String> core = new HashMap<>();
+    core.put(DwcTerm.occurrenceID.simpleName(), "raw_er_" + DwcTerm.occurrenceID.simpleName());
+    core.put(DwcTerm.catalogNumber.simpleName(), "raw_er_" + DwcTerm.catalogNumber.simpleName());
+    core.put(DwcTerm.collectionCode.simpleName(), "raw_er_" + DwcTerm.collectionCode.simpleName());
+    core.put(
+        DwcTerm.institutionCode.simpleName(), "raw_er_" + DwcTerm.institutionCode.simpleName());
+    core.put(DwcTerm.recordNumber.simpleName(), "raw_er_" + DwcTerm.recordNumber.simpleName());
+    core.put(DwcTerm.basisOfRecord.simpleName(), "raw_er_" + DwcTerm.basisOfRecord.simpleName());
+    core.put(DwcTerm.recordedBy.simpleName(), "raw_er_" + DwcTerm.recordedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceStatus.simpleName(), "raw_er_" + DwcTerm.occurrenceStatus.simpleName());
+    core.put(
+        DwcTerm.individualCount.simpleName(), "raw_er_" + DwcTerm.individualCount.simpleName());
+    core.put(DwcTerm.scientificName.simpleName(), "raw_er_" + DwcTerm.scientificName.simpleName());
+    core.put(DwcTerm.taxonConceptID.simpleName(), "raw_er_" + DwcTerm.taxonConceptID.simpleName());
+    core.put(DwcTerm.taxonRank.simpleName(), "raw_er_" + DwcTerm.taxonRank.simpleName());
+    core.put(DwcTerm.kingdom.simpleName(), "raw_er_" + DwcTerm.kingdom.simpleName());
+    core.put(DwcTerm.phylum.simpleName(), "raw_er_" + DwcTerm.phylum.simpleName());
+    core.put(DwcTerm.class_.simpleName(), "raw_er_" + DwcTerm.class_.simpleName());
+    core.put(DwcTerm.order.simpleName(), "raw_er_" + DwcTerm.order.simpleName());
+    core.put(DwcTerm.family.simpleName(), "raw_er_" + DwcTerm.family.simpleName());
+    core.put(DwcTerm.genus.simpleName(), "raw_er_" + DwcTerm.genus.simpleName());
+    core.put(DwcTerm.vernacularName.simpleName(), "raw_er_" + DwcTerm.vernacularName.simpleName());
+    core.put(
+        DwcTerm.decimalLatitude.simpleName(), "raw_er_" + DwcTerm.decimalLatitude.simpleName());
+    core.put(
+        DwcTerm.decimalLongitude.simpleName(), "raw_er_" + DwcTerm.decimalLongitude.simpleName());
+    core.put(DwcTerm.geodeticDatum.simpleName(), "raw_er_" + DwcTerm.geodeticDatum.simpleName());
+    core.put(
+        DwcTerm.coordinateUncertaintyInMeters.simpleName(),
+        "raw_er_" + DwcTerm.coordinateUncertaintyInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumElevationInMeters.simpleName(),
+        "raw_er_" + DwcTerm.maximumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumElevationInMeters.simpleName(),
+        "raw_er_" + DwcTerm.minimumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumDepthInMeters.simpleName(),
+        "raw_er_" + DwcTerm.minimumDepthInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumDepthInMeters.simpleName(),
+        "raw_er_" + DwcTerm.maximumDepthInMeters.simpleName());
+    core.put(DwcTerm.country.simpleName(), "raw_er_" + DwcTerm.country.simpleName());
+    core.put(DwcTerm.stateProvince.simpleName(), "raw_er_" + DwcTerm.stateProvince.simpleName());
+    core.put(DwcTerm.locality.simpleName(), "raw_er_" + DwcTerm.locality.simpleName());
+    core.put(
+        DwcTerm.locationRemarks.simpleName(), "raw_er_" + DwcTerm.locationRemarks.simpleName());
+    core.put(DwcTerm.year.simpleName(), "raw_er_" + DwcTerm.year.simpleName());
+    core.put(DwcTerm.month.simpleName(), "raw_er_" + DwcTerm.month.simpleName());
+    core.put(DwcTerm.day.simpleName(), "raw_er_" + DwcTerm.day.simpleName());
+    core.put(DwcTerm.eventDate.simpleName(), "raw_er_" + DwcTerm.eventDate.simpleName());
+    core.put(DwcTerm.eventID.simpleName(), "raw_er_" + DwcTerm.eventID.simpleName());
+    core.put(DwcTerm.identifiedBy.simpleName(), "raw_er_" + DwcTerm.identifiedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceRemarks.simpleName(), "raw_er_" + DwcTerm.occurrenceRemarks.simpleName());
+    core.put(
+        DwcTerm.dataGeneralizations.simpleName(),
+        "raw_er_" + DwcTerm.dataGeneralizations.simpleName());
+    core.put(
+        DwcTerm.otherCatalogNumbers.simpleName(),
+        "raw_er_" + DwcTerm.otherCatalogNumbers.simpleName());
+    core.put(DcTerm.references.simpleName(), "raw_er_" + DcTerm.references.simpleName());
+
+    ExtendedRecord er =
+        ExtendedRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCoreTerms(core)
+            .build();
+
+    TemporalRecord tr =
+        TemporalRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    BasicRecord br = BasicRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    LocationRecord lr =
+        LocationRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    TaxonRecord txr =
+        TaxonRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setAcceptedUsage(
+                RankedName.newBuilder()
+                    .setRank(Rank.SPECIES)
+                    .setName("txr_Usage_name")
+                    .setKey(4444)
+                    .build())
+            .build();
+
+    ALATaxonRecord atxr =
+        ALATaxonRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    ALAAttributionRecord aar =
+        ALAAttributionRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    ALAUUIDRecord aur =
+        ALAUUIDRecord.newBuilder()
+            .setId("aur_id")
+            .setUuid("aur_uuid")
+            .setUniqueKey("aur_uniqueKey")
+            .setFirstLoaded(6L)
+            .build();
+
+    ImageRecord ir = ImageRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    TaxonProfile tp = TaxonProfile.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    MultimediaRecord mr =
+        MultimediaRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    ALASensitivityRecord asr =
+        ALASensitivityRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    Long lastLoadDate = 9L;
+    Long lastProcessedDate = 10L;
+
+    IndexRecord source =
+        IndexRecordTransform.createIndexRecord(
+            br, tr, lr, txr, atxr, er, aar, aur, ir, tp, asr, mr, lastLoadDate, lastProcessedDate);
+
+    // When
+    String result = CoreCsvConverter.convert(source);
+
+    // Should
+    Assert.assertEquals(String.join(",", expectet), result);
+  }
+
+  @Test
+  public void termListTest() {
+
+    // Expected
+    List<String> expected = new LinkedList<>();
+    expected.add(DwcTerm.occurrenceID.qualifiedName());
+    expected.add(DwcTerm.catalogNumber.qualifiedName());
+    expected.add(DwcTerm.collectionCode.qualifiedName());
+    expected.add(DwcTerm.institutionCode.qualifiedName());
+    expected.add(DwcTerm.recordNumber.qualifiedName());
+    expected.add(DwcTerm.basisOfRecord.qualifiedName());
+    expected.add(DwcTerm.recordedBy.qualifiedName());
+    expected.add(DwcTerm.occurrenceStatus.qualifiedName());
+    expected.add(DwcTerm.individualCount.qualifiedName());
+    expected.add(DwcTerm.scientificName.qualifiedName());
+    expected.add(DwcTerm.taxonConceptID.qualifiedName());
+    expected.add(DwcTerm.taxonRank.qualifiedName());
+    expected.add(DwcTerm.kingdom.qualifiedName());
+    expected.add(DwcTerm.phylum.qualifiedName());
+    expected.add(DwcTerm.class_.qualifiedName());
+    expected.add(DwcTerm.order.qualifiedName());
+    expected.add(DwcTerm.family.qualifiedName());
+    expected.add(DwcTerm.genus.qualifiedName());
+    expected.add(DwcTerm.vernacularName.qualifiedName());
+    expected.add(DwcTerm.decimalLatitude.qualifiedName());
+    expected.add(DwcTerm.decimalLongitude.qualifiedName());
+    expected.add(DwcTerm.geodeticDatum.qualifiedName());
+    expected.add(DwcTerm.coordinateUncertaintyInMeters.qualifiedName());
+    expected.add(DwcTerm.maximumElevationInMeters.qualifiedName());
+    expected.add(DwcTerm.minimumElevationInMeters.qualifiedName());
+    expected.add(DwcTerm.minimumDepthInMeters.qualifiedName());
+    expected.add(DwcTerm.maximumDepthInMeters.qualifiedName());
+    expected.add(DwcTerm.country.qualifiedName());
+    expected.add(DwcTerm.stateProvince.qualifiedName());
+    expected.add(DwcTerm.locality.qualifiedName());
+    expected.add(DwcTerm.locationRemarks.qualifiedName());
+    expected.add(DwcTerm.year.qualifiedName());
+    expected.add(DwcTerm.month.qualifiedName());
+    expected.add(DwcTerm.day.qualifiedName());
+    expected.add(DwcTerm.eventDate.qualifiedName());
+    expected.add(DwcTerm.eventID.qualifiedName());
+    expected.add(DwcTerm.identifiedBy.qualifiedName());
+    expected.add(DwcTerm.occurrenceRemarks.qualifiedName());
+    expected.add(DwcTerm.dataGeneralizations.qualifiedName());
+    expected.add(DwcTerm.otherCatalogNumbers.qualifiedName());
+    expected.add(DwcTerm.acceptedNameUsage.qualifiedName());
+    expected.add(DwcTerm.acceptedNameUsageID.qualifiedName());
+    expected.add(DwcTerm.associatedOccurrences.qualifiedName());
+    expected.add(DwcTerm.associatedReferences.qualifiedName());
+    expected.add(DwcTerm.associatedSequences.qualifiedName());
+    expected.add(DwcTerm.associatedTaxa.qualifiedName());
+    expected.add(DwcTerm.behavior.qualifiedName());
+    expected.add(DwcTerm.collectionID.qualifiedName());
+    expected.add(DwcTerm.continent.qualifiedName());
+    expected.add(DwcTerm.coordinatePrecision.qualifiedName());
+    expected.add(DwcTerm.countryCode.qualifiedName());
+    expected.add(DwcTerm.county.qualifiedName());
+    expected.add(DwcTerm.datasetID.qualifiedName());
+    expected.add(DwcTerm.datasetName.qualifiedName());
+    expected.add(DwcTerm.dateIdentified.qualifiedName());
+    expected.add(DwcTerm.disposition.qualifiedName());
+    expected.add(DwcTerm.dynamicProperties.qualifiedName());
+    expected.add(DwcTerm.endDayOfYear.qualifiedName());
+    expected.add(DwcTerm.establishmentMeans.qualifiedName());
+    expected.add(DwcTerm.eventRemarks.qualifiedName());
+    expected.add(DwcTerm.eventTime.qualifiedName());
+    expected.add(DwcTerm.fieldNotes.qualifiedName());
+    expected.add(DwcTerm.fieldNumber.qualifiedName());
+    expected.add(DwcTerm.footprintSpatialFit.qualifiedName());
+    expected.add(DwcTerm.footprintSRS.qualifiedName());
+    expected.add(DwcTerm.footprintWKT.qualifiedName());
+    expected.add(DwcTerm.georeferencedBy.qualifiedName());
+    expected.add(DwcTerm.georeferencedDate.qualifiedName());
+    expected.add(DwcTerm.georeferenceProtocol.qualifiedName());
+    expected.add(DwcTerm.georeferenceRemarks.qualifiedName());
+    expected.add(DwcTerm.georeferenceSources.qualifiedName());
+    expected.add(DwcTerm.georeferenceVerificationStatus.qualifiedName());
+    expected.add(DwcTerm.habitat.qualifiedName());
+    expected.add(DwcTerm.higherClassification.qualifiedName());
+    expected.add(DwcTerm.higherGeography.qualifiedName());
+    expected.add(DwcTerm.higherGeographyID.qualifiedName());
+    expected.add(DwcTerm.identificationID.qualifiedName());
+    expected.add(DwcTerm.identificationQualifier.qualifiedName());
+    expected.add(DwcTerm.identificationReferences.qualifiedName());
+    expected.add(DwcTerm.identificationRemarks.qualifiedName());
+    expected.add(DwcTerm.identificationVerificationStatus.qualifiedName());
+    expected.add(DwcTerm.informationWithheld.qualifiedName());
+    expected.add(DwcTerm.infraspecificEpithet.qualifiedName());
+    expected.add(DwcTerm.institutionID.qualifiedName());
+    expected.add(DwcTerm.island.qualifiedName());
+    expected.add(DwcTerm.islandGroup.qualifiedName());
+    expected.add(DwcTerm.lifeStage.qualifiedName());
+    expected.add(DwcTerm.locationAccordingTo.qualifiedName());
+    expected.add(DwcTerm.locationID.qualifiedName());
+    expected.add(DwcTerm.maximumDistanceAboveSurfaceInMeters.qualifiedName());
+    expected.add(DwcTerm.measurementAccuracy.qualifiedName());
+    expected.add(DwcTerm.measurementDeterminedBy.qualifiedName());
+    expected.add(DwcTerm.measurementDeterminedDate.qualifiedName());
+    expected.add(DwcTerm.measurementID.qualifiedName());
+    expected.add(DwcTerm.measurementMethod.qualifiedName());
+    expected.add(DwcTerm.measurementRemarks.qualifiedName());
+    expected.add(DwcTerm.measurementType.qualifiedName());
+    expected.add(DwcTerm.measurementUnit.qualifiedName());
+    expected.add(DwcTerm.measurementValue.qualifiedName());
+    expected.add(DwcTerm.municipality.qualifiedName());
+    expected.add(DwcTerm.nameAccordingTo.qualifiedName());
+    expected.add(DwcTerm.nameAccordingToID.qualifiedName());
+    expected.add(DwcTerm.namePublishedIn.qualifiedName());
+    expected.add(DwcTerm.namePublishedInID.qualifiedName());
+    expected.add(DwcTerm.namePublishedInYear.qualifiedName());
+    expected.add(DwcTerm.nomenclaturalCode.qualifiedName());
+    expected.add(DwcTerm.nomenclaturalStatus.qualifiedName());
+    expected.add(DwcTerm.organismID.qualifiedName());
+    expected.add(DwcTerm.organismQuantity.qualifiedName());
+    expected.add(DwcTerm.organismQuantityType.qualifiedName());
+    expected.add(DwcTerm.originalNameUsage.qualifiedName());
+    expected.add(DwcTerm.originalNameUsageID.qualifiedName());
+    expected.add(DwcTerm.ownerInstitutionCode.qualifiedName());
+    expected.add(DwcTerm.parentNameUsage.qualifiedName());
+    expected.add(DwcTerm.parentNameUsageID.qualifiedName());
+    expected.add(DwcTerm.pointRadiusSpatialFit.qualifiedName());
+    expected.add(DwcTerm.preparations.qualifiedName());
+    expected.add(DwcTerm.previousIdentifications.qualifiedName());
+    expected.add(DwcTerm.relatedResourceID.qualifiedName());
+    expected.add(DwcTerm.relationshipAccordingTo.qualifiedName());
+    expected.add(DwcTerm.minimumDistanceAboveSurfaceInMeters.qualifiedName());
+    expected.add(DwcTerm.relationshipEstablishedDate.qualifiedName());
+    expected.add(DwcTerm.relationshipOfResource.qualifiedName());
+    expected.add(DwcTerm.relationshipRemarks.qualifiedName());
+    expected.add(DwcTerm.reproductiveCondition.qualifiedName());
+    expected.add(DwcTerm.resourceID.qualifiedName());
+    expected.add(DwcTerm.resourceRelationshipID.qualifiedName());
+    expected.add(DwcTerm.samplingEffort.qualifiedName());
+    expected.add(DwcTerm.samplingProtocol.qualifiedName());
+    expected.add(DwcTerm.scientificNameAuthorship.qualifiedName());
+    expected.add(DwcTerm.scientificNameID.qualifiedName());
+    expected.add(DwcTerm.sex.qualifiedName());
+    expected.add(DwcTerm.specificEpithet.qualifiedName());
+    expected.add(DwcTerm.startDayOfYear.qualifiedName());
+    expected.add(DwcTerm.subgenus.qualifiedName());
+    expected.add(DwcTerm.taxonID.qualifiedName());
+    expected.add(DwcTerm.taxonomicStatus.qualifiedName());
+    expected.add(DwcTerm.taxonRemarks.qualifiedName());
+    expected.add(DwcTerm.typeStatus.qualifiedName());
+    expected.add(DwcTerm.verbatimCoordinates.qualifiedName());
+    expected.add(DwcTerm.verbatimCoordinateSystem.qualifiedName());
+    expected.add(DwcTerm.verbatimDepth.qualifiedName());
+    expected.add(DwcTerm.verbatimElevation.qualifiedName());
+    expected.add(DwcTerm.verbatimEventDate.qualifiedName());
+    expected.add(DwcTerm.verbatimLatitude.qualifiedName());
+    expected.add(DwcTerm.verbatimLocality.qualifiedName());
+    expected.add(DwcTerm.verbatimLongitude.qualifiedName());
+    expected.add(DwcTerm.verbatimSRS.qualifiedName());
+    expected.add(DwcTerm.verbatimTaxonRank.qualifiedName());
+    expected.add(DwcTerm.waterBody.qualifiedName());
+    expected.add("http://rs.tdwg.org/dwc/terms/occurrenceAttributes");
+    // DC Terms
+    expected.add(DcTerm.references.qualifiedName());
+    expected.add(DcTerm.accessRights.qualifiedName());
+    expected.add(DcTerm.bibliographicCitation.qualifiedName());
+    expected.add(DcTerm.language.qualifiedName());
+    expected.add(DcTerm.license.qualifiedName());
+    expected.add(DcTerm.modified.qualifiedName());
+    expected.add(DcTerm.rights.qualifiedName());
+    expected.add(DcTerm.rightsHolder.qualifiedName());
+    expected.add(DcTerm.source.qualifiedName());
+    expected.add(DcTerm.type.qualifiedName());
+    // ALA Terms
+    expected.add("http://rs.ala.org.au/terms/1.0/photographer");
+    expected.add("http://rs.ala.org.au/terms/1.0/northing");
+    expected.add("http://rs.ala.org.au/terms/1.0/easting");
+    expected.add("http://rs.ala.org.au/terms/1.0/species");
+    expected.add("http://rs.ala.org.au/terms/1.0/subfamily");
+    expected.add("http://rs.ala.org.au/terms/1.0/subspecies");
+    expected.add("http://rs.ala.org.au/terms/1.0/superfamily");
+    expected.add("http://rs.ala.org.au/terms/1.0/zone");
+    // ABCD Terms
+    expected.add("http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifier");
+    expected.add("http://rs.tdwg.org/abcd/terms/abcdIdentificationQualifierInsertionPoint");
+    expected.add("http://rs.tdwg.org/abcd/terms/abcdTypeStatus");
+    expected.add("http://rs.tdwg.org/abcd/terms/typifiedName");
+    // HISPID Terms
+    expected.add("http://hiscom.chah.org.au/hispid/terms/secondaryCollectors");
+    expected.add("http://hiscom.chah.org.au/hispid/terms/identifierRole");
+    // GGBN Terms
+    expected.add("http://data.ggbn.org/schemas/ggbn/terms/loanDate");
+    expected.add("http://data.ggbn.org/schemas/ggbn/terms/loanDestination");
+    expected.add("http://data.ggbn.org/schemas/ggbn/terms/loanIdentifier");
+    expected.add("http://rs.tdwg.org/dwc/terms/locationAttributes");
+    expected.add("http://rs.tdwg.org/dwc/terms/eventAttributes");
+    // Other Terms
+    expected.add("taxonRankID");
+    // GBIF Terms
+    expected.add(GbifTerm.recordedByID.qualifiedName());
+
+    // When
+    List<String> result = CoreCsvConverter.getTerms();
+
+    // Should
+    Assert.assertEquals(expected.size(), result.size());
+    for (int x = 0; x < expected.size(); x++) {
+      Assert.assertEquals(expected.get(x), result.get(x));
+    }
+  }
+}

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/MultimediaCsvConverterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/MultimediaCsvConverterTest.java
@@ -1,0 +1,390 @@
+package au.org.ala.pipelines.converters;
+
+import au.org.ala.pipelines.transforms.IndexRecordTransform;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.gbif.dwc.terms.DcTerm;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.io.avro.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MultimediaCsvConverterTest {
+
+  @Test
+  public void converterTest() {
+    // Expected
+    // tr = 1, br = 2, lr = 3, trx = 4, atxr = 5, aur = 6, ir = 7, asr = 8
+    String[] expectet = {
+      "\"aur_uuid\"", // id
+      "\"aur_uuid\"", // DwcTerm.identifier
+      "\"\"", // DcTerm.creator
+      "\"\"", // DcTerm.created
+      "\"\"", // DcTerm.title
+      "\"\"", // DcTerm.format
+      "\"br_license\"", // DcTerm.license
+      "\"\"", // DcTerm.rights
+      "\"\"", // DcTerm.rightsHolder
+      "\"br_References\"", // DcTerm.references
+    };
+
+    // State
+    Map<String, String> core = new HashMap<>();
+    core.put(DwcTerm.occurrenceID.simpleName(), "raw_er_" + DwcTerm.occurrenceID.simpleName());
+    core.put(DwcTerm.catalogNumber.simpleName(), "raw_er_" + DwcTerm.catalogNumber.simpleName());
+    core.put(DwcTerm.collectionCode.simpleName(), "raw_er_" + DwcTerm.collectionCode.simpleName());
+    core.put(
+        DwcTerm.institutionCode.simpleName(), "raw_er_" + DwcTerm.institutionCode.simpleName());
+    core.put(DwcTerm.recordNumber.simpleName(), "raw_er_" + DwcTerm.recordNumber.simpleName());
+    core.put(DwcTerm.basisOfRecord.simpleName(), "raw_er_" + DwcTerm.basisOfRecord.simpleName());
+    core.put(DwcTerm.recordedBy.simpleName(), "raw_er_" + DwcTerm.recordedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceStatus.simpleName(), "raw_er_" + DwcTerm.occurrenceStatus.simpleName());
+    core.put(
+        DwcTerm.individualCount.simpleName(), "raw_er_" + DwcTerm.individualCount.simpleName());
+    core.put(DwcTerm.scientificName.simpleName(), "raw_er_" + DwcTerm.scientificName.simpleName());
+    core.put(DwcTerm.taxonConceptID.simpleName(), "raw_er_" + DwcTerm.taxonConceptID.simpleName());
+    core.put(DwcTerm.taxonRank.simpleName(), "raw_er_" + DwcTerm.taxonRank.simpleName());
+    core.put(DwcTerm.kingdom.simpleName(), "raw_er_" + DwcTerm.kingdom.simpleName());
+    core.put(DwcTerm.phylum.simpleName(), "raw_er_" + DwcTerm.phylum.simpleName());
+    core.put(DwcTerm.class_.simpleName(), "raw_er_" + DwcTerm.class_.simpleName());
+    core.put(DwcTerm.order.simpleName(), "raw_er_" + DwcTerm.order.simpleName());
+    core.put(DwcTerm.family.simpleName(), "raw_er_" + DwcTerm.family.simpleName());
+    core.put(DwcTerm.genus.simpleName(), "raw_er_" + DwcTerm.genus.simpleName());
+    core.put(DwcTerm.vernacularName.simpleName(), "raw_er_" + DwcTerm.vernacularName.simpleName());
+    core.put(
+        DwcTerm.decimalLatitude.simpleName(), "raw_er_" + DwcTerm.decimalLatitude.simpleName());
+    core.put(
+        DwcTerm.decimalLongitude.simpleName(), "raw_er_" + DwcTerm.decimalLongitude.simpleName());
+    core.put(DwcTerm.geodeticDatum.simpleName(), "raw_er_" + DwcTerm.geodeticDatum.simpleName());
+    core.put(
+        DwcTerm.coordinateUncertaintyInMeters.simpleName(),
+        "raw_er_" + DwcTerm.coordinateUncertaintyInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumElevationInMeters.simpleName(),
+        "raw_er_" + DwcTerm.maximumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumElevationInMeters.simpleName(),
+        "raw_er_" + DwcTerm.minimumElevationInMeters.simpleName());
+    core.put(
+        DwcTerm.minimumDepthInMeters.simpleName(),
+        "raw_er_" + DwcTerm.minimumDepthInMeters.simpleName());
+    core.put(
+        DwcTerm.maximumDepthInMeters.simpleName(),
+        "raw_er_" + DwcTerm.maximumDepthInMeters.simpleName());
+    core.put(DwcTerm.country.simpleName(), "raw_er_" + DwcTerm.country.simpleName());
+    core.put(DwcTerm.stateProvince.simpleName(), "raw_er_" + DwcTerm.stateProvince.simpleName());
+    core.put(DwcTerm.locality.simpleName(), "raw_er_" + DwcTerm.locality.simpleName());
+    core.put(
+        DwcTerm.locationRemarks.simpleName(), "raw_er_" + DwcTerm.locationRemarks.simpleName());
+    core.put(DwcTerm.year.simpleName(), "raw_er_" + DwcTerm.year.simpleName());
+    core.put(DwcTerm.month.simpleName(), "raw_er_" + DwcTerm.month.simpleName());
+    core.put(DwcTerm.day.simpleName(), "raw_er_" + DwcTerm.day.simpleName());
+    core.put(DwcTerm.eventDate.simpleName(), "raw_er_" + DwcTerm.eventDate.simpleName());
+    core.put(DwcTerm.eventID.simpleName(), "raw_er_" + DwcTerm.eventID.simpleName());
+    core.put(DwcTerm.identifiedBy.simpleName(), "raw_er_" + DwcTerm.identifiedBy.simpleName());
+    core.put(
+        DwcTerm.occurrenceRemarks.simpleName(), "raw_er_" + DwcTerm.occurrenceRemarks.simpleName());
+    core.put(
+        DwcTerm.dataGeneralizations.simpleName(),
+        "raw_er_" + DwcTerm.dataGeneralizations.simpleName());
+    core.put(
+        DwcTerm.otherCatalogNumbers.simpleName(),
+        "raw_er_" + DwcTerm.otherCatalogNumbers.simpleName());
+    core.put(DcTerm.references.simpleName(), "raw_er_" + DcTerm.references.simpleName());
+
+    ExtendedRecord er =
+        ExtendedRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCoreTerms(core)
+            .build();
+
+    TemporalRecord tr =
+        TemporalRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(1L)
+            .setDateIdentified("")
+            .setCreated(11L)
+            .setYear(111)
+            .setMonth(1111)
+            .setDay(11111)
+            .setEventDate(EventDate.newBuilder().setGte("1999").setLte("2000").build())
+            .setStartDayOfYear(111111)
+            .setEndDayOfYear(1111111)
+            .setModified("1999")
+            .setDateIdentified("1999")
+            .setDatePrecision("1999")
+            .build();
+
+    BasicRecord br =
+        BasicRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(2L)
+            .setGbifId(22L)
+            .setBasisOfRecord("br_basisOfRecord")
+            .setSex("br_sex")
+            .setLifeStage("br_lifeStage")
+            .setLifeStageLineage(Collections.singletonList("br_lifeStageLineage"))
+            .setEstablishmentMeans("br_establishmentMeans")
+            .setIndividualCount(222)
+            .setTypeStatus("br_typeStatus")
+            .setTypifiedName("br_typifiedName")
+            .setSampleSizeValue(222d)
+            .setSampleSizeUnit("br_sampleSizeUnit")
+            .setOrganismQuantity(2222d)
+            .setOrganismQuantityType("br_organismQuantityType")
+            .setRelativeOrganismQuantity(22222d)
+            .setReferences("br_References")
+            .setLicense("br_license")
+            .setIdentifiedByIds(
+                Collections.singletonList(
+                    AgentIdentifier.newBuilder()
+                        .setType("br_agent_type")
+                        .setValue("br_agent_value")
+                        .build()))
+            .setRecordedByIds(
+                Collections.singletonList(
+                    AgentIdentifier.newBuilder()
+                        .setType("br_agent_type_rb")
+                        .setValue("br_agent_value_rb")
+                        .build()))
+            .setRecordedBy(Arrays.asList("br_recordedBy_1", "br_recordedBy_2"))
+            .setOccurrenceStatus("br_occurrenceStatus")
+            .setIsClustered(true)
+            .build();
+
+    LocationRecord lr =
+        LocationRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setId("lr_id")
+            .setCreated(3L)
+            .setContinent("lr_continent")
+            .setWaterBody("lr_waterBody")
+            .setCountry("lr_country")
+            .setCountryCode("lr_countryCode")
+            .setPublishingCountry("lr_publishingCountry")
+            .setStateProvince("lr_stateProvince")
+            .setMinimumElevationInMeters(33d)
+            .setMaximumElevationInMeters(333d)
+            .setElevation(3333d)
+            .setElevationAccuracy(33333d)
+            .setMinimumDepthInMeters(33333d)
+            .setMaximumDepthInMeters(333333d)
+            .setDepth(33333333d)
+            .setDepthAccuracy(333333333d)
+            .setMinimumDistanceAboveSurfaceInMeters(3333333333d)
+            .setMaximumDistanceAboveSurfaceInMeters(33333333333d)
+            .setDecimalLatitude(333333333333d)
+            .setDecimalLongitude(3333333333333d)
+            .setCoordinateUncertaintyInMeters(33333333333333d)
+            .setCoordinatePrecision(333333333333333d)
+            .setHasCoordinate(true)
+            .setRepatriated(true)
+            .setHasGeospatialIssue(false)
+            .setLocality("lr_locality")
+            .setGeoreferencedDate("lr_georeferencedDate")
+            .setFootprintWKT("lr_footprintWKT")
+            .setBiome("lr_biome")
+            .build();
+
+    TaxonRecord txr =
+        TaxonRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setSynonym(false)
+            .setUsage(
+                RankedName.newBuilder()
+                    .setRank(Rank.SPECIES)
+                    .setName("txr_Usage_name")
+                    .setKey(4)
+                    .build())
+            .setClassification(
+                Arrays.asList(
+                    RankedName.newBuilder()
+                        .setRank(Rank.SPECIES)
+                        .setName("txr_Classification_SPECIES_name")
+                        .setKey(44)
+                        .build(),
+                    RankedName.newBuilder()
+                        .setRank(Rank.CLASS)
+                        .setName("txr_Classification_CLASS_name")
+                        .setKey(444)
+                        .build()))
+            .setAcceptedUsage(
+                RankedName.newBuilder()
+                    .setRank(Rank.SPECIES)
+                    .setName("txr_Usage_name")
+                    .setKey(4444)
+                    .build())
+            .setNomenclature(
+                Nomenclature.newBuilder()
+                    .setId("txr_Nomenclature_id")
+                    .setSource("txr_Nomenclature_Source")
+                    .build())
+            .setDiagnostics(
+                Diagnostic.newBuilder()
+                    .setConfidence(44444)
+                    .setStatus(Status.ACCEPTED)
+                    .setNote("txr_Diagnostic_Note")
+                    .setMatchType(MatchType.EXACT)
+                    .setLineage(Collections.singletonList("txr_Diagnostic_Lineage"))
+                    .build())
+            .setUsageParsedName(ParsedName.newBuilder().build())
+            .setIucnRedListCategoryCode("txr_IucnRedListCategoryCode")
+            .build();
+
+    ALATaxonRecord atxr =
+        ALATaxonRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setScientificName("atxr_ScientificName")
+            .setScientificNameAuthorship("atxr_ScientificNameAuthorship")
+            .setTaxonConceptID("atxr_TaxonConceptID")
+            .setTaxonRank("atxr_TaxonRank")
+            .setTaxonRankID(5)
+            .setLft(55)
+            .setRgt(555)
+            .setMatchType("atxr_MatchType")
+            .setNameType("atxr_NameType")
+            .setKingdom("atxr_Kingdom")
+            .setKingdomID("atxr_KingdomID")
+            .setPhylum("atxr_Phylum")
+            .setPhylumID("atxr_PhylumID")
+            .setClasss("atxr_Classs")
+            .setClassID("atxr_ClassID")
+            .setOrder("atxr_Order")
+            .setOrderID("atxr_OrderID")
+            .setFamily("atxr_Family")
+            .setFamilyID("atxr_FamilyID")
+            .setGenus("atxr_Genus")
+            .setGenusID("atxr_GenusID")
+            .setSpecies("atxr_Species")
+            .setSpeciesID("atxr_SpeciesID")
+            .setVernacularName("atxr_VernacularName")
+            .setSpeciesGroup(Collections.singletonList("atxr_SpeciesGroup"))
+            .setSpeciesSubgroup(Collections.singletonList("atxr_SpeciesSubgroup"))
+            .setDiagnostics(
+                Diagnostic.newBuilder()
+                    .setConfidence(5555)
+                    .setStatus(Status.ACCEPTED)
+                    .setNote("atxr_Diagnostic_Note")
+                    .setMatchType(MatchType.EXACT)
+                    .setLineage(Collections.singletonList("atxr_Diagnostic_Lineage"))
+                    .build())
+            .build();
+
+    ALAAttributionRecord aar =
+        ALAAttributionRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setDataResourceUid("aar_DataResourceUid")
+            .setDataResourceName("aar_DataResourceName")
+            .setDataProviderUid("aar_DataProviderUid")
+            .setDataProviderName("aar_DataProviderName")
+            .setCollectionUid("aar_CollectionUid")
+            .setCollectionName("aar_CollectionName")
+            .setInstitutionUid("aar_InstitutionUid")
+            .setInstitutionName("aar_InstitutionName")
+            .setLicenseType("aar_LicenseType")
+            .setLicenseVersion("aar_LicenseVersion")
+            .setProvenance("aar_Provenance")
+            .setHasDefaultValues(false)
+            .setHubMembership(
+                Collections.singletonList(
+                    EntityReference.newBuilder()
+                        .setName("aar_EntityReference_name")
+                        .setUid("aar_EntityReference_uuid")
+                        .setUri("aar_EntityReference_uri")
+                        .build()))
+            .build();
+
+    ALAUUIDRecord aur =
+        ALAUUIDRecord.newBuilder()
+            .setId("aur_id")
+            .setUuid("aur_uuid")
+            .setUniqueKey("aur_uniqueKey")
+            .setFirstLoaded(6L)
+            .build();
+
+    ImageRecord ir =
+        ImageRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(7L)
+            .setImageItems(
+                Collections.singletonList(
+                    Image.newBuilder()
+                        .setCreated("ir_Image")
+                        .setAudience("ir_Audienc")
+                        .setCreator("ir_Creator")
+                        .setContributor("ir_Contributor")
+                        .setDatasetId("ir_DatasetId")
+                        .setLicense("ir_License")
+                        .setLatitude(77d)
+                        .setLongitude(777d)
+                        .setSpatial("ir_Spatial")
+                        .setTitle("ir_Title")
+                        .setRightsHolder("ir_RightsHolder")
+                        .setIdentifier("ir_Identifier")
+                        .build()))
+            .build();
+
+    TaxonProfile tp = TaxonProfile.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+    MultimediaRecord mr =
+        MultimediaRecord.newBuilder().setId(DwcTerm.occurrenceID.simpleName()).build();
+
+    ALASensitivityRecord asr =
+        ALASensitivityRecord.newBuilder()
+            .setId(DwcTerm.occurrenceID.simpleName())
+            .setCreated(8L)
+            .setIsSensitive(false)
+            .setSensitive("asr_Sensitive")
+            .setDataGeneralizations("asr_DataGeneralizations")
+            .setInformationWithheld("asr_InformationWithheld")
+            .setGeneralisationToApplyInMetres("asr_GeneralisationToApplyInMetres")
+            .setGeneralisationInMetres("asr_GeneralisationInMetres")
+            .setOriginal(Collections.singletonMap("asr_Original_key", "asr_Original_value"))
+            .setAltered(Collections.singletonMap("asr_Altered_key", "asr_Altered_value"))
+            .build();
+
+    Long lastLoadDate = 9L;
+    Long lastProcessedDate = 10L;
+
+    IndexRecord source =
+        IndexRecordTransform.createIndexRecord(
+            br, tr, lr, txr, atxr, er, aar, aur, ir, tp, asr, mr, lastLoadDate, lastProcessedDate);
+
+    // When
+    String result = MultimediaCsvConverter.convert(source);
+
+    // Should
+    Assert.assertEquals(String.join(",", expectet), result);
+  }
+
+  @Test
+  public void termListTest() {
+
+    // Expected
+    List<String> expected = new LinkedList<>();
+
+    expected.add("id");
+    expected.add(DcTerm.identifier.qualifiedName());
+    expected.add(DcTerm.creator.qualifiedName());
+    expected.add(DcTerm.created.qualifiedName());
+    expected.add(DcTerm.title.qualifiedName());
+    expected.add(DcTerm.format.qualifiedName());
+    expected.add(DcTerm.license.qualifiedName());
+    expected.add(DcTerm.rights.qualifiedName());
+    expected.add(DcTerm.rightsHolder.qualifiedName());
+    expected.add(DcTerm.references.qualifiedName());
+
+    // When
+    List<String> result = MultimediaCsvConverter.getTerms();
+
+    // Should
+    Assert.assertEquals(expected.size(), result.size());
+    for (int x = 0; x < expected.size(); x++) {
+      Assert.assertEquals(expected.get(x), result.get(x));
+    }
+  }
+}

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/util/DwcaMetaXmlTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/util/DwcaMetaXmlTest.java
@@ -1,0 +1,78 @@
+package au.org.ala.pipelines.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.gbif.dwc.terms.DcTerm;
+import org.gbif.dwc.terms.DwcTerm;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DwcaMetaXmlTest {
+
+  private final String path = getClass().getResource("/metaxml").getPath();
+
+  @Test
+  public void writerTest() throws IOException {
+    // State
+    String file = "core-multimedia.xml";
+
+    List<String> core =
+        Arrays.asList(
+            DwcTerm.occurrenceID.qualifiedName(), DwcTerm.occurrenceStatus.qualifiedName());
+
+    List<String> multimedia =
+        Arrays.asList(DcTerm.identifier.qualifiedName(), DcTerm.contributor.qualifiedName());
+
+    // When
+    DwcaMetaXml.builder()
+        .coreTerms(core)
+        .multimediaTerms(multimedia)
+        .pathToWrite(path + "/test-" + file)
+        .create()
+        .write();
+
+    // Should
+    List<String> expected = Files.readAllLines(Paths.get(path, file));
+    List<String> result = Files.readAllLines(Paths.get(path, "test-" + file));
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(expected.size(), result.size());
+    for (int x = 0; x < expected.size(); x++) {
+      Assert.assertEquals(expected.get(0), result.get(0));
+    }
+  }
+
+  @Test
+  public void writerEmptyMultimediaTest() throws IOException {
+    // State
+    String file = "empty-multimedia.xml";
+
+    List<String> core =
+        Arrays.asList(
+            DwcTerm.occurrenceID.qualifiedName(), DwcTerm.occurrenceStatus.qualifiedName());
+
+    List<String> multimedia = Collections.emptyList();
+
+    // When
+    DwcaMetaXml.builder()
+        .coreTerms(core)
+        .multimediaTerms(multimedia)
+        .pathToWrite(path + "/test-" + file)
+        .create()
+        .write();
+
+    // Should
+    List<String> expected = Files.readAllLines(Paths.get(path, file));
+    List<String> result = Files.readAllLines(Paths.get(path, "test-" + file));
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(expected.size(), result.size());
+    for (int x = 0; x < expected.size(); x++) {
+      Assert.assertEquals(expected.get(0), result.get(0));
+    }
+  }
+}

--- a/livingatlas/pipelines/src/test/resources/metaxml/core-multimedia.xml
+++ b/livingatlas/pipelines/src/test/resources/metaxml/core-multimedia.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<archive metadata="eml.xml" xmlns="http://rs.tdwg.org/dwc/text/">
+  <core encoding="UTF-8" linesTerminatedBy="\r\n" fieldsTerminatedBy="," fieldsEnclosedBy="&quot;" ignoreHeaderLines="0" rowType="http://rs.tdwg.org/dwc/terms/Occurrence">
+    <files>
+      <location>occurrence.csv</location>
+    </files>
+    <id index="0"/>
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/occurrenceID"/>
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/occurrenceStatus"/>
+  </core>
+  <extension encoding="UTF-8" linesTerminatedBy="\r\n" fieldsTerminatedBy="," fieldsEnclosedBy="&quot;" ignoreHeaderLines="0" rowType="http://rs.gbif.org/terms/1.0/Multimedia">
+    <files>
+      <location>image.csv</location>
+    </files>
+    <coreid index="0"/>
+    <field index="0" term="http://purl.org/dc/terms/identifier"/>
+    <field index="1" term="http://purl.org/dc/terms/contributor"/>
+  </extension>
+</archive>

--- a/livingatlas/pipelines/src/test/resources/metaxml/empty-multimedia.xml
+++ b/livingatlas/pipelines/src/test/resources/metaxml/empty-multimedia.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<archive metadata="eml.xml" xmlns="http://rs.tdwg.org/dwc/text/">
+  <core encoding="UTF-8" linesTerminatedBy="\r\n" fieldsTerminatedBy="," fieldsEnclosedBy="&quot;" ignoreHeaderLines="0" rowType="http://rs.tdwg.org/dwc/terms/Occurrence">
+    <files>
+      <location>occurrence.csv</location>
+    </files>
+    <id index="0"/>
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/occurrenceID"/>
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/occurrenceStatus"/>
+  </core>
+</archive>

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -66,6 +66,7 @@ dwca-avro --> interpret --> validate --> uuid --> image-sync ... │
 -  'validation-report' dumps out a CSV list of datasets ready to be indexed to '/tmp/validation-report.csv';
 -  'clustering' clustering of occurrences;
 -  'prune-datasets' remove any datasets no longer registered in the collectory;
+-  'dwca-export' export a dwca archive;
 
 All the steps generate an output. If only the final output is desired, the intermediate outputs can be ignored.
 
@@ -89,6 +90,7 @@ Usage:
   $CMD [options] prune-datasets
   $CMD [options] validation-report
   $CMD [options] do-all        (<dr>...|all) $WHEREL
+  $CMD [options] dwca-export     (<dr>...|all)         $WHERE
   $CMD -h | --help
   $CMD -v | --version
 
@@ -708,6 +710,43 @@ function index () {
     logStepEnd "Index-Record" $dr $ltype $SECONDS
 }
 
+function dwca_export () {
+    dr=$1
+    ltype=$2
+    CLASS=au.org.ala.pipelines.beam.IndexRecordToDwcaPipeline
+
+    logStepStart "Dwca-export" $dr
+    SECONDS=0
+
+    PRE=image-sync-sh-args.spark-embedded
+    if [[ $ltype = "spark-embedded" || $ltype = "local" ]] ; then
+        $_D java $EXTRA_JVM_CLI_ARGS \
+            $(getConf $PRE.jvm)  \
+            -cp $PIPELINES_JAR $CLASS \
+            --datasetId=$dr \
+            --config=$config $ARGS
+    fi
+
+    PRE=image-sync-sh-args.spark-cluster
+    if [[ $ltype = "spark-cluster" ]] ; then
+        $_D /data/spark/bin/spark-submit \
+            --name "Dwca-export $dr" \
+            $(toArg $PRE num-executors) \
+            $(toArg $PRE executor-cores) \
+            $(toArg $PRE executor-memory) \
+            $(toArg $PRE driver-memory) \
+            --class $CLASS \
+            --master $SPARK_MASTER \
+            --driver-java-options "-Dlog4j.configuration=file:$CONFIG_DIR/log4j.properties" \
+            $PIPELINES_JAR \
+            --datasetId=$dr \
+            --config=$config $ARGS
+            # TODO set here an optional colorized log4j properties
+    fi
+
+    logStepEnd "Dwca-export" $dr $ltype $SECONDS
+}
+
 if ($archive_list) ; then
     archive-list
 fi
@@ -774,6 +813,10 @@ fi
 
 if ($validate || $do_all); then
     do_step validate
+fi
+
+if ($dwca_export || $do_all); then
+    do_step dwca_export
 fi
 
 if ($uuid || $do_all); then

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,8 @@
     <lz4.version>1.3.0</lz4.version>
     <commons-codec.version>1.11</commons-codec.version>
 
+    <freemarker.version>2.3.31</freemarker.version>
+
     <!-- Test -->
     <junit4.version>4.13.1</junit4.version>
     <mockwebserver.version>3.11.0</mockwebserver.version>
@@ -760,6 +762,12 @@
         <groupId>org.geotools</groupId>
         <artifactId>gt-epsg-hsql</artifactId>
         <version>${geotools.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.freemarker</groupId>
+        <artifactId>freemarker</artifactId>
+        <version>${freemarker.version}</version>
       </dependency>
 
       <!-- Mini Pipeline-->

--- a/tools/extension-converter-maven-plugin/pom.xml
+++ b/tools/extension-converter-maven-plugin/pom.xml
@@ -15,10 +15,6 @@
   <name>Pipelines :: Tools :: Extension converter</name>
   <description>Maven plugin generates conveters java classes for raw extensions</description>
 
-  <properties>
-    <freemarker.version>2.3.31</freemarker.version>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -58,7 +54,6 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>${freemarker.version}</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
This is a draft PR. I checked several ALA datasets via GBIF "download DWCA" link and found that there are only 40 terms inside, so I implemented converter for those fields first and I have the following questions:

1) What terms do I need, all these? - https://github.com/AtlasOfLivingAustralia/biocache-store/blob/develop/src/main/scala/au/org/ala/biocache/export/DwCAExporter.scala#L34
2) Term DwcTerm.class_ contains raw class value, is it a bug in **IndexRecordTransform**?
3) I didn't find interpreted DwcTerm.eventDate, only raw_eventDate, is it ok?
4) For multivalued fields I use **;** as a separator, is that ok?
