### PR TITLE
#554 support triplet identifiers in clustering

### DIFF
--- a/gbif/pipelines/clustering-gbif/src/main/java/org/gbif/pipelines/clustering/RowOccurrenceFeatures.java
+++ b/gbif/pipelines/clustering-gbif/src/main/java/org/gbif/pipelines/clustering/RowOccurrenceFeatures.java
@@ -211,8 +211,12 @@ public class RowOccurrenceFeatures implements OccurrenceFeatures {
   }
 
   @Override
-  public List<String> listIdentifiers() {
-    return getStrings(
-        "occurrenceID", "fieldNumber", "recordNumber", "catalogNumber", "otherCatalogNumbers");
+  public String getInstitutionCode() {
+    return get("institutionCode");
+  }
+
+  @Override
+  public String getCollectionCode() {
+    return get("collectionCode");
   }
 }

--- a/gbif/pipelines/clustering-gbif/src/main/scala/org/gbif/pipelines/clustering/Cluster.scala
+++ b/gbif/pipelines/clustering-gbif/src/main/scala/org/gbif/pipelines/clustering/Cluster.scala
@@ -97,7 +97,8 @@ object Cluster {
             Option(r.getAs[String]("fieldNumber")),
             Option(r.getAs[String]("recordNumber")),
             Option(r.getAs[String]("catalogNumber")),
-            Option(r.getAs[String]("otherCatalogNumbers"))
+            Option(r.getAs[String]("otherCatalogNumbers")),
+            triplify(r) // ic:cc:cn format
           )
 
           // clean IDs

--- a/gbif/pipelines/clustering-gbif/src/main/scala/org/gbif/pipelines/clustering/package.scala
+++ b/gbif/pipelines/clustering-gbif/src/main/scala/org/gbif/pipelines/clustering/package.scala
@@ -1,5 +1,7 @@
 package org.gbif.pipelines
 
