### PR TITLE
Removes case sensitivity for fields names for image sync

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ImagePipelineUtils.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ImagePipelineUtils.java
@@ -1,0 +1,58 @@
+package au.org.ala.pipelines.beam;
+
+import au.com.bytecode.opencsv.CSVParser;
+import au.org.ala.utils.ALAFsUtils;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.gbif.dwc.terms.Term;
+
+public class ImagePipelineUtils {
+
+  public static void validateHeaders(List<String> headers, List<String> requiredHeaders) {
+    for (String hdr : requiredHeaders) {
+      if (headers.indexOf(hdr.toLowerCase(Locale.ROOT)) < 0) {
+        throw new RuntimeException("Missing header: " + hdr);
+      }
+    }
+  }
+
+  public static int indexOf(List<String> headers, String header) {
+    return headers.indexOf(header.toLowerCase(Locale.ROOT));
+  }
+
+  public static int indexOf(List<String> headers, Term term) {
+    return headers.indexOf(term.simpleName().toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Read the headers, returning them lowercased
+   *
+   * @param fs
+   * @param imageServiceExportPath
+   * @return
+   * @throws IOException
+   */
+  public static List<String> readHeadersLowerCased(FileSystem fs, String imageServiceExportPath)
+      throws IOException {
+
+    InputStream input = ALAFsUtils.openInputStream(fs, imageServiceExportPath);
+    GZIPInputStream inputStream = new GZIPInputStream(input);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+    String headerLine = reader.readLine();
+    final CSVParser parser = new CSVParser();
+    List<String> headers =
+        Arrays.stream(parser.parseLine(headerLine))
+            .map(c -> c.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toList());
+    reader.close();
+    return headers;
+  }
+}

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ImageServicePipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ImageServicePipelineTestIT.java
@@ -4,6 +4,7 @@ import au.org.ala.pipelines.options.ImageServicePipelineOptions;
 import au.org.ala.util.TestUtils;
 import au.org.ala.utils.ValidationUtils;
 import java.io.File;
+import java.io.IOException;
 import okhttp3.mockwebserver.MockWebServer;
 import org.apache.commons.io.FileUtils;
 import org.gbif.pipelines.common.beam.options.DwcaPipelineOptions;
@@ -32,14 +33,15 @@ public class ImageServicePipelineTestIT {
 
   /** Test the generation of UUIDs for datasets that are use non-DwC terms for unique key terms */
   @Test
-  public void testNonDwC() {
+  public void testNonDwC() throws Exception {
     // dr1864 - has deviceId
     String absolutePath = new File("src/test/resources").getAbsolutePath();
     // Step 1: load a dataset and verify all records have a UUID associated
     loadTestDataset("dr893", absolutePath + "/image-service/dr893", "image-service");
   }
 
-  public void loadTestDataset(String datasetID, String inputPath, String testDir) {
+  public void loadTestDataset(String datasetID, String inputPath, String testDir)
+      throws IOException {
 
     DwcaPipelineOptions dwcaOptions =
         PipelinesOptionsFactory.create(

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ImageServicePipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/ImageServicePipelineTestIT.java
@@ -93,7 +93,10 @@ public class ImageServicePipelineTestIT {
     String absolutePath = new File("src/test/resources").getAbsolutePath();
     String imageServiceExportPath =
         absolutePath + "/" + testDir + "/" + datasetID + "/image-service-export.csv";
+    String imageServiceExportPathGz = imageServiceExportPath + ".gz";
 
-    ImageServiceSyncPipeline.run(imageOptions, imageServiceExportPath);
+    TestUtils.compressGzip(imageServiceExportPath, imageServiceExportPathGz);
+
+    ImageServiceSyncPipeline.run(imageOptions, imageServiceExportPathGz);
   }
 }

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/NonImageServicePipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/NonImageServicePipelineTestIT.java
@@ -32,14 +32,14 @@ public class NonImageServicePipelineTestIT {
 
   /** Test the generation of UUIDs for datasets that are use non-DwC terms for unique key terms */
   @Test
-  public void testNonDwC() {
+  public void testNonDwC() throws Exception {
     // dr1864 - has deviceId
     String absolutePath = new File("src/test/resources").getAbsolutePath();
     // Step 1: load a dataset and verify all records have a UUID associated
     loadTestDataset("dr893", absolutePath + "/image-service-non/dr893", "image-service-non");
   }
 
-  public void loadTestDataset(String datasetID, String inputPath, String testDir) {
+  public void loadTestDataset(String datasetID, String inputPath, String testDir) throws Exception {
 
     DwcaPipelineOptions dwcaOptions =
         PipelinesOptionsFactory.create(

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/NonImageServicePipelineTestIT.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/beam/NonImageServicePipelineTestIT.java
@@ -91,7 +91,9 @@ public class NonImageServicePipelineTestIT {
     String absolutePath = new File("src/test/resources").getAbsolutePath();
     String imageServiceExportPath =
         absolutePath + "/" + testDir + "/" + datasetID + "/image-service-export.csv";
+    String imageServiceExportPathGz = imageServiceExportPath + ".gz";
+    TestUtils.compressGzip(imageServiceExportPath, imageServiceExportPathGz);
 
-    ImageServiceSyncPipeline.run(imageOptions, imageServiceExportPath);
+    ImageServiceSyncPipeline.run(imageOptions, imageServiceExportPathGz);
   }
 }

--- a/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/util/TestUtils.java
@@ -3,7 +3,11 @@ package au.org.ala.util;
 import au.org.ala.kvs.ALAPipelinesConfig;
 import au.org.ala.kvs.ALAPipelinesConfigFactory;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URL;
+import java.util.zip.GZIPOutputStream;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -123,5 +127,18 @@ public class TestUtils {
         };
     server.setDispatcher(dispatcher);
     return server;
+  }
+
+  public static void compressGzip(String source, String target) throws IOException {
+
+    try (GZIPOutputStream gos = new GZIPOutputStream(new FileOutputStream(target));
+        FileInputStream fis = new FileInputStream(source)) {
+      // copy file
+      byte[] buffer = new byte[1024];
+      int len;
+      while ((len = fis.read(buffer)) > 0) {
+        gos.write(buffer, 0, len);
+      }
+    }
   }
 }

--- a/livingatlas/pipelines/src/test/resources/image-service-non/dr893/image-service-export.csv
+++ b/livingatlas/pipelines/src/test/resources/image-service-non/dr893/image-service-export.csv
@@ -1,5 +1,6 @@
-image-service-id-1,http://www.bowerbird.org.au/observations/49875/fakeImage.jpg
-image-service-id-2,http://www.bowerbird.org.au/observations/48531/fakeImage2.jpg
-image-service-id-3,http://www.bowerbird.org.au/observations/98064/fakeImage.jpg
-image-service-id-4,http://www.bowerbird.org.au/observations/4810/fakeImage.jpg
-image-service-id-5,http://www.bowerbird.org.au/observations/76433/fakeImage.jpg
+imageid,identifier,creator,format,license
+image-service-id-1,http://www.bowerbird.org.au/observations/49875/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-2,http://www.bowerbird.org.au/observations/48531/fakeImage2.jpg,dummy user,image/jpg,CC0
+image-service-id-3,http://www.bowerbird.org.au/observations/98064/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-4,http://www.bowerbird.org.au/observations/4810/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-5,http://www.bowerbird.org.au/observations/76433/fakeImage.jpg,dummy user,image/jpg,CC0

--- a/livingatlas/pipelines/src/test/resources/image-service/dr893/image-service-export.csv
+++ b/livingatlas/pipelines/src/test/resources/image-service/dr893/image-service-export.csv
@@ -1,5 +1,6 @@
-image-service-id-1,http://www.bowerbird.org.au/observations/49875/fakeImage.jpg
-image-service-id-2,http://www.bowerbird.org.au/observations/48531/fakeImage2.jpg
-image-service-id-3,http://www.bowerbird.org.au/observations/98064/fakeImage.jpg
-image-service-id-4,http://www.bowerbird.org.au/observations/4810/fakeImage.jpg
-image-service-id-5,http://www.bowerbird.org.au/observations/76433/fakeImage.jpg
+imageid,identifier,creator,format,license
+image-service-id-1,http://www.bowerbird.org.au/observations/49875/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-2,http://www.bowerbird.org.au/observations/48531/fakeImage2.jpg,dummy user,image/jpg,CC0
+image-service-id-3,http://www.bowerbird.org.au/observations/98064/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-4,http://www.bowerbird.org.au/observations/4810/fakeImage.jpg,dummy user,image/jpg,CC0
+image-service-id-5,http://www.bowerbird.org.au/observations/76433/fakeImage.jpg,dummy user,image/jpg,CC0


### PR DESCRIPTION
Work https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/434
Also removes the hardcoded requirement for column positions. See [this code](https://github.com/gbif/pipelines/pull/558/files#diff-86ee2daf79702ac5b1713e3bed0ca05e9a948647a8cab3770041a6fc17baacdcL166)