### PR TITLE
Retries for collectory lookups and removal of silent failures

### DIFF
--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -40,10 +40,13 @@ sds:
 collectory:
   wsUrl: https://collections.ala.org.au/ws/
   timeoutSec: 70
+  retryConfig:
+    maxAttempts: 10
+    initialIntervalMillis: 10000
   httpHeaders:
     Authorization: add-a-api-key-here
 imageService:
-  wsUrl: https://aws-image-service-pipelines-test.ala.org.au/
+  wsUrl: https://images-test.ala.org.au/
   timeoutSec: 70
   httpHeaders:
     apiKey: add-a-api-key-here
@@ -54,12 +57,20 @@ geocodeConfig:
   country:
     path: /data/pipelines-shp/political
     field: ISO_A2
+    intersectBuffer:  0.135
+    intersectMapping:
+      CX: AU
+      CC: AU
+      HM: AU
+      NF: AU
   eez:
     path: /data/pipelines-shp/eez
     field: ISO2
+    intersectBuffer:  0.135
   stateProvince:
     path: /data/pipelines-shp/cw_state_poly
     field: FEATURE
+    intersectBuffer: 0
   biome:
     path: /data/pipelines-shp/gadm0
     field: FEATURE

--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -844,7 +844,6 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper-version}</version>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.jboss.netty</groupId>