+import org.apache.spark.sql.Row
+
 package object clustering {
   // IDs to skip
   val omitIds = List("NO APLICA", "NA", "[]", "NO DISPONIBLE", "NO DISPONIBL", "NO NUMBER", "--", "UNKNOWN")
@@ -24,4 +26,16 @@ WHERE speciesKey IS NOT NULL
 """
 
   case class SimpleOccurrence(gbifID: String, decimalLatitude: Double)
+
+  /**
+   * @return A triplified version of the codes if all present, otherwise None
+   */
+  def triplify(r: Row) : Option[String] = {
+    val ic = Option(r.getAs[String]("institutionCode"));
+    val cc = Option(r.getAs[String]("collectionCode"));
+    val cn = Option(r.getAs[String]("catalogNumber"));
+
+    if (!ic.isEmpty && !cc.isEmpty && !cn.isEmpty) Option(ic.get + ":" + cc.get + ":" + cn.get)
+    else None
+  }
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/clustering/HashKeyOccurrence.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/clustering/HashKeyOccurrence.java
@@ -1,7 +1,5 @@
 package au.org.ala.clustering;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.schemas.JavaBeanSchema;
 import org.apache.beam.sdk.schemas.SchemaCoder;
@@ -35,6 +33,8 @@ public class HashKeyOccurrence implements OccurrenceFeatures {
   @Nullable String recordNumber = null;
   @Nullable String catalogNumber = null;
   @Nullable String otherCatalogNumbers = null;
+  @Nullable String institutionCode = null;
+  @Nullable String collectionCode = null;
 
   public @Nullable String getHashKey() {
     return hashKey;
@@ -225,23 +225,20 @@ public class HashKeyOccurrence implements OccurrenceFeatures {
   }
 
   @Override
-  public List<String> listIdentifiers() {
-    List<String> identifiers = new ArrayList<>();
-    if (occurrenceID != null) {
-      identifiers.add(occurrenceID);
-    }
-    if (fieldNumber != null) {
-      identifiers.add(fieldNumber);
-    }
-    if (recordNumber != null) {
-      identifiers.add(recordNumber);
-    }
-    if (catalogNumber != null) {
-      identifiers.add(catalogNumber);
-    }
-    if (otherCatalogNumbers != null) {
-      identifiers.add(otherCatalogNumbers);
-    }
-    return identifiers;
+  public @Nullable String getInstitutionCode() {
+    return institutionCode;
+  }
+
+  public void setInstitutionCode(@Nullable String institutionCode) {
+    this.institutionCode = institutionCode;
+  }
+
+  @Override
+  public @Nullable String getCollectionCode() {
+    return collectionCode;
+  }
+
+  public void setCollectionCode(@Nullable String collectionCode) {
+    this.collectionCode = collectionCode;
   }
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeatures.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeatures.java
@@ -1,6 +1,10 @@
 package org.gbif.pipelines.core.parsers.clustering;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The API to access the dimensions of an occurrence record necessary for clustering. Defined as an
@@ -47,5 +51,29 @@ public interface OccurrenceFeatures {
 
   String getOtherCatalogNumbers();
 
-  List<String> listIdentifiers();
+  String getInstitutionCode();
+
+  String getCollectionCode();
+
+  default List<String> listIdentifiers() {
+    return Stream.of(
+            getOccurrenceID(),
+            getFieldNumber(),
+            getRecordNumber(),
+            getCatalogNumber(),
+            getOtherCatalogNumbers(),
+            getTripleIdentifier())
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  /** @return a triplet identifier of standard form ic:cc:cn when all triplets are present */
+  default String getTripleIdentifier() {
+    String[] codes = {getInstitutionCode(), getCollectionCode(), getCatalogNumber()};
+    if (!Arrays.stream(codes).anyMatch(Objects::isNull)) {
+      return String.join(":", codes);
+    } else {
+      return null;
+    }
+  }
 }

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeaturesPojo.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeaturesPojo.java
@@ -1,9 +1,5 @@
 package org.gbif.pipelines.core.parsers.clustering;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.Builder;
 
 /** A POJO implementation for simple tests. */
@@ -29,6 +25,8 @@ public class OccurrenceFeaturesPojo implements OccurrenceFeatures {
   private final String recordNumber;
   private final String catalogNumber;
   private final String otherCatalogNumbers;
+  private final String institutionCode;
+  private final String collectionCode;
 
   @Override
   public String getId() {
@@ -131,14 +129,12 @@ public class OccurrenceFeaturesPojo implements OccurrenceFeatures {
   }
 
   @Override
-  public List<String> listIdentifiers() {
-    return Stream.of(
-            getOccurrenceID(),
-            getFieldNumber(),
-            getRecordNumber(),
-            getCatalogNumber(),
-            getOtherCatalogNumbers())
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+  public String getInstitutionCode() {
+    return institutionCode;
+  }
+
+  @Override
+  public String getCollectionCode() {
+    return collectionCode;
   }
 }

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceRelationshipsTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceRelationshipsTest.java
@@ -192,6 +192,35 @@ public class OccurrenceRelationshipsTest {
     assertTrue(assertion.justificationContainsAll(SAME_DATE, WITHIN_200m, SAME_ACCEPTED_SPECIES));
   }
 
+  // test that triplets used in e.g. catalogNumber will be handled (e.g. arctos, embl)
+  @Test
+  public void testMaterialiseTriplet() {
+    OccurrenceFeatures o1 =
+        OccurrenceFeaturesPojo.builder()
+            .id("1")
+            .datasetKey("1")
+            .speciesKey("1")
+            .institutionCode("A")
+            .collectionCode("B")
+            .catalogNumber("C")
+            .build();
+
+    OccurrenceFeatures o2 =
+        OccurrenceFeaturesPojo.builder()
+            .id("2")
+            .datasetKey("2")
+            .speciesKey("1")
+            .eventDate("20210101")
+            .decimalLatitude(1.0)
+            .decimalLongitude(1.0)
+            .catalogNumber("A:B:C")
+            .build();
+
+    RelationshipAssertion<OccurrenceFeatures> assertion = OccurrenceRelationships.generate(o1, o2);
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContainsAll(IDENTIFIERS_OVERLAP));
+  }
+
   @Test
   public void testNormaliseID() {
     assertEquals("ABC", OccurrenceRelationships.normalizeID(" A-/, B \\C"));


### PR DESCRIPTION
This materializes a "triple" from the IC, CC, CN to help match real-world data where triples are regularly seen in the catalogNumber field.

Addresses #554 