### PR TITLE
Fixed the version check of yq in lapipelines script which was matching against incorrect version of YQ.

### DIFF
--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -21,7 +21,8 @@ then
 fi
 
 # https://mikefarah.gitbook.io/yq/upgrading-from-v3
-if [[ "$(yq -V 2>&1)" =~ .*3.?.?.* ]]
+YQ_VERSION="$(yq -V  | sed 's/.* //g')"
+if [[ $YQ_VERSION =~ ^3 ]]
 then
     function YQ_VERIFY() {
         cat "$1" | yq v -
@@ -31,7 +32,7 @@ then
         echo "$OUT"
     }
 else
-    if [[ "$(yq -V 2>&1)" =~ .*4.?.?.* ]]
+    if [[ $YQ_VERSION =~ ^4 ]]
 then
     function YQ_VERIFY() {
         cat "$1" | yq e 'true' - > /dev/null


### PR DESCRIPTION
Fixed the version check of yq which was matching against incorrect version of yq in certain circumstances, e.g. 4.13.0 was being evaluated to version 3.

Fixes #609 