### PR TITLE
Reorder and rename of la-pipelines steps

### DIFF
--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -70,54 +70,54 @@ The $CMD can be executed to run all the ingress steps or only a few of them:
 
 Pipeline ingress steps:
 
-    ┌───── do-all ───────────────────────────────────────────────┐
-    │                                                            │
-dwca-avro --> interpret --> validate --> uuid --> image-sync ... │
-  --> image-load --> sds --> index --> sample --> jackknife --> solr
+    ┌───── do-all ───────────────────────────────────────────────────────┐
+    │                                                                    │
+dwca-avro --> interpret --> validate --> uuid --> sds --> image-load ... │
+                 --> image-sync --> index --> sample --> jackknife --> solr
 
 -  'dwca-avro' reads a Dwc-A and converts it to an verbatim.avro file;
 -  'interpret' reads verbatim.avro, interprets it and writes the interpreted data and the issues to Avro files;
--  'sds' runs the sensitive data checks;
 -  'validate' validates the identifiers for a dataset, checking for duplicate and empty keys;
 -  'uuid' mints UUID on new records and rematches to existing UUIDs for records loaded before;
--  'migrate' used for migration;
+-  'sds' runs the sensitive data checks;
 -  'image-load' pushes an export of multimedia AVRO files to the image service;
 -  'image-sync' retrieves details of images stored in image service for indexing purposes;
--  'sample' use the sampling service to retrieve values for points for the layers in the spatial service;
 -  'index' generates a AVRO records ready to be index to SOLR;
+-  'sample' use the sampling service to retrieve values for points for the layers in the spatial service;
 -  'jackknife' adds an aggregated jackknife AVRO for all datasets. Requires samping-avro. After running a full 'index' is required.
 -  'solr' reads index records in AVRO and submits them to SOLR;
--  'solr-sync' sync schema
+-  'solr-schema' sync schema
 -  'archive-list' dumps out a list of archives that can be ingested to '/tmp/dataset-archive-list.csv';
 -  'dataset-list' dumps out a list of datasets that have been ingested to '/tmp/dataset-counts.csv';
 -  'validation-report' dumps out a CSV list of datasets ready to be indexed to '/tmp/validation-report.csv';
 -  'clustering' clustering of occurrences;
 -  'prune-datasets' remove any datasets no longer registered in the collectory;
 -  'dwca-export' export a dwca archive;
+-  'migrate' used for migration;
 
 All the steps generate an output. If only the final output is desired, the intermediate outputs can be ignored.
 
 Usage:
-  $CMD [options] archive-list
-  $CMD [options] dataset-list
   $CMD [options] dwca-avro     (<dr>...|all)
   $CMD [options] interpret     (<dr>...|all)         $WHEREL
-  $CMD [options] sds           (<dr>...|all)         $WHEREL
   $CMD [options] validate      (<dr>...|all)         $WHERE
   $CMD [options] uuid          (<dr>...|all)         $WHERE
-  $CMD [options] migrate  (<dr>...|all)         $WHERE
-  $CMD [options] image-sync    (<dr>...|all)         $WHERE
+  $CMD [options] sds           (<dr>...|all)         $WHEREL
   $CMD [options] image-load    (<dr>...|all)         $WHERE
+  $CMD [options] image-sync    (<dr>...|all)         $WHERE
   $CMD [options] index         (<dr>...|all)         $WHEREL
   $CMD [options] sample        (<dr>...|all)         $WHERE
-  $CMD [options] jackknife     (all)                 $WHERE
   $CMD [options] clustering    (all)                 $WHERE
+  $CMD [options] jackknife     (all)                 $WHERE
   $CMD [options] solr          (<dr>...|all)         $WHERE
-  $CMD [options] solr-sync          (<dr>...|all)         $WHERE
+  $CMD [options] solr-schema   (<dr>...|all)         $WHERE
+  $CMD [options] archive-list
+  $CMD [options] dataset-list
   $CMD [options] prune-datasets
   $CMD [options] validation-report
-  $CMD [options] do-all        (<dr>...|all) $WHEREL
-  $CMD [options] dwca-export     (<dr>...|all)         $WHERE
+  $CMD [options] do-all        (<dr>...|all)         $WHEREL
+  $CMD [options] dwca-export   (<dr>...|all)         $WHERE
+  $CMD [options] migrate       (<dr>...|all)         $WHERE
   $CMD -h | --help
   $CMD -v | --version
 
@@ -842,38 +842,15 @@ if ($validate || $do_all); then
     do_step validate
 fi
 
-if ($dwca_export || $do_all); then
+if ($dwca_export); then
     do_step dwca_export
 fi
 
 if ($uuid || $do_all); then
     do_step uuid
 fi
-
-if ($migrate); then
-    do_step migrate
-fi
-
-if ($image_sync || $do_all); then
-  if [[ $drs != "all" ]] ; then
-      for d in "${drs[@]}"; do
-          image-sync $d $TYPE
-      done
-  else
-      while IFS=, read -r datasetID recordCount
-      do
-          log.info "Dataset = $datasetID and count = $recordCount"
-          if [ "$recordCount" -gt "50000" ]; then
-              if [ $USE_CLUSTER = true ]; then
-                  image-sync $datasetID spark-cluster
-              else
-                  image-sync $datasetID spark-embedded
-              fi
-          else
-              image-sync $datasetID spark-embedded
-          fi
-      done < /tmp/dataset-counts.csv
-  fi
+if ($sds || $do_all); then
+    do_step sds
 fi
 
 if ($image_load || $do_all); then
