### PR TITLE
ALA minor fixes

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ImageServiceDiffLoadPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ImageServiceDiffLoadPipeline.java
@@ -115,35 +115,40 @@ public class ImageServiceDiffLoadPipeline {
                           @Element String imageMapping, OutputReceiver<KV<String, Multimedia>> out)
                           throws Exception {
 
-                        final CSVParser parser = new CSVParser();
-                        String[] parts = parser.parseLine(imageMapping);
+                        try {
+                          final CSVParser parser = new CSVParser();
+                          String[] parts = parser.parseLine(imageMapping);
 
-                        if (parts.length != NO_OF_CSV_FIELDS) {
-                          throw new RuntimeException("Problem with line: " + imageMapping);
+                          if (parts.length == NO_OF_CSV_FIELDS) {
+
+                            // CSV is imageID
+                            // Swap so we key on URL for later grouping
+                            Multimedia multimedia =
+                                Multimedia.newBuilder()
+                                    .setIdentifier(parts[0]) // image service ID
+                                    .setAudience(parts[2])
+                                    .setContributor(parts[3])
+                                    .setCreated(parts[4])
+                                    .setCreator(parts[5])
+                                    .setDescription(parts[6])
+                                    .setFormat(parts[7])
+                                    .setLicense(parts[8])
+                                    .setPublisher(parts[9])
+                                    .setReferences(parts[10])
+                                    .setRightsHolder(parts[11])
+                                    .setSource(parts[12])
+                                    .setTitle(parts[13])
+                                    .setType(parts[14])
+                                    .build();
+
+                            // output imageURL (from source) -> multimedia
+                            out.output(KV.of(StringUtils.trim(parts[1]).toLowerCase(), multimedia));
+                          } else {
+                            log.error("Problem line length: " + imageMapping);
+                          }
+                        } catch (Exception e) {
+                          log.error("Problem parsing line: " + imageMapping);
                         }
-
-                        // CSV is imageID
-                        // Swap so we key on URL for later grouping
-                        Multimedia multimedia =
-                            Multimedia.newBuilder()
-                                .setIdentifier(parts[0]) // image service ID
-                                .setAudience(parts[2])
-                                .setContributor(parts[3])
-                                .setCreated(parts[4])
-                                .setCreator(parts[5])
-                                .setDescription(parts[6])
-                                .setFormat(parts[7])
-                                .setLicense(parts[8])
-                                .setPublisher(parts[9])
-                                .setReferences(parts[10])
-                                .setRightsHolder(parts[11])
-                                .setSource(parts[12])
-                                .setTitle(parts[13])
-                                .setType(parts[14])
-                                .build();
-
-                        // output imageURL (from source) -> multimedia
-                        out.output(KV.of(StringUtils.trim(parts[1]).toLowerCase(), multimedia));
                       }
                     }));
 

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
@@ -321,10 +321,11 @@ public class IndexRecordTransform implements Serializable, IndexFields {
             && !field.name().equals(SPECIES_GROUP)
             && !field.name().equals(SPECIES_SUBGROUP)
             && !field.name().equals(TAXON_RANK)
-            && !field.name().equals("classs") // avoid indexing with "classs" spelling
             && !skipKeys.contains(field.name())) {
 
-          if (field.name().equalsIgnoreCase("issues")) {
+          if (field.name().equalsIgnoreCase("classs")) {
+            indexRecord.getStrings().put(DwcTerm.class_.simpleName(), value.toString());
+          } else if (field.name().equalsIgnoreCase("issues")) {
             assertions.add((String) value);
           } else {
             if (value instanceof Integer) {
@@ -630,6 +631,8 @@ public class IndexRecordTransform implements Serializable, IndexFields {
             TemporalRecord.getClassSchema().getFields().stream()
                 .map(Field::name)
                 .collect(Collectors.toList()))
+        .add(DwcTerm.class_.simpleName())
+        .add(DwcTerm.geodeticDatum.simpleName())
         .build();
   }
 
@@ -793,6 +796,7 @@ public class IndexRecordTransform implements Serializable, IndexFields {
       doc.setLatLng(latlon);
     }
 
+    doc.getStrings().put(DwcTerm.geodeticDatum.simpleName(), PIPELINES_GEODETIC_DATUM);
     doc.getStrings().put(LAT_LONG, latlon); // is set to IGNORE in headerAttributes
     doc.getStrings()
         .put(POINT_1, getLatLongString(lat, lon, "#")); // is set to IGNORE in headerAttributes

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexRecordTransform.java
@@ -46,6 +46,8 @@ public class IndexRecordTransform implements Serializable, IndexFields {
 
   private static final long serialVersionUID = 1279313931024806169L;
   private static final TermFactory TERM_FACTORY = TermFactory.instance();
+  public static final String ISSUES = "issues";
+  public static final String CLASSS = "classs";
 
   // Core
   @NonNull private TupleTag<ExtendedRecord> erTag;
@@ -323,9 +325,9 @@ public class IndexRecordTransform implements Serializable, IndexFields {
             && !field.name().equals(TAXON_RANK)
             && !skipKeys.contains(field.name())) {
 
-          if (field.name().equalsIgnoreCase("classs")) {
+          if (field.name().equalsIgnoreCase(CLASSS)) {
             indexRecord.getStrings().put(DwcTerm.class_.simpleName(), value.toString());
-          } else if (field.name().equalsIgnoreCase("issues")) {
+          } else if (field.name().equalsIgnoreCase(ISSUES)) {
             assertions.add((String) value);
           } else {
             if (value instanceof Integer) {

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexValues.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/IndexValues.java
@@ -13,4 +13,5 @@ public interface IndexValues {
   String IMAGE = "Image";
   String SOUND = "Sound";
   String VIDEO = "Video";
+  String PIPELINES_GEODETIC_DATUM = "EPSG:4326";
 }

--- a/livingatlas/pipelines/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
+++ b/livingatlas/pipelines/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 package org.apache.beam.sdk.io.solr;
+
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
@@ -26,7 +27,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -44,7 +44,6 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -65,8 +64,8 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CursorMarkParams;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,8 +113,8 @@ import org.slf4j.LoggerFactory;
  */
 @Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
-        "rawtypes", // TODO(https://issues.apache.org/jira/browse/BEAM-10556)
-        "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
+  "rawtypes", // TODO(https://issues.apache.org/jira/browse/BEAM-10556)
+  "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class SolrIO {
 
@@ -255,13 +254,13 @@ public class SolrIO {
     public static RetryConfiguration create(int maxAttempts, Duration maxDuration) {
       checkArgument(maxAttempts > 0, "maxAttempts must be greater than 0");
       checkArgument(
-              maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
-              "maxDuration must be greater than 0");
+          maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
+          "maxDuration must be greater than 0");
       return new AutoValue_SolrIO_RetryConfiguration.Builder()
-              .setMaxAttempts(maxAttempts)
-              .setMaxDuration(maxDuration)
-              .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
-              .build();
+          .setMaxAttempts(maxAttempts)
+          .setMaxDuration(maxDuration)
+          .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
+          .build();
     }
 
     // Exposed only to allow tests to easily simulate server errors
@@ -282,18 +281,18 @@ public class SolrIO {
     /** This is the default predicate used to test if a failed Solr operation should be retried. */
     private static class DefaultRetryPredicate implements RetryPredicate {
       private static final ImmutableSet<Integer> ELIGIBLE_CODES =
-              ImmutableSet.of(
-                      SolrException.ErrorCode.CONFLICT.code,
-                      SolrException.ErrorCode.SERVER_ERROR.code,
-                      SolrException.ErrorCode.SERVICE_UNAVAILABLE.code,
-                      SolrException.ErrorCode.INVALID_STATE.code,
-                      SolrException.ErrorCode.UNKNOWN.code);
+          ImmutableSet.of(
+              SolrException.ErrorCode.CONFLICT.code,
+              SolrException.ErrorCode.SERVER_ERROR.code,
+              SolrException.ErrorCode.SERVICE_UNAVAILABLE.code,
+              SolrException.ErrorCode.INVALID_STATE.code,
+              SolrException.ErrorCode.UNKNOWN.code);
 
       @Override
       public boolean test(Throwable t) {
         return (t instanceof IOException
-                || t instanceof SolrServerException
-                || (t instanceof SolrException && ELIGIBLE_CODES.contains(((SolrException) t).code())));
+            || t instanceof SolrServerException
+            || (t instanceof SolrException && ELIGIBLE_CODES.contains(((SolrException) t).code())));
       }
     }
   }
@@ -372,10 +371,10 @@ public class SolrIO {
       // TODO remove this configuration, we can figure out the best number
       // by tuning batchSize when pipelines run.
       checkArgument(
-              batchSize > 0 && batchSize < MAX_BATCH_SIZE,
-              "Valid values for batchSize are 1 (inclusive) to %s (exclusive), but was: %s ",
-              MAX_BATCH_SIZE,
-              batchSize);
+          batchSize > 0 && batchSize < MAX_BATCH_SIZE,
+          "Valid values for batchSize are 1 (inclusive) to %s (exclusive), but was: %s ",
+          MAX_BATCH_SIZE,
+          batchSize);
       return builder().setBatchSize(batchSize).build();
     }
 
@@ -388,7 +387,7 @@ public class SolrIO {
     @Override
     public PCollection<SolrDocument> expand(PBegin input) {
       checkArgument(
-              getConnectionConfiguration() != null, "withConnectionConfiguration() is required");
+          getConnectionConfiguration() != null, "withConnectionConfiguration() is required");
       checkArgument(getCollection() != null, "from() is required");
       return input.apply("Create", Create.of(this)).apply("ReadAll", readAll());
     }
@@ -416,9 +415,9 @@ public class SolrIO {
 
     static ReplicaInfo create(Replica replica) {
       return new AutoValue_SolrIO_ReplicaInfo(
-              replica.getStr(ZkStateReader.CORE_NAME_PROP),
-              replica.getCoreUrl(),
-              replica.getStr(ZkStateReader.BASE_URL_PROP));
+          replica.getStr(ZkStateReader.CORE_NAME_PROP),
+          replica.getCoreUrl(),
+          replica.getStr(ZkStateReader.BASE_URL_PROP));
     }
   }
 
@@ -439,7 +438,7 @@ public class SolrIO {
             // We need to check both state of the replica and live nodes
             // to make sure that the replica is alive
             if (replica.getState() == Replica.State.ACTIVE
-                    && clusterState.getLiveNodes().contains(replica.getNodeName())) {
+                && clusterState.getLiveNodes().contains(replica.getNodeName())) {
               randomActiveReplica = replica;
               break;
             }
@@ -447,9 +446,9 @@ public class SolrIO {
           // TODO in case of this replica goes inactive while the pipeline runs.
           // We should pick another active replica of this shard.
           checkState(
-                  randomActiveReplica != null,
-                  "Can not found an active replica for slice %s",
-                  slice.getName());
+              randomActiveReplica != null,
+              "Can not found an active replica for slice %s",
+              slice.getName());
           out.output(spec.withReplicaInfo(ReplicaInfo.create(checkNotNull(randomActiveReplica))));
         }
       }
@@ -470,7 +469,7 @@ public class SolrIO {
       solrQuery.setRows(spec.getBatchSize());
       solrQuery.setDistrib(false);
       try (AuthorizedSolrClient<HttpSolrClient> client =
-                   spec.getConnectionConfiguration().createClient(replicaInfo.baseUrl())) {
+          spec.getConnectionConfiguration().createClient(replicaInfo.baseUrl())) {
         SchemaRequest.UniqueKey request = new SchemaRequest.UniqueKey();
         try {
           SchemaResponse.UniqueKeyResponse response = client.process(spec.getCollection(), request);
@@ -503,9 +502,9 @@ public class SolrIO {
     @Override
     public PCollection<SolrDocument> expand(PCollection<Read> input) {
       return input
-              .apply("Split", ParDo.of(new SplitFn()))
-              .apply("Reshuffle", Reshuffle.viaRandomKey())
-              .apply("Read", ParDo.of(new ReadFn()));
+          .apply("Split", ParDo.of(new SplitFn()))
+          .apply("Reshuffle", Reshuffle.viaRandomKey())
+          .apply("Read", ParDo.of(new ReadFn()));
     }
   }
 
@@ -622,17 +621,17 @@ public class SolrIO {
         solrClient = spec.getConnectionConfiguration().createClient();
 
         retryBackoff =
-                FluentBackoff.DEFAULT
-                        .withMaxRetries(0) // default to no retrying
-                        .withInitialBackoff(RETRY_INITIAL_BACKOFF);
+            FluentBackoff.DEFAULT
+                .withMaxRetries(0) // default to no retrying
+                .withInitialBackoff(RETRY_INITIAL_BACKOFF);
 
         if (spec.getRetryConfiguration() != null) {
           // FluentBackoff counts retries excluding the original while we count attempts
           // to remove ambiguity (hence the -1)
           retryBackoff =
-                  retryBackoff
-                          .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
-                          .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
+              retryBackoff
+                  .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
+                  .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
         }
       }
 
@@ -676,18 +675,18 @@ public class SolrIO {
 
               // fail immediately if no retry configuration doesn't handle this
               if (spec.getRetryConfiguration() == null
-                      || !spec.getRetryConfiguration().getRetryPredicate().test(exception)) {
+                  || !spec.getRetryConfiguration().getRetryPredicate().test(exception)) {
                 throw new IOException(
-                        "Error writing to Solr (no attempt made to retry)", exception);
+                    "Error writing to Solr (no attempt made to retry)", exception);
               }
 
               // see if we can pause and try again
               if (!BackOffUtils.next(sleeper, backoff)) {
                 throw new IOException(
-                        String.format(
-                                "Error writing to Solr after %d attempt(s). No more attempts allowed",
-                                attempt),
-                        exception);
+                    String.format(
+                        "Error writing to Solr after %d attempt(s). No more attempts allowed",
+                        attempt),
+                    exception);
 
               } else {
                 // Note: this used in test cases to verify behavior

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
@@ -1,6 +1,7 @@
 package au.org.ala.pipelines.beam;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import au.org.ala.pipelines.options.*;
 import au.org.ala.sampling.LayerCrawler;
@@ -8,10 +9,14 @@ import au.org.ala.util.SolrUtils;
 import au.org.ala.util.TestUtils;
 import au.org.ala.utils.ValidationUtils;
 import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 import okhttp3.mockwebserver.MockWebServer;
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.common.SolrDocument;
+import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.pipelines.common.beam.options.DwcaPipelineOptions;
 import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
 import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
@@ -81,6 +86,62 @@ public class CompleteIngestPipelineTestIT {
     SolrDocument sensitive = SolrUtils.getRecords("sensitive:generalised").get(0);
     assertEquals(-35.3, (double) sensitive.get("decimalLatitude"), 0.00001);
     assertEquals("-35.260319", sensitive.get("sensitive_decimalLatitude"));
+
+    // 4. check content of record
+    checkSingleRecordContent();
+  }
+
+  public static void checkSingleRecordContent() throws Exception {
+    Optional<SolrDocument> record = SolrUtils.getRecord("occurrenceID:not-an-uuid-5");
+
+    assertEquals(record.isPresent(), true);
+    assertEquals("not-an-uuid-5", record.get().get("occurrenceID"));
+
+    assertEquals("Scioglyptis chionomera", record.get().get("scientificName"));
+    assertEquals("Scioglyptis chionomera", record.get().get("raw_scientificName"));
+
+    assertEquals("Animalia", record.get().get("raw_kingdom"));
+    assertEquals("Animalia", record.get().get("kingdom"));
+
+    assertEquals("Arthropoda", record.get().get("phylum"));
+    assertEquals("Arthropoda", record.get().get("raw_phylum"));
+    assertEquals("Insecta", record.get().get("class"));
+    assertEquals("Insecta", record.get().get("raw_class"));
+    assertEquals("Lepidoptera", record.get().get("order"));
+    assertEquals("Lepidoptera", record.get().get("raw_order"));
+    assertEquals("Geometridae", record.get().get("family"));
+    assertEquals("Geometridae", record.get().get("raw_family"));
+    assertEquals("Scioglyptis", record.get().get("genus"));
+    assertEquals("Scioglyptis", record.get().get("raw_genus"));
+
+    assertEquals("species", record.get().get("raw_taxonRank"));
+    assertEquals("species", record.get().get("taxonRank"));
+    assertEquals(7000, record.get().get("taxonRankID"));
+
+    Date eventDate = (Date) record.get().get("eventDate");
+    assertNotNull(eventDate);
+
+    assertEquals("2016-11-26", new SimpleDateFormat("yyyy-MM-dd").format(eventDate));
+    assertEquals("26/11/16", record.get().get("raw_eventDate"));
+    assertEquals(26, record.get().get("day"));
+    assertEquals("26", record.get().get("raw_day"));
+    assertEquals(11, record.get().get("month"));
+    assertEquals("11", record.get().get("raw_month"));
+    assertEquals(2016, record.get().get("year"));
+    assertEquals("2016", record.get().get("raw_year"));
+
+    assertEquals("Victoria", record.get().get("raw_stateProvince"));
+    assertEquals("Australia", record.get().get("raw_country"));
+    assertEquals("Victoria", record.get().get("stateProvince"));
+    assertEquals("Australia", record.get().get("country"));
+    assertNull(record.get().get("raw_countryCode"));
+    assertEquals("AU", record.get().get("countryCode"));
+
+    assertEquals("-37.9909881", record.get().get("raw_decimalLatitude"));
+    assertEquals("145.1256931", record.get().get("raw_decimalLongitude"));
+    assertEquals(-37.990988, record.get().get("decimalLatitude"));
+    assertEquals(145.125693, record.get().get("decimalLongitude"));
+    assertEquals("EPSG:4326", record.get().get("raw_" + DwcTerm.geodeticDatum.simpleName()));
   }
 
   public void loadTestDataset(String datasetID, String inputPath) throws Exception {

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/java/CompleteIngestJavaPipelineTestIT.java
@@ -1,5 +1,6 @@
 package au.org.ala.pipelines.java;
 
+import static au.org.ala.pipelines.beam.CompleteIngestPipelineTestIT.checkSingleRecordContent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -88,6 +89,9 @@ public class CompleteIngestJavaPipelineTestIT {
     SolrDocument sensitive = SolrUtils.getRecords("sensitive:generalised").get(0);
     assertEquals(-35.3, (double) sensitive.get("decimalLatitude"), 0.00001);
     assertEquals("-35.260319", sensitive.get("sensitive_decimalLatitude"));
+
+    // 4. check content of record
+    checkSingleRecordContent();
   }
 
   public void loadTestDataset(String datasetID, String inputPath) throws Exception {

--- a/livingatlas/pipelines/src/test/java/au/org/ala/util/SolrUtils.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/util/SolrUtils.java
@@ -189,9 +189,9 @@ public class SolrUtils {
 
     SolrQuery params = new SolrQuery();
     params.setQuery(queryUrl);
-    params.setSort("score ", SolrQuery.ORDER.desc);
-    params.setStart(Integer.getInteger("0"));
-    params.setRows(Integer.getInteger("100"));
+    params.setSort("score", SolrQuery.ORDER.desc);
+    params.setStart(0);
+    params.setRows(100);
 
     QueryResponse response = solr.query(params);
     SolrDocumentList results = response.getResults();
@@ -208,9 +208,9 @@ public class SolrUtils {
 
     SolrQuery params = new SolrQuery();
     params.setQuery(queryUrl);
-    params.setSort("score ", SolrQuery.ORDER.desc);
-    params.setStart(Integer.getInteger("0"));
-    params.setRows(Integer.getInteger("100"));
+    params.setSort("score", SolrQuery.ORDER.desc);
+    params.setStart(0);
+    params.setRows(100);
 
     QueryResponse response = solr.query(params);
     SolrDocumentList results = response.getResults();
@@ -223,9 +223,9 @@ public class SolrUtils {
 
     SolrQuery params = new SolrQuery();
     params.setQuery(queryUrl);
-    params.setSort("score ", SolrQuery.ORDER.desc);
-    params.setStart(Integer.getInteger("0"));
-    params.setRows(Integer.getInteger("100"));
+    params.setSort("score", SolrQuery.ORDER.desc);
+    params.setStart(0);
+    params.setRows(100);
 
     QueryResponse response = solr.query(params);
     return response.getResults();

--- a/livingatlas/pipelines/src/test/java/au/org/ala/util/SolrUtils.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/util/SolrUtils.java
@@ -8,6 +8,7 @@ import java.nio.file.FileSystem;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import okio.BufferedSink;
@@ -22,6 +23,7 @@ import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.ConfigSetAdminResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.jetbrains.annotations.NotNull;
 
@@ -179,6 +181,25 @@ public class SolrUtils {
     adminRequest.setCollectionName(BIOCACHE_TEST_SOLR_COLLECTION);
     adminRequest.process(cloudSolrClient);
     cloudSolrClient.close();
+  }
+
+  public static Optional<SolrDocument> getRecord(String queryUrl) throws Exception {
+    CloudSolrClient solr = new CloudSolrClient(getZkHost());
+    solr.setDefaultCollection(BIOCACHE_TEST_SOLR_COLLECTION);
+
+    SolrQuery params = new SolrQuery();
+    params.setQuery(queryUrl);
+    params.setSort("score ", SolrQuery.ORDER.desc);
+    params.setStart(Integer.getInteger("0"));
+    params.setRows(Integer.getInteger("100"));
+
+    QueryResponse response = solr.query(params);
+    SolrDocumentList results = response.getResults();
+    if (results.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(results.get(0));
+    }
   }
 
   public static Long getRecordCount(String queryUrl) throws Exception {

--- a/livingatlas/solr/conf/managed-schema
+++ b/livingatlas/solr/conf/managed-schema
@@ -446,7 +446,22 @@
   <field name="subfamily"   type="string" docValues="true" indexed="true"/>
 
   <!-- ALA Sensitive data fields -->
-  <field name="sensitive"                       type="string" docValues="true" indexed="true"/>
+  <field name="sensitive"                             type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_dataGeneralizations"         type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_day"                         type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_decimalLatitude"             type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_decimalLongitude"            type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_eventDate"                   type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_eventID"                     type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_eventTime"                   type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_footprintWKT"                type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_locality"                    type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_locationRemarks"             type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_month"                       type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_verbatimCoordinates"         type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_verbatimEventDate"           type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_verbatimLatitude"            type="string" docValues="true" indexed="true"/>
+  <field name="sensitive_verbatimLocality"            type="string" docValues="true" indexed="true"/>
   <field name="generalisationInMetres"          type="string" docValues="true" indexed="true"/>
   <field name="generalisationToApplyInMetres"   type="string" docValues="true" indexed="true"/>
 
@@ -473,10 +488,11 @@
   <field name="assertionUserId"        type="string"  docValues="true" indexed="true" multiValued="true" />
   <field name="userAssertions"         type="string"  docValues="true" indexed="true" />
   <field name="hasUserAssertions"      type="boolean" docValues="true" indexed="true" />
+  <field name="lastAssertionDate"      type="date"    docValues="true" indexed="true" />
 
   <!-- Free text search fields -->
-  <field name="text"         type="text"   multiValued="true" indexed="true" stored="false" />
-  <field name="matched_name" type="string" multiValued="true" indexed="true" stored="false" />
+  <field name="text"                   type="text"    multiValued="true" indexed="true" stored="false" />
+  <field name="matched_name"           type="string"  multiValued="true" indexed="true" stored="false" />
 
   <!-- occurrenceDetails needs to be remapped on export -->
   <!-- see https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/236 -->

--- a/livingatlas/solr/scripts/update-solr-cluster-config.sh
+++ b/livingatlas/solr/scripts/update-solr-cluster-config.sh
@@ -4,18 +4,18 @@ cd ../conf
 echo 'Zipping configset'
 rm config.zip
 zip config.zip *
-
-echo 'Deleting existing collection'
-curl -X GET "http://localhost:8985/solr/admin/collections?action=DELETE&name=biocache"
-
-echo 'Deleting existing configset'
-curl -X GET "http://localhost:8985/solr/admin/configs?action=DELETE&name=biocache&omitHeader=true"
+#
+#echo 'Deleting existing collection'
+#curl -X GET "http://localhost:8985/solr/admin/collections?action=DELETE&name=biocache"
+#
+#echo 'Deleting existing configset'
+#curl -X GET "http://localhost:8985/solr/admin/configs?action=DELETE&name=biocache&omitHeader=true"
 
 echo 'Creating  configset'
-curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=biocache"
+curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=biocache24"
 
-echo 'Creating  collection'
-curl -X GET "http://localhost:8985/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
+#echo 'Creating  collection'
+#curl -X GET "http://localhost:8985/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
 
 cd ../..
 rm solr/conf/config.zip

--- a/livingatlas/solr/scripts/update-solr-cluster-config.sh
+++ b/livingatlas/solr/scripts/update-solr-cluster-config.sh
@@ -4,18 +4,18 @@ cd ../conf
 echo 'Zipping configset'
 rm config.zip
 zip config.zip *
-#
-#echo 'Deleting existing collection'
-#curl -X GET "http://localhost:8985/solr/admin/collections?action=DELETE&name=biocache"
-#
-#echo 'Deleting existing configset'
-#curl -X GET "http://localhost:8985/solr/admin/configs?action=DELETE&name=biocache&omitHeader=true"
+
+echo 'Deleting existing collection'
+curl -X GET "http://localhost:8985/solr/admin/collections?action=DELETE&name=biocache"
+
+echo 'Deleting existing configset'
+curl -X GET "http://localhost:8985/solr/admin/configs?action=DELETE&name=biocache&omitHeader=true"
 
 echo 'Creating  configset'
-curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=biocache24"
+curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=biocache"
 
-#echo 'Creating  collection'
-#curl -X GET "http://localhost:8985/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
+echo 'Creating  collection'
+curl -X GET "http://localhost:8985/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
 
 cd ../..
 rm solr/conf/config.zip


### PR DESCRIPTION
Fix for `class` & `geodeticDatum`  indexing and additional checks in integration tests
Explicitly adding sensitive fields to solr schema.
Exception handling in image service loading to avoid breaking pipeline for adhoc bad records.
Indexing of interpreted `class` field.
`lastAssertionDate` added to SOLR schema
SolrIO update to bring inline with beam 2.28.0
Change to ImageLoadDiffPipeline to log bad records instead of failing.