--- a/livingatlas/pipelines/src/main/java/au/org/ala/kvs/ShapeFile.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/kvs/ShapeFile.java
@@ -1,6 +1,7 @@
 package au.org.ala.kvs;
 
 import java.io.Serializable;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -14,4 +15,8 @@ public class ShapeFile implements Serializable {
   String field;
   /** URL to source of the shapefile */
   String source;
+  /** Intersect buffer 0.1 = 11km, 0.135 = 15km, 0.18 = 20km */
+  Double intersectBuffer = 0.18;
+  /** Intersect mapping to allow intersected values to mapped to different values e.g. CX -> AU * */
+  Map<String, String> intersectMapping;
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/kvs/cache/ALACollectionKVStoreFactory.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/kvs/cache/ALACollectionKVStoreFactory.java
@@ -11,7 +11,6 @@ import org.gbif.kvs.KeyValueStore;
 import org.gbif.kvs.cache.KeyValueCache;
 import org.gbif.kvs.hbase.Command;
 import org.gbif.pipelines.core.functions.SerializableSupplier;
-import org.gbif.rest.client.configuration.ClientConfiguration;
 
 /** Key value store factory for Collection lookups */
 @Slf4j
@@ -41,13 +40,6 @@ public class ALACollectionKVStoreFactory {
   public static KeyValueStore<ALACollectionLookup, ALACollectionMatch> create(
       ALAPipelinesConfig config) {
 
-    ClientConfiguration clientConfiguration =
-        ClientConfiguration.builder()
-            .withBaseApiUrl(config.getCollectory().getWsUrl()) // GBIF base API url
-            .withTimeOut(
-                config.getCollectory().getTimeoutSec()) // Geocode service connection time-out
-            .build();
-
     ALACollectoryServiceClient wsClient = new ALACollectoryServiceClient(config.getCollectory());
     Command closeHandler =
         () -> {
@@ -73,7 +65,7 @@ public class ALACollectionKVStoreFactory {
             try {
               return service.lookupCodes(key.getInstitutionCode(), key.getCollectionCode());
             } catch (Exception ex) {
-              // this is can happen for bad data and this service is suspectible to http 404 due to
+              // this is can happen for bad data and this service is susceptible to http 404 due to
               // the fact
               // it takes URL parameters from the raw data. So log and carry on for now.
               log.error(

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/SolrPipelineOptions.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/SolrPipelineOptions.java
@@ -70,4 +70,9 @@ public interface SolrPipelineOptions extends IndexingPipelineOptions {
   Integer getNumOfPartitions();
 
   void setNumOfPartitions(Integer numOfPartitions);
+
+  @Description("Output AVRO to file path")
+  String getOutputAvroToFilePath();
+
+  void setOutputAvroToFilePath(String outputAvroToFilePath);
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAMetadataTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAMetadataTransform.java
@@ -1,0 +1,67 @@
+package au.org.ala.pipelines.transforms;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.METADATA_RECORDS_COUNT;
+import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.RecordType.METADATA;
+
+import au.org.ala.kvs.client.ALACollectoryMetadata;
+import au.org.ala.pipelines.interpreters.ALAAttributionInterpreter;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.gbif.kvs.KeyValueStore;
+import org.gbif.pipelines.core.functions.SerializableConsumer;
+import org.gbif.pipelines.core.functions.SerializableSupplier;
+import org.gbif.pipelines.core.interpreters.Interpretation;
+import org.gbif.pipelines.io.avro.ALAMetadataRecord;
+import org.gbif.pipelines.transforms.Transform;
+
+@Slf4j
+public class ALAMetadataTransform extends Transform<String, ALAMetadataRecord> {
+
+  private final SerializableSupplier<KeyValueStore<String, ALACollectoryMetadata>>
+      dataResourceKvStoreSupplier;
+  private KeyValueStore<String, ALACollectoryMetadata> kvStore;
+  private final String datasetId;
+
+  @Builder(buildMethodName = "create")
+  private ALAMetadataTransform(
+      SerializableSupplier<KeyValueStore<String, ALACollectoryMetadata>>
+          dataResourceKvStoreSupplier,
+      String datasetId) {
+    super(
+        ALAMetadataRecord.class,
+        METADATA,
+        ALAMetadataRecord.class.getName(),
+        METADATA_RECORDS_COUNT);
+    this.dataResourceKvStoreSupplier = dataResourceKvStoreSupplier;
+    this.datasetId = datasetId;
+  }
+
+  public ALAMetadataTransform counterFn(SerializableConsumer<String> counterFn) {
+    setCounterFn(counterFn);
+    return this;
+  }
+
+  /** Beam @Setup initializes resources */
+  @Setup
+  public void setup() {
+    if (kvStore == null && dataResourceKvStoreSupplier != null) {
+      log.info("Initialize DataResource KV store");
+      kvStore = dataResourceKvStoreSupplier.get();
+    }
+  }
+
+  /** Beam @Setup can be applied only to void method * */
+  public ALAMetadataTransform init() {
+    setup();
+    return this;
+  }
+
+  @Override
+  public Optional<ALAMetadataRecord> convert(String source) {
+    return Interpretation.from(source)
+        .to(id -> ALAMetadataRecord.newBuilder().setId(id).build())
+        .via(ALAAttributionInterpreter.interpretDatasetKey(datasetId, kvStore))
+        .getOfNullable();
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/ALAOccurrenceIssue.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/ALAOccurrenceIssue.java
@@ -9,6 +9,10 @@ import org.gbif.dwc.terms.GbifTerm;
 import org.gbif.dwc.terms.Term;
 import org.gbif.utils.AnnotationUtils;
 
+/**
+ * Living Atlas issue extension. We should look to merge this with {@link
+ * org.gbif.api.vocabulary.OccurrenceIssue} enum See: https://github.com/gbif/pipelines/issues/530
+ */
 public enum ALAOccurrenceIssue implements InterpretationRemark {
 
   // Location related
@@ -19,7 +23,6 @@ public enum ALAOccurrenceIssue implements InterpretationRemark {
   MISSING_COORDINATEPRECISION(InterpretationRemarkSeverity.WARNING, TermsGroup.COORDINATES_TERMS),
   UNCERTAINTY_IN_PRECISION(InterpretationRemarkSeverity.WARNING, TermsGroup.COORDINATES_TERMS),
   UNCERTAINTY_NOT_SPECIFIED(InterpretationRemarkSeverity.WARNING, TermsGroup.COORDINATES_TERMS),
-  COORDINATE_PRECISION_INVALID(InterpretationRemarkSeverity.WARNING, TermsGroup.COORDINATES_TERMS),
 
   STATE_COORDINATE_MISMATCH(
       InterpretationRemarkSeverity.WARNING, TermsGroup.COORDINATES_COUNTRY_TERMS),

--- a/livingatlas/pipelines/src/test/java/au/org/ala/clustering/ClusteringTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/clustering/ClusteringTest.java
@@ -1,18 +1,14 @@
-package au.org.ala;
+package au.org.ala.clustering;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertNotNull;
-
-import au.org.ala.clustering.ClusteringCandidates;
-import au.org.ala.clustering.HashKeyOccurrence;
-import au.org.ala.clustering.HashKeyOccurrenceBuilder;
 import au.org.ala.pipelines.beam.ClusteringPipeline;
+import com.google.common.base.Splitter;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.values.KV;
 import org.gbif.pipelines.core.parsers.clustering.OccurrenceRelationships;
 import org.gbif.pipelines.core.parsers.clustering.RelationshipAssertion;
 import org.gbif.pipelines.io.avro.Relationship;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ClusteringTest {
@@ -40,22 +36,22 @@ public class ClusteringTest {
             "urn:lsid:biodiversity.org.au:afd.taxon:9b8ca2d0-3524-4e12-a328-9a426b31cd12|-12381|130859|1994|9|26,6ca4917e-36e9-4067-bd29-4de87f1e303c,dr340,urn:lsid:biodiversity.org.au:afd.taxon:9b8ca2d0-3524-4e12-a328-9a426b31cd12,Pteropus alecto,AU,urn:lsid:biodiversity.org.au:afd.taxon:9b8ca2d0-3524-4e12-a328-9a426b31cd12,PRESERVED_SPECIMEN,-12.38091,130.85902,1994,9,26,,null,null,null,null,M.41902.001,urn:lsid:ozcam.taxonomy.org.au:AM:Mammalogy:M.41902.001,ecatalogue.irn:2217345; urn:catalog:AM:Mammalogy:M.41902.001");
 
     RelationshipAssertion<HashKeyOccurrence> assertion = OccurrenceRelationships.generate(h1, h2);
-    assertNotNull(assertion);
-    assertNotNull(
+    Assert.assertNotNull(assertion);
+    Assert.assertNotNull(
         assertion.justificationContains(
             RelationshipAssertion.FeatureAssertion.SAME_ACCEPTED_SPECIES));
-    assertNotNull(
+    Assert.assertNotNull(
         assertion.justificationContains(RelationshipAssertion.FeatureAssertion.SAME_COORDINATES));
-    assertNotNull(
+    Assert.assertNotNull(
         assertion.justificationContains(RelationshipAssertion.FeatureAssertion.SAME_COUNTRY));
 
     // assertion related
-    assertNotNull(OccurrenceRelationships.generate(h1, h2));
-    assertNotNull(OccurrenceRelationships.generate(h2, h3));
-    assertNotNull(OccurrenceRelationships.generate(h3, h4));
-    assertNotNull(OccurrenceRelationships.generate(h1, h3));
-    assertNotNull(OccurrenceRelationships.generate(h1, h4));
-    assertNotNull(OccurrenceRelationships.generate(h2, h4));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h1, h2));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h2, h3));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h3, h4));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h1, h3));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h1, h4));
+    Assert.assertNotNull(OccurrenceRelationships.generate(h2, h4));
 
     List<HashKeyOccurrence> candidates = new ArrayList<>();
     candidates.add(h1);
@@ -71,11 +67,11 @@ public class ClusteringTest {
             .build();
 
     List<KV<String, Relationship>> kvs2 = ClusteringPipeline.createRelationships(cc, 50);
-    assertNotEquals(kvs2.size(), 0);
+    Assert.assertNotEquals(kvs2.size(), 0);
   }
 
   public HashKeyOccurrence createFromString(String str) {
-    String[] parts = str.split(",");
+    String[] parts = Splitter.on(',').splitToList(str).toArray(new String[0]);
     return HashKeyOccurrenceBuilder.aHashKeyOccurrence()
         .withHashKey(parts[0])
         .withId(parts[1])

--- a/livingatlas/pipelines/src/test/java/au/org/ala/kvs/GeocodeServiceTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/kvs/GeocodeServiceTestIT.java
@@ -26,6 +26,130 @@ public class GeocodeServiceTestIT {
    * HashMap.
    */
   @Test
+  public void testCountryCoastalPoint() {
+
+    KeyValueStore<LatLng, GeocodeResponse> geoService =
+        GeocodeKvStoreFactory.createCountrySupplier(TestUtils.getConfig()).get();
+
+    GeocodeResponse resp =
+        geoService.get(LatLng.builder().withLongitude(119.7).withLatitude(-20.0).build());
+    assertTrue(!resp.getLocations().isEmpty());
+    assertEquals("AU", resp.getLocations().get(0).getName());
+
+    GeocodeResponse resp2 =
+        geoService.get(
+            LatLng.builder().withLongitude(124.9500000000).withLatitude(-15.0667000000).build());
+    assertTrue(!resp2.getLocations().isEmpty());
+    assertEquals("AU", resp2.getLocations().get(0).getName());
+
+    GeocodeResponse resp3 =
+        geoService.get(LatLng.builder().withLongitude(115.445278).withLatitude(-20.827222).build());
+    assertTrue(!resp3.getLocations().isEmpty());
+    assertEquals("AU", resp3.getLocations().get(0).getName());
+  }
+
+  @Test
+  public void testExternalTerritories() {
+
+    KeyValueStore<LatLng, GeocodeResponse> geoService =
+        GeocodeKvStoreFactory.createCountrySupplier(TestUtils.getConfig()).get();
+
+    // Christmas Island
+    GeocodeResponse resp =
+        geoService.get(
+            LatLng.builder()
+                .withLongitude(105.65916507921472)
+                .withLatitude(-10.47444666578651)
+                .build());
+    assertTrue(!resp.getLocations().isEmpty());
+    assertEquals("AU", resp.getLocations().get(0).getName());
+
+    // Cocos Island
+    GeocodeResponse resp2 =
+        geoService.get(
+            LatLng.builder()
+                .withLongitude(96.82189811041627)
+                .withLatitude(-12.149492596153177)
+                .build());
+    assertTrue(!resp2.getLocations().isEmpty());
+    assertEquals("AU", resp2.getLocations().get(0).getName());
+
+    // HM Heard Island and McDonald Islands
+    GeocodeResponse resp3 =
+        geoService.get(
+            LatLng.builder()
+                .withLongitude(73.50048378875914)
+                .withLatitude(-53.05122953207953)
+                .build());
+    assertTrue(!resp3.getLocations().isEmpty());
+    assertEquals("AU", resp2.getLocations().get(0).getName());
+
+    // Norfolk Island
+    GeocodeResponse resp4 =
+        geoService.get(
+            LatLng.builder()
+                .withLongitude(167.96164271317312)
+                .withLatitude(-29.030669709715056)
+                .build());
+    assertTrue(!resp4.getLocations().isEmpty());
+    assertEquals("AU", resp4.getLocations().get(0).getName());
+
+    // Lord Howe
+    GeocodeResponse resp5 =
+        geoService.get(
+            LatLng.builder()
+                .withLongitude(159.0851385821144)
+                .withLatitude(-31.560315624981254)
+                .build());
+    assertTrue(!resp5.getLocations().isEmpty());
+    assertEquals("AU", resp5.getLocations().get(0).getName());
+  }
+
+  /**
+   * Tests the Get operation on {@link KeyValueStore} that wraps a simple KV store backed by a
+   * HashMap.
+   */
+  @Test
+  public void testCountryDatelineTests() {
+
+    KeyValueStore<LatLng, GeocodeResponse> geoService =
+        GeocodeKvStoreFactory.createCountrySupplier(TestUtils.getConfig()).get();
+
+    // FJ
+    GeocodeResponse resp =
+        geoService.get(LatLng.builder().withLongitude(179.9).withLatitude(-17.99).build());
+    assertFalse(resp.getLocations().isEmpty());
+    assertEquals("FJ", resp.getLocations().get(0).getName());
+
+    // NZ
+    GeocodeResponse resp2 =
+        geoService.get(LatLng.builder().withLongitude(179.9).withLatitude(-40.0).build());
+    assertFalse(resp2.getLocations().isEmpty());
+    assertEquals("NZ", resp2.getLocations().get(0).getName());
+
+    // NZ - other side of dateline
+    GeocodeResponse resp3 =
+        geoService.get(LatLng.builder().withLongitude(-179.9).withLatitude(-40.0).build());
+    assertFalse(resp3.getLocations().isEmpty());
+    assertEquals("NZ", resp3.getLocations().get(0).getName());
+
+    // south pole
+    GeocodeResponse resp4 =
+        geoService.get(LatLng.builder().withLongitude(179.9).withLatitude(-90.0).build());
+    assertFalse(resp4.getLocations().isEmpty());
+    assertEquals("AQ", resp4.getLocations().get(0).getName());
+
+    // north pole
+    GeocodeResponse resp5 =
+        geoService.get(LatLng.builder().withLongitude(179.9).withLatitude(90.0).build());
+    assertTrue(resp5.getLocations().isEmpty());
+  }
+
+  /**
+   * Tests the Get operation on {@link KeyValueStore} that wraps a simple KV store backed by a
+   * HashMap.
+   */
+  @Test
   public void testBiomeTerrestrial() {
 
     KeyValueStore<LatLng, GeocodeResponse> geoService =

--- a/livingatlas/pipelines/src/test/java/au/org/ala/parser/UncertaintyRangeParserTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/parser/UncertaintyRangeParserTest.java
@@ -4,16 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import au.org.ala.pipelines.parser.DistanceParser;
 import java.util.UnknownFormatConversionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests ported from
  * https://github.com/AtlasOfLivingAustralia/biocache-store/blob/master/src/test/scala/au/org/ala/biocache/DistanceRangeParserTest.scala
  */
 public class UncertaintyRangeParserTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void parseRange() {

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ClusteringPipelineIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ClusteringPipelineIT.java
@@ -7,6 +7,9 @@ import au.com.bytecode.opencsv.CSVReader;
 import au.org.ala.pipelines.options.ClusteringPipelineOptions;
 import au.org.ala.utils.ValidationUtils;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.avro.file.CodecFactory;
@@ -75,10 +78,12 @@ public class ClusteringPipelineIT {
     String absolutePath = new File("src/test/resources").getAbsolutePath();
 
     // Step 1: load a dataset and verify all records have a UUID associated
-    CSVReader csvReader =
-        new CSVReader(
-            new FileReader(
-                new File(absolutePath + "/clustering/" + dataResourceUid + "/occurrence.csv")));
+    Reader reader =
+        Files.newBufferedReader(
+            Paths.get(absolutePath + "/clustering/" + dataResourceUid + "/occurrence.csv"),
+            StandardCharsets.UTF_8);
+
+    CSVReader csvReader = new CSVReader(reader);
 
     DatumWriter<IndexRecord> datumWriter = new GenericDatumWriter<>(IndexRecord.getClassSchema());
 

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/CompleteIngestPipelineTestIT.java
@@ -94,7 +94,7 @@ public class CompleteIngestPipelineTestIT {
   public static void checkSingleRecordContent() throws Exception {
     Optional<SolrDocument> record = SolrUtils.getRecord("occurrenceID:not-an-uuid-5");
 
-    assertEquals(record.isPresent(), true);
+    assertTrue(record.isPresent());
     assertEquals("not-an-uuid-5", record.get().get("occurrenceID"));
 
     assertEquals("Scioglyptis chionomera", record.get().get("scientificName"));

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/ALAAttributionInterpreterTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/ALAAttributionInterpreterTestIT.java
@@ -14,6 +14,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.kvs.KeyValueStore;
 import org.gbif.pipelines.io.avro.ALAAttributionRecord;
+import org.gbif.pipelines.io.avro.ALAMetadataRecord;
 import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -39,8 +40,12 @@ public class ALAAttributionInterpreterTestIT {
 
     KeyValueStore<ALACollectionLookup, ALACollectionMatch> kvs =
         ALACollectionKVStoreFactory.create(TestUtils.getConfig());
+
+    ALAMetadataRecord mdr =
+        ALAMetadataRecord.newBuilder().setDataResourceUid("test").setId("test").build();
+
     BiConsumer<ExtendedRecord, ALAAttributionRecord> fcn =
-        ALAAttributionInterpreter.interpretCodes(kvs);
+        ALAAttributionInterpreter.interpretCodes(kvs, mdr);
 
     Map<String, String> map = new HashMap<>();
     map.put(DwcTerm.institutionCode.namespace() + DwcTerm.institutionCode.simpleName(), "CSIRO");
@@ -59,8 +64,12 @@ public class ALAAttributionInterpreterTestIT {
 
     KeyValueStore<ALACollectionLookup, ALACollectionMatch> kvs =
         ALACollectionKVStoreFactory.create(TestUtils.getConfig());
+
+    ALAMetadataRecord mdr =
+        ALAMetadataRecord.newBuilder().setDataResourceUid("test").setId("test").build();
+
     BiConsumer<ExtendedRecord, ALAAttributionRecord> fcn =
-        ALAAttributionInterpreter.interpretCodes(kvs);
+        ALAAttributionInterpreter.interpretCodes(kvs, mdr);
 
     Map<String, String> map = new HashMap<>();
     map.put(DwcTerm.institutionCode.namespace() + DwcTerm.institutionCode.simpleName(), "ANIC");

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/AlaTemporalInterpreterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/AlaTemporalInterpreterTest.java
@@ -1,7 +1,6 @@
 package au.org.ala.pipelines.interpreters;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import au.org.ala.pipelines.vocabulary.ALAOccurrenceIssue;
 import java.util.HashMap;
@@ -40,7 +39,7 @@ public class AlaTemporalInterpreterTest {
     TemporalRecord tr = create("2000-01-01/2000-01-01");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
     assertEquals("2000-01-01", tr.getEventDate().getGte());
-    assertEquals(null, tr.getEventDate().getLte());
+    assertNull(tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.DAY_PRECISION, tr.getDatePrecision());
   }
 
@@ -49,7 +48,7 @@ public class AlaTemporalInterpreterTest {
     TemporalRecord tr = create("2000-01-01");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
     assertEquals("2000-01-01", tr.getEventDate().getGte());
-    assertEquals(null, tr.getEventDate().getLte());
+    assertNull(tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.DAY_PRECISION, tr.getDatePrecision());
   }
 
@@ -57,8 +56,8 @@ public class AlaTemporalInterpreterTest {
   public void testDatePrecisionMonthRange() {
     TemporalRecord tr = create("2000-01/2000-02");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
-    assertEquals(tr.getEventDate().getGte(), "2000-01");
-    assertEquals(tr.getEventDate().getLte(), "2000-02");
+    assertEquals("2000-01", tr.getEventDate().getGte());
+    assertEquals("2000-02", tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.MONTH_RANGE_PRECISION, tr.getDatePrecision());
   }
 
@@ -66,8 +65,8 @@ public class AlaTemporalInterpreterTest {
   public void testDatePrecisionMonth() {
     TemporalRecord tr = create("2000-01/2000-01");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
-    assertEquals(tr.getEventDate().getGte(), "2000-01");
-    assertEquals(tr.getEventDate().getLte(), null);
+    assertEquals("2000-01", tr.getEventDate().getGte());
+    assertNull(tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.MONTH_PRECISION, tr.getDatePrecision());
   }
 
@@ -75,8 +74,8 @@ public class AlaTemporalInterpreterTest {
   public void testDatePrecisionMonth2() {
     TemporalRecord tr = create("2000-01");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
-    assertEquals(tr.getEventDate().getGte(), "2000-01");
-    assertEquals(tr.getEventDate().getLte(), null);
+    assertEquals("2000-01", tr.getEventDate().getGte());
+    assertNull(tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.MONTH_PRECISION, tr.getDatePrecision());
   }
 
@@ -84,8 +83,8 @@ public class AlaTemporalInterpreterTest {
   public void testDatePrecisionYear() {
     TemporalRecord tr = create("2000/2001");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
-    assertEquals(tr.getEventDate().getGte(), "2000");
-    assertEquals(tr.getEventDate().getLte(), "2001");
+    assertEquals("2000", tr.getEventDate().getGte());
+    assertEquals("2001", tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.YEAR_RANGE_PRECISION, tr.getDatePrecision());
   }
 
@@ -93,8 +92,8 @@ public class AlaTemporalInterpreterTest {
   public void testDatePrecisionYear2() {
     TemporalRecord tr = create("2000/2000");
     ALATemporalInterpreter.checkDatePrecision(null, tr);
-    assertEquals(tr.getEventDate().getGte(), "2000");
-    assertEquals(null, tr.getEventDate().getLte());
+    assertEquals("2000", tr.getEventDate().getGte());
+    assertNull(tr.getEventDate().getLte());
     assertEquals(ALATemporalInterpreter.YEAR_PRECISION, tr.getDatePrecision());
   }
 
@@ -108,8 +107,8 @@ public class AlaTemporalInterpreterTest {
     TemporalInterpreter temporalInterpreter = TemporalInterpreter.builder().create();
     temporalInterpreter.interpretTemporal(er, tr);
 
-    assertEquals(tr.getEventDate().getGte(), "2000");
-    assertEquals(tr.getEventDate().getLte(), "2001");
+    assertEquals("2000", tr.getEventDate().getGte());
+    assertEquals("2001", tr.getEventDate().getLte());
   }
 
   @Test

--- a/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedYamlConfigurationTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/utils/CombinedYamlConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
@@ -142,7 +143,7 @@ public class CombinedYamlConfigurationTest {
   @Test
   public void testYamlDump() throws IOException {
     String yamlPath = testConf.toYamlFile();
-    String yamlStr = new String(Files.readAllBytes(Paths.get(yamlPath)));
+    String yamlStr = new String(Files.readAllBytes(Paths.get(yamlPath)), StandardCharsets.UTF_8);
 
     assertThat(yamlStr.length(), greaterThan(0));
     assertThat(yamlStr.contains("{fsPath}"), equalTo(false));

--- a/livingatlas/pipelines/src/test/java/au/org/ala/utils/JackKnifeTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/utils/JackKnifeTest.java
@@ -5,22 +5,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import au.org.ala.pipelines.jackknife.JackKnife;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests ported from
  * https://github.com/AtlasOfLivingAustralia/biocache-store/blob/master/src/test/scala/au/org/ala/biocache/DistanceRangeParserTest.scala
  */
 public class JackKnifeTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void jackKnife() {
 
     // too few values
-    int size = 10;
     Double[] values =
         new Double[] {
           Double.NaN,

--- a/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines-maven.yaml
@@ -19,14 +19,22 @@ geocodeConfig:
     path: "/tmp/pipelines-shp/political"
     field: ISO_A2
     source: "http://www.naturalearthdata.com"
+    intersectBuffer:  0.135
+    intersectMapping:
+      CX: AU
+      CC: AU
+      HM: AU
+      NF: AU
   eez:
     path: "/tmp/pipelines-shp/eez"
     field: ISO2
     source: "http://www.naturalearthdata.com"
+    intersectBuffer: 0.135
   stateProvince:
     path: "/tmp/pipelines-shp/cw_state_poly"
     field: FEATURE
     source: "http://vliz.be/vmdcdata/marbound/"
+    intersectBuffer: 0.135
   biome:
     path: "/tmp/pipelines-shp/gadm0"
     field: FEATURE

--- a/livingatlas/pipelines/src/test/resources/pipelines.yaml
+++ b/livingatlas/pipelines/src/test/resources/pipelines.yaml
@@ -41,12 +41,20 @@ geocodeConfig:
   country:
     path: /data/pipelines-shp/political
     field: ISO_A2
+    intersectBuffer: 0.135
+    intersectMapping:
+      CX: AU
+      CC: AU
+      HM: AU
+      NF: AU
   eez:
     path: /data/pipelines-shp/eez
     field: ISO2
+    intersectBuffer:  0.135
   stateProvince:
     path: /data/pipelines-shp/cw_state_poly
     field: FEATURE
+    intersectBuffer: 0.135
   biome:
     path: /data/pipelines-shp/gadm0
     field: FEATURE

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -299,6 +299,13 @@ function dataset-list() {
          --config=$config $ARGS
 }
 
+function validation-report() {
+    # dump out archive list
+    log.info "Creating validation report"
+    java $EXTRA_JVM_CLI_ARGS -cp $LOCAL_PIPELINES_JAR au.org.ala.utils.ValidationReportWriter \
+       --config=$config $ARGS
+}
+
 function dwca-avro () {
     dr=$1
     CLASS=au.org.ala.pipelines.beam.ALADwcaToVerbatimPipeline

--- a/livingatlas/solr/conf/managed-schema
+++ b/livingatlas/solr/conf/managed-schema
@@ -137,8 +137,8 @@
 
   <field name="id" type="string" docValues="true" multiValued="false" indexed="true"/>
 
-  <!-- version field required for updating user assertions -->
-  <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
+  <!-- required for solr optimistic concurrency update -->
+  <field name="_version_" type="long" docValues="true" indexed="false" stored="false"/>
 
   <!-- required for WMS -->
   <field name="point-0.0001"  type="string" docValues="true" indexed="true" />
@@ -149,7 +149,6 @@
   <field name="point-1"       type="string" docValues="true" indexed="true" />
   <field name="lat_long"      type="string" docValues="true" indexed="false" />
   <field name="biome"         type="string" docValues="true" indexed="true" />
-  <field name="speciesHabitats"         type="string" docValues="true" indexed="true" />
   <field name="geohash"       type="geohash"     indexed="true"/>
   <field name="quad"          type="quad"        indexed="true"/>
   <field name="packedQuad"    type="packedQuad"  indexed="true"/>
@@ -492,10 +491,13 @@
   <field name="userAssertions"         type="string"  docValues="true" indexed="true" />
   <field name="hasUserAssertions"      type="boolean" docValues="true" indexed="true" />
   <field name="lastAssertionDate"      type="date"    docValues="true" indexed="true" />
+  <field name="userVerified"           type="boolean" docValues="true" indexed="true" />
 
   <!-- Free text search fields -->
   <field name="text"                   type="text"    multiValued="true" indexed="true" stored="false" />
   <field name="matched_name"           type="string"  multiValued="true" indexed="true" stored="false" />
+  <field name="text_recordedBy"        type="textgen" multiValued="true" indexed="true" stored="false" />
+  <field name="text_identifiedBy"      type="textgen" multiValued="true" indexed="true" stored="false" />
 
   <!-- occurrenceDetails needs to be remapped on export -->
   <!-- see https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/236 -->
@@ -673,7 +675,6 @@
   <copyField source="lat_long"         dest="location"/>
   <copyField source="lat_long"         dest="quad"/>
   <copyField source="lat_long"         dest="packedQuad"/>
-  <copyField source="biome"            dest="speciesHabitats"/>
   <copyField source="occurrenceYear"   dest="occurrence_year"/>
 
   <!-- Do we need this -->
@@ -706,6 +707,8 @@
   <copyField source="raw_typeStatus" dest="text"/>
   <copyField source="raw_vernacularName" dest="text"/>
   <copyField source="recordedBy" dest="text"/>
+  <copyField source="identifiedBy" dest="text_identifiedBy"/>
+  <copyField source="recordedBy" dest="text_recordedBy"/>
   <copyField source="scientificName" dest="matched_name"/>
   <copyField source="scientificName" dest="text"/>
   <copyField source="species" dest="text"/>

--- a/livingatlas/solr/conf/solrconfig.xml
+++ b/livingatlas/solr/conf/solrconfig.xml
@@ -536,7 +536,10 @@
          especially if the skipped fields are large compressed text
          fields.
     -->
-    <enableLazyFieldLoading>true</enableLazyFieldLoading>
+    <!-- Set to false due to a bug in 8.8
+         See: https://stackoverflow.com/questions/66335803/solr-throws-error-on-partial-update-after-upgrade-to-8-8
+    -->
+    <enableLazyFieldLoading>false</enableLazyFieldLoading>
 
     <!-- Use Filter For Sorted Query
 

--- a/livingatlas/solr/scripts/update-solr-cluster-config.sh
+++ b/livingatlas/solr/scripts/update-solr-cluster-config.sh
@@ -5,17 +5,17 @@ echo 'Zipping configset'
 rm config.zip
 zip config.zip *
 
-echo 'Deleting existing collection'
-curl -X GET "http://localhost:8985/solr/admin/collections?action=DELETE&name=biocache"
+#echo 'Deleting existing collection'
+#curl -X GET "http://localhost:8987/solr/admin/collections?action=DELETE&name=biocache3"
 
-echo 'Deleting existing configset'
-curl -X GET "http://localhost:8985/solr/admin/configs?action=DELETE&name=biocache&omitHeader=true"
+#echo 'Deleting existing configset'
+#curl -X GET "http://localhost:8986/solr/admin/configs?action=DELETE&name=biocache4&omitHeader=true"
 
 echo 'Creating  configset'
-curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8985/solr/admin/configs?action=UPLOAD&name=biocache"
+curl -X POST --header "Content-Type:application/octet-stream" --data-binary @config.zip "http://localhost:8987/solr/admin/configs?action=UPLOAD&name=biocache4"
 
-echo 'Creating  collection'
-curl -X GET "http://localhost:8985/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
+#echo 'Creating  collection'
+#curl -X GET "http://localhost:8986/solr/admin/collections?action=CREATE&name=biocache&numShards=8&maxShardsPerNode=1&replicationFactor=1&collection.configName=biocache"
 
 cd ../..
 rm solr/conf/config.zip

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/GeocodeKvStore.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/GeocodeKvStore.java
@@ -63,7 +63,9 @@ public class GeocodeKvStore implements KeyValueStore<LatLng, GeocodeResponse>, S
     }
 
     // If that doesn't help, use the database.
-    if (locations == null) {
+    if (locations == null
+        || locations.getLocations() == null
+        || locations.getLocations().isEmpty()) {
       locations = kvStore.get(latLng);
     }
 

--- a/sdks/models/src/main/avro/specific/ala-attribution-record.avsc
+++ b/sdks/models/src/main/avro/specific/ala-attribution-record.avsc
@@ -1,47 +1,69 @@
 [
-{
-  "name" : "EntityReference",
-  "namespace":"org.gbif.pipelines.io.avro",
-  "type" : "record",
-  "fields" : [
-    {"name": "uid", "type": ["null", "string"], "default" : null },
-    {"name": "name", "type": ["null", "string"], "default" : null },
-    {"name": "uri", "type": ["null", "string"], "default" : null }
-  ]
-},
-{
-  "name":"ALAAttributionRecord",
-  "namespace":"org.gbif.pipelines.io.avro",
-  "type":"record",
-  "doc":"ALA Attribution",
-  "fields":[
-    {"name": "id","type":"string"},
-    {"name": "dataResourceUid", "type": ["null", "string"], "default" : null },
-    {"name": "dataResourceName", "type": ["null", "string"], "default" : null },
-    {"name": "dataProviderUid", "type": ["null", "string"], "default" : null },
-    {"name": "dataProviderName", "type": ["null", "string"], "default" : null },
-    {"name": "collectionUid", "type": ["null", "string"], "default" : null },
-    {"name": "collectionName", "type": ["null", "string"], "default" : null },
-    {"name": "institutionUid", "type": ["null", "string"], "default" : null },
-    {"name": "institutionName", "type": ["null", "string"], "default" : null },
-    {"name": "licenseType", "type": ["null", "string"], "default" : null },
-    {"name": "licenseVersion", "type": ["null", "string"], "default" : null },
-    {"name": "provenance", "type": ["null", "string"], "default" : null },
-    {"name": "hasDefaultValues", "type": "boolean", "default" : false },
-    {"name": "hubMembership", "type": {"type": "array", "items": "EntityReference"}, "default" : [] },
-    {"name": "issues", "type": "IssueRecord", "default":{}},
-    {"name": "connectionParameters", "default" : null, "type" : ["null",
+  {
+    "name" : "EntityReference",
+    "namespace":"org.gbif.pipelines.io.avro",
+    "type" : "record",
+    "fields" : [
+      {"name": "uid", "type": ["null", "string"], "default" : null },
+      {"name": "name", "type": ["null", "string"], "default" : null },
+      {"name": "uri", "type": ["null", "string"], "default" : null }
+    ]
+  },
+  {
+    "name":"ALAMetadataRecord",
+    "namespace":"org.gbif.pipelines.io.avro",
+    "type":"record",
+    "doc":"ALA Metadata Record",
+    "fields":[
+      {"name": "id","type":"string"},
+      {"name": "dataResourceUid", "type": ["null", "string"], "default" : null },
+      {"name": "dataResourceName", "type": ["null", "string"], "default" : null },
+      {"name": "dataProviderUid", "type": ["null", "string"], "default" : null },
+      {"name": "dataProviderName", "type": ["null", "string"], "default" : null },
+      {"name": "collectionUid", "type": ["null", "string"], "default" : null },
+      {"name": "collectionName", "type": ["null", "string"], "default" : null },
+      {"name": "institutionUid", "type": ["null", "string"], "default" : null },
+      {"name": "institutionName", "type": ["null", "string"], "default" : null },
+      {"name": "licenseType", "type": ["null", "string"], "default" : null },
+      {"name": "licenseVersion", "type": ["null", "string"], "default" : null },
+      {"name": "provenance", "type": ["null", "string"], "default" : null },
+      {"name": "hasDefaultValues", "type": "boolean", "default" : false },
+      {"name": "hubMembership", "type": {"type": "array", "items": "EntityReference"}, "default" : [] },
+      {"name": "connectionParameters", "default" : null, "type" : ["null",
         {
           "name" : "ConnectionParameters",
           "type" : "record",
           "fields" : [
-			{"name": "protocol", "type": ["null", "string"], "default" : null },
-			{"name": "url", "type": ["null", "string"], "default" : null },
-			{"name": "termsForUniqueKey", "type": {"type": "array", "items": "string"}, "default" : [] }
+            {"name": "protocol", "type": ["null", "string"], "default" : null },
+            {"name": "url", "type": ["null", "string"], "default" : null },
+            {"name": "termsForUniqueKey", "type": {"type": "array", "items": "string"}, "default" : [] }
           ]
         }
       ]
-    }
-  ]
-}
+      }
+    ]
+  },
+  {
+    "name":"ALAAttributionRecord",
+    "namespace":"org.gbif.pipelines.io.avro",
+    "type":"record",
+    "doc":"ALA Attribution",
+    "fields":[
+      {"name": "id","type":"string"},
+      {"name": "dataResourceUid", "type": ["null", "string"], "default" : null },
+      {"name": "dataResourceName", "type": ["null", "string"], "default" : null },
+      {"name": "dataProviderUid", "type": ["null", "string"], "default" : null },
+      {"name": "dataProviderName", "type": ["null", "string"], "default" : null },
+      {"name": "collectionUid", "type": ["null", "string"], "default" : null },
+      {"name": "collectionName", "type": ["null", "string"], "default" : null },
+      {"name": "institutionUid", "type": ["null", "string"], "default" : null },
+      {"name": "institutionName", "type": ["null", "string"], "default" : null },
+      {"name": "licenseType", "type": ["null", "string"], "default" : null },
+      {"name": "licenseVersion", "type": ["null", "string"], "default" : null },
+      {"name": "provenance", "type": ["null", "string"], "default" : null },
+      {"name": "hasDefaultValues", "type": "boolean", "default" : false },
+      {"name": "hubMembership", "type": {"type": "array", "items": "EntityReference"}, "default" : [] },
+      {"name": "issues", "type": "IssueRecord", "default":{}}
+    ]
+  }
 ]


### PR DESCRIPTION
Fixes for issues:
 * https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/358
 * https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/357
 * https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/393
 
Also includes
* added `_version_` to SOLR schema to allow updates (for assertion support)
* enableLazyFieldLoading=false due to SOLR 8.8 bug
* removed speciesHabitats copyField
* Retries for collectory lookups and removal of silent failures
* Changes so that the collectory lookup for metadata is done only once  and at the start of the pipeline
* Fix validation-report (bad merge)
* zookeeper pom scope changed - required by validation report
* Fixes for ImageServiceLoadDiffPipelines - to remove the dependency on CSV export field order
* Mapping of Christmas Island and other external territories to AU
* Configurable intersection buffer to include records on coastline
* `text_recordedBy` and `text_identifiedBy` copy fields to support free text search of `recordedBy` and `identifiedBy` (required by AVH)