@@ -898,8 +875,26 @@ if ($image_load || $do_all); then
     fi
 fi
 
-if ($sds || $do_all); then
-    do_step sds
+if ($image_sync || $do_all); then
+  if [[ $drs != "all" ]] ; then
+      for d in "${drs[@]}"; do
+          image-sync $d $TYPE
+      done
+  else
+      while IFS=, read -r datasetID recordCount
+      do
+          log.info "Dataset = $datasetID and count = $recordCount"
+          if [ "$recordCount" -gt "50000" ]; then
+              if [ $USE_CLUSTER = true ]; then
+                  image-sync $datasetID spark-cluster
+              else
+                  image-sync $datasetID spark-embedded
+              fi
+          else
+              image-sync $datasetID spark-embedded
+          fi
+      done < /tmp/dataset-counts.csv
+  fi
 fi
 
 if ($index || $do_all); then
@@ -930,10 +925,13 @@ if ($solr || $do_all); then
   do_step_simple solr
 fi
 
-if ($solr_sync || $do_all); then
+if ($solr_schema || $do_all); then
   do_step_simple solr-sync
 fi
 
+if ($migrate); then
+    do_step migrate
+fi
 
 # All ended correctly, so untrap EXIT catch
 trap - EXIT


### PR DESCRIPTION
Reviewing the documentation in:
https://confluence.csiro.au/display/CIU/Process+overview+and+issues
and talking with @djtfmartin I reordered and renamed some la-pipelines steps.

The help looks like now:

```
$ la-pipelines -h
LA-Pipelines data ingress utility.

The la-pipelines can be executed to run all the ingress steps or only a few of them:

Pipeline ingress steps:

    ┌───── do-all ───────────────────────────────────────────────────────┐
    │                                                                    │
dwca-avro --> interpret --> validate --> uuid --> sds --> image-load ... │
                 --> image-sync --> index --> sample --> jackknife --> solr

-  'dwca-avro' reads a Dwc-A and converts it to an verbatim.avro file;
-  'interpret' reads verbatim.avro, interprets it and writes the interpreted data and the issues to Avro files;
-  'validate' validates the identifiers for a dataset, checking for duplicate and empty keys;
-  'uuid' mints UUID on new records and rematches to existing UUIDs for records loaded before;
-  'sds' runs the sensitive data checks;
-  'image-load' pushes an export of multimedia AVRO files to the image service;
-  'image-sync' retrieves details of images stored in image service for indexing purposes;
-  'index' generates a AVRO records ready to be index to SOLR;
-  'sample' use the sampling service to retrieve values for points for the layers in the spatial service;
-  'jackknife' adds an aggregated jackknife AVRO for all datasets. Requires samping-avro. After running a full 'index' is required.
-  'solr' reads index records in AVRO and submits them to SOLR;
-  'solr-schema' sync schema
-  'archive-list' dumps out a list of archives that can be ingested to '/tmp/dataset-archive-list.csv';
-  'dataset-list' dumps out a list of datasets that have been ingested to '/tmp/dataset-counts.csv';
-  'validation-report' dumps out a CSV list of datasets ready to be indexed to '/tmp/validation-report.csv';
-  'clustering' clustering of occurrences;
-  'prune-datasets' remove any datasets no longer registered in the collectory;
-  'dwca-export' export a dwca archive;
-  'migrate' used for migration;

All the steps generate an output. If only the final output is desired, the intermediate outputs can be ignored.

Usage:
  la-pipelines [options] dwca-avro     (<dr>...|all)
  la-pipelines [options] interpret     (<dr>...|all)         [--local|--embedded|--cluster]
  la-pipelines [options] validate      (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] uuid          (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] sds           (<dr>...|all)         [--local|--embedded|--cluster]
  la-pipelines [options] image-load    (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] image-sync    (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] index         (<dr>...|all)         [--local|--embedded|--cluster]
  la-pipelines [options] sample        (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] clustering    (all)                 [--embedded|--cluster]
  la-pipelines [options] jackknife     (all)                 [--embedded|--cluster]
  la-pipelines [options] solr          (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] solr-schema   (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] archive-list
  la-pipelines [options] dataset-list
  la-pipelines [options] prune-datasets
  la-pipelines [options] validation-report
  la-pipelines [options] do-all        (<dr>...|all)         [--local|--embedded|--cluster]
  la-pipelines [options] dwca-export   (<dr>...|all)         [--embedded|--cluster]
  la-pipelines [options] migrate       (<dr>...|all)         [--embedded|--cluster]
  la-pipelines -h | --help
  la-pipelines -v | --version

Options:
  --config=<files>     Comma separated list of alternative la-pipeline yaml configurations (the last file has the highest precedence).
  --extra-args=<args>  Additional "arg1=values,arg2=value" to pass to pipeline options (highest precedence than yml values).
  --no-colors          No colorize logs output.
  --dry-run            Print the commands without actually running them.
  --debug              Debug la-pipelines.
  -h --help            Show this help.
  -v --version         Show version.
```

And the equivalent in the la-toolkit:

https://user-images.githubusercontent.com/180085/135055604-3f26ee4d-4865-4982-b40b-34db3aaa5e3c.mp4

