### PR TITLE
Fix: https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/487

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDMintingPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDMintingPipeline.java
@@ -184,7 +184,9 @@ public class ALAUUIDMintingPipeline {
                             options.getTargetPath(),
                             options.getDatasetId().trim(),
                             options.getAttempt().toString(),
-                            "verbatim.avro")))
+                            "interpreted",
+                            "verbatim",
+                            "*.avro")))
             .apply(
                 ParDo.of(
                     new DoFn<ExtendedRecord, KV<String, String>>() {

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDValidationPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDValidationPipeline.java
@@ -153,7 +153,9 @@ public class ALAUUIDValidationPipeline {
                           options.getTargetPath(),
                           options.getDatasetId().trim(),
                           options.getAttempt().toString(),
-                          "verbatim.avro")));
+                          "interpreted",
+                          "verbatim",
+                          "*.avro")));
 
       // check all records have valid keys
       PCollection<String> invalidKeyResults =


### PR DESCRIPTION
Fixes the UUID generation for event core archives.
This change means the uuid pipeline needs to be ran after the interpretation pipeline.