### PR TITLE
Add missing config to SOLR /export requestHandler

### DIFF
--- a/livingatlas/solr/conf/solrconfig.xml
+++ b/livingatlas/solr/conf/solrconfig.xml
@@ -851,6 +851,14 @@
       <str name="wt">json</str>
       <str name="df">text</str>
     </lst>
+    <lst name="invariants">
+      <str name="rq">{!xport}</str>
+      <bool name="distrib">false</bool>
+    </lst>
+    <arr name="components">
+      <str>query</str>
+    </arr>
+    <str name="useParams">_EXPORT</str>
   </requestHandler>
 
   <!-- realtime get handler, guaranteed to return the latest stored fields of


### PR DESCRIPTION
Can be test with an export request. e.g. `http://localhost:8983/solr/biocache/export?q=year:1910&fl=id&sort=id%20asc`.

Test the `df` by using an appropriate search term for `q`.