### PR TITLE
685 sampling hashing

### DIFF
--- a/livingatlas/configs/la-pipelines-emr.yaml
+++ b/livingatlas/configs/la-pipelines-emr.yaml
@@ -66,6 +66,7 @@ index:
   allDatasetsInputPath: hdfs:///pipelines-all-datasets
 
 solr:
+  numOfPartitions: 10
   inputPath: hdfs:///pipelines-data
   targetPath: hdfs:///pipelines-data
   allDatasetsInputPath: hdfs:///pipelines-all-datasets

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToSolrPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordToSolrPipeline.java
@@ -18,15 +18,15 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.extensions.joinlibrary.Join;
 import org.apache.beam.sdk.io.AvroIO;
 import org.apache.beam.sdk.io.solr.SolrIO;
 import org.apache.beam.sdk.transforms.*;
-import org.apache.beam.sdk.transforms.Partition.PartitionFn;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
 import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
 import org.apache.beam.sdk.values.*;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.directory.api.util.Strings;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaResponse;
@@ -39,12 +39,27 @@ import org.jetbrains.annotations.NotNull;
 import org.joda.time.Duration;
 import org.slf4j.MDC;
 
-/** Pipeline that joins sample data and index records and indexes to SOLR. */
+/**
+ * Pipeline that joins index records with:
+ * 1) sample data (environmental and contextual properties)
+ * 2) jacknife environmental outlier information
+ * 3) clustering (duplicate detection)
+ * 4) expert distribution outlier information
+ * and then indexes to SOLR.
+ *
+ * Jackknife, clustering and expert distribution are joined with IndexRecords in a single CoGroupByKey
+ * as they are all using occurrenceIDs. These output are generated in other pipelines which are ran prior
+ * to running this one.
+ *
+ * Sampling is joined to IndexRecords using a latitude_longitude string.
+ * */
 @Slf4j
 public class IndexRecordToSolrPipeline {
 
   static final SampleRecord nullSampling = SampleRecord.newBuilder().setLatLng("NO_VALUE").build();
+
   public static final String EMPTY = "EMPTY";
+  static final IndexRecord nullIndexRecord = IndexRecord.newBuilder().setId(EMPTY).build();
   static final JackKnifeOutlierRecord nullJkor =
       JackKnifeOutlierRecord.newBuilder().setId(EMPTY).setItems(new ArrayList<>()).build();
   static final Relationships nullClustering =
@@ -67,129 +82,98 @@ public class IndexRecordToSolrPipeline {
     System.exit(0);
   }
 
-  public static boolean hasCoordinates(IndexRecord indexRecord) {
-    return indexRecord.getLatLng() != null;
-  }
-
   public static void run(SolrPipelineOptions options) {
 
     final List<String> schemaFields = getSchemaFields(options);
     final List<String> dynamicFieldPrefixes = getSchemaDynamicFieldPrefixes(options);
+    final int numOfPartitions = options.getNumOfPartitions();
 
     Pipeline pipeline = Pipeline.create(options);
 
     // Load IndexRecords - keyed on UUID
     PCollection<KV<String, IndexRecord>> indexRecordsCollection =
         loadIndexRecords(options, pipeline);
+    PCollection<KV<String, JackKnifeOutlierRecord>> jackKnife =
+        loadJackKnifeRecords(options, pipeline);
+    PCollection<KV<String, Relationships>> clusters = loadClusteringRecords(options, pipeline);
+    PCollection<KV<String, DistributionOutlierRecord>> outliers =
+        loadOutlierRecords(options, pipeline);
 
-    // If configured to do so, include jack knife information
-    if (options.getIncludeJackKnife()) {
-      log.info("Adding jack knife to the index");
-      indexRecordsCollection = addJacknifeInfo(options, pipeline, indexRecordsCollection);
-    } else {
-      log.info("Skipping adding jack knife to the index");
-    }
+    // Co group IndexRecords with coordinates with Sample data
+    final TupleTag<IndexRecord> indexRecordTag = new TupleTag<>();
+    final TupleTag<JackKnifeOutlierRecord> jackknifeTag = new TupleTag<>();
+    final TupleTag<Relationships> clusterTag = new TupleTag<>();
+    final TupleTag<DistributionOutlierRecord> outliersTag = new TupleTag<>();
 
-    // If configured to do so, include jack knife information
-    if (options.getIncludeClustering()) {
-      log.info("Adding clustering to the index");
-      indexRecordsCollection = addClusteringInfo(options, pipeline, indexRecordsCollection);
-    } else {
-      log.info("Skipping adding clustering to the index");
-    }
+    // Join collections by LatLng string
+    PCollection<KV<String, CoGbkResult>> results =
+        KeyedPCollectionTuple.of(indexRecordTag, indexRecordsCollection)
+            .and(jackknifeTag, jackKnife)
+            .and(clusterTag, clusters)
+            .and(outliersTag, outliers)
+            .apply(CoGroupByKey.create());
 
-    if (options.getIncludeOutlier()) {
-      log.info("Adding outlier to the index");
-      indexRecordsCollection = addOutlierInfo(options, pipeline, indexRecordsCollection);
-    } else {
-      log.info("Skipping adding outlier to the index");
-    }
+    // run the CoGroupByKey
+    indexRecordsCollection =
+        results.apply(
+            ParDo.of(joinProcessing(indexRecordTag, jackknifeTag, clusterTag, outliersTag)));
 
-    PCollection<KV<String, IndexRecord>> recordsWithoutCoordinates = null;
+    PCollection<IndexRecord> readyToIndex = null;
 
     if (options.getIncludeSampling()) {
 
       log.info("Adding sampling to the index");
 
       // Load Samples - keyed on LatLng
-      PCollection<KV<String, SampleRecord>> sampleRecords = loadSampleRecords(options, pipeline);
+      PCollection<KV<String, SampleRecord>> sampleRecords =
+          loadSampleRecords(options, pipeline, numOfPartitions);
 
-      // Split into records with coordinates and records without
-      // Filter records with coordinates - we will join these to samples
-      PCollection<KV<String, IndexRecord>> recordsWithCoordinates =
+      // partition into withCoordinates and withoutCoordinates...
+      PCollectionList<KV<String, IndexRecord>> partitions =
           indexRecordsCollection.apply(
-              Filter.by(indexRecord -> hasCoordinates(indexRecord.getValue())));
+              Partition.of(
+                  2,
+                  (Partition.PartitionFn<KV<String, IndexRecord>>)
+                      (elem, numPartitions) -> hasCoordinates(elem.getValue()) ? 0 : 1));
 
-      // Filter records without coordinates - we will index, but not sample these
-      recordsWithoutCoordinates =
-          indexRecordsCollection.apply(
-              Filter.by(indexRecord -> !hasCoordinates(indexRecord.getValue())));
+      PCollection<KV<String, IndexRecord>> recordsWithCoordinates = partitions.get(0);
+      PCollection<IndexRecord> recordsWithoutCoordinates = partitions.get(1).apply(Values.create());
 
       // Convert to KV <LatLng, IndexRecord>
-      PCollection<KV<String, IndexRecord>> recordsWithCoordinatesKeyedLatng =
+      PCollection<KV<String, IndexRecord>> indexRecordsKeyedLatng =
           recordsWithCoordinates.apply(
               MapElements.via(
                   new SimpleFunction<KV<String, IndexRecord>, KV<String, IndexRecord>>() {
                     @Override
                     public KV<String, IndexRecord> apply(KV<String, IndexRecord> input) {
+                      // add hash
+                      Random ran = new Random();
+                      // values 0 to numOfPartitions
+                      int x = ran.nextInt(numOfPartitions - 1);
                       String latLng =
-                          input.getValue().getLatLng() == null
-                              ? "NO_LAT_LNG"
-                              : input.getValue().getLatLng();
+                          Strings.isEmpty(input.getValue().getLatLng())
+                              ? input
+                                  .getValue()
+                                  .getId() // just need a unique ID so there is no join
+                              : x + "-" + input.getValue().getLatLng();
                       return KV.of(latLng, input.getValue());
                     }
                   }));
 
-      final Integer noOfPartitions = options.getNumOfPartitions();
-      PCollection<KV<String, IndexRecord>> pcs = null;
-
-      if (noOfPartitions > 1) {
-
-        PCollectionList<KV<String, IndexRecord>> partitions =
-            recordsWithCoordinatesKeyedLatng.apply(
-                Partition.of(
-                    noOfPartitions,
-                    (PartitionFn<KV<String, IndexRecord>>)
-                        (elem, numPartitions) ->
-                            (elem.getValue().getInts().get(DwcTerm.month.simpleName()) != null
-                                    ? elem.getValue().getInts().get(DwcTerm.month.simpleName())
-                                    : 0)
-                                % noOfPartitions));
-
-        PCollectionList<KV<String, IndexRecord>> pcl = null;
-        for (int i = 0; i < noOfPartitions; i++) {
-          PCollection<KV<String, IndexRecord>> p =
-              joinSampleRecord(sampleRecords, partitions.get(i));
-          if (i == 0) {
-            pcl = PCollectionList.of(p);
-          } else {
-            pcl = pcl.and(p);
-          }
-        }
-
-        pcs = pcl.apply(Flatten.pCollections());
-
-      } else {
-        pcs = joinSampleRecord(sampleRecords, recordsWithCoordinatesKeyedLatng);
-      }
-
-      log.info("Adding step 4: Create SOLR connection");
+      // add sampling to records with coordinates
+      readyToIndex = joinSampleRecord(indexRecordsKeyedLatng, sampleRecords);
       SolrIO.ConnectionConfiguration conn =
           SolrIO.ConnectionConfiguration.create(options.getZkHost());
 
-      writeToSolr(options, pcs, conn, schemaFields, dynamicFieldPrefixes);
-
-      if (recordsWithoutCoordinates != null) {
-        log.info("Adding step 5: Write records (without coordinates) to SOLR");
-        writeToSolr(options, recordsWithoutCoordinates, conn, schemaFields, dynamicFieldPrefixes);
-      }
+      writeToSolr(options, readyToIndex, conn, schemaFields, dynamicFieldPrefixes);
+      writeToSolr(options, recordsWithoutCoordinates, conn, schemaFields, dynamicFieldPrefixes);
 
     } else {
+      readyToIndex = indexRecordsCollection.apply(Values.create());
       log.info("Adding step 4: Create SOLR connection");
       SolrIO.ConnectionConfiguration conn =
           SolrIO.ConnectionConfiguration.create(options.getZkHost());
-
-      writeToSolr(options, indexRecordsCollection, conn, schemaFields, dynamicFieldPrefixes);
+      writeToSolr(options, readyToIndex, conn, schemaFields, dynamicFieldPrefixes);
     }
 
     log.info("Starting pipeline");
@@ -198,11 +182,15 @@ public class IndexRecordToSolrPipeline {
     log.info("Solr indexing pipeline complete");
   }
 
+  public static boolean hasCoordinates(IndexRecord indexRecord) {
+    return indexRecord.getLatLng() != null;
+  }
+
   @NotNull
   private static List<String> getSchemaFields(SolrPipelineOptions options) {
-    try {
-      CloudSolrClient client =
-          new CloudSolrClient.Builder().withZkHost(options.getZkHost()).build();
+    try (CloudSolrClient client =
+        new CloudSolrClient.Builder(ImmutableList.of(options.getZkHost()), Optional.empty())
+            .build()) {
       SchemaRequest.Fields fields = new SchemaRequest.Fields();
       SchemaResponse.FieldsResponse response = fields.process(client, options.getSolrCollection());
       return response.getFields().stream()
@@ -215,9 +203,9 @@ public class IndexRecordToSolrPipeline {
 
   @NotNull
   private static List<String> getSchemaDynamicFieldPrefixes(SolrPipelineOptions options) {
-    try {
-      CloudSolrClient client =
-          new CloudSolrClient.Builder().withZkHost(options.getZkHost()).build();
+    try (CloudSolrClient client =
+        new CloudSolrClient.Builder(ImmutableList.of(options.getZkHost()), Optional.empty())
+            .build()) {
       SchemaRequest.DynamicFields fields = new SchemaRequest.DynamicFields();
       SchemaResponse.DynamicFieldsResponse response =
           fields.process(client, options.getSolrCollection());
@@ -229,95 +217,45 @@ public class IndexRecordToSolrPipeline {
     }
   }
 
-  private static PCollection<KV<String, IndexRecord>> joinSampleRecord(
-      PCollection<KV<String, SampleRecord>> sampleRecords,
-      PCollection<KV<String, IndexRecord>> recordsWithCoordinatesKeyedLatng) {
-    PCollection<KV<String, IndexRecord>> indexRecordsCollection;
+  private static PCollection<IndexRecord> joinSampleRecord(
+      PCollection<KV<String, IndexRecord>> indexRecords,
+      PCollection<KV<String, SampleRecord>> sampleRecords) {
+
     // Co group IndexRecords with coordinates with Sample data
     final TupleTag<IndexRecord> indexRecordTag = new TupleTag<>();
     final TupleTag<SampleRecord> samplingTag = new TupleTag<>();
 
     // Join collections by LatLng string
     PCollection<KV<String, CoGbkResult>> results =
-        KeyedPCollectionTuple.of(samplingTag, sampleRecords)
-            .and(indexRecordTag, recordsWithCoordinatesKeyedLatng)
+        KeyedPCollectionTuple.of(indexRecordTag, indexRecords)
+            .and(samplingTag, sampleRecords)
             .apply(CoGroupByKey.create());
 
     // Create collection which contains samples keyed with indexRecord.id
     return results.apply(ParDo.of(joinSampling(indexRecordTag, samplingTag)));
   }
 
-  private static PCollection<KV<String, IndexRecord>> addJacknifeInfo(
-      SolrPipelineOptions options,
-      Pipeline pipeline,
-      PCollection<KV<String, IndexRecord>> indexRecords) {
-
-    // Load Jackknife, keyed on ID
-    PCollection<KV<String, JackKnifeOutlierRecord>> jackKnifeRecordsKeyedRecordID =
-        loadJackKnifeRecords(options, pipeline);
-
-    // Join indexRecordsSampling and jackKnife
-    PCollection<KV<String, KV<IndexRecord, JackKnifeOutlierRecord>>>
-        indexRecordSamplingJoinJackKnife =
-            Join.leftOuterJoin(indexRecords, jackKnifeRecordsKeyedRecordID, nullJkor);
-
-    // Add Jackknife information
-    return indexRecordSamplingJoinJackKnife.apply(ParDo.of(addJackknifeInfo()));
-  }
-
-  private static PCollection<KV<String, IndexRecord>> addClusteringInfo(
-      SolrPipelineOptions options,
-      Pipeline pipeline,
-      PCollection<KV<String, IndexRecord>> indexRecords) {
-
-    // Load clustering, keyed on ID
-    PCollection<KV<String, Relationships>> clusteringRecordsKeyedRecordID =
-        loadClusteringRecords(options, pipeline);
-
-    // Join indexRecordsSampling and jackKnife
-    PCollection<KV<String, KV<IndexRecord, Relationships>>> indexRecordJoinClustering =
-        Join.leftOuterJoin(indexRecords, clusteringRecordsKeyedRecordID, nullClustering);
-
-    // Add Jackknife information
-    return indexRecordJoinClustering.apply(ParDo.of(addClusteringInfo()));
-  }
-
-  private static PCollection<KV<String, IndexRecord>> addOutlierInfo(
-      SolrPipelineOptions options,
-      Pipeline pipeline,
-      PCollection<KV<String, IndexRecord>> indexRecords) {
-
-    // Load outlier records, keyed on ID
-    PCollection<KV<String, DistributionOutlierRecord>> outlierRecords =
-        loadOutlierRecords(options, pipeline);
-    PCollection<KV<String, KV<IndexRecord, DistributionOutlierRecord>>> indexRecordJoinOurlier =
-        Join.leftOuterJoin(indexRecords, outlierRecords, nullOutlier);
-
-    // Add Jackknife information
-    return indexRecordJoinOurlier.apply(ParDo.of(addOutlierInfo()));
-  }
-
   private static void writeToSolr(
       SolrPipelineOptions options,
-      PCollection<KV<String, IndexRecord>> kvIndexRecords,
+      PCollection<IndexRecord> indexRecords,
       SolrIO.ConnectionConfiguration conn,
       final List<String> schemaFields,
       final List<String> dynamicFieldPrefixes) {
 
     if (options.getOutputAvroToFilePath() == null) {
 
-      kvIndexRecords
+      indexRecords
           .apply(
               "IndexRecord to SOLR Document",
               ParDo.of(
-                  new DoFn<KV<String, IndexRecord>, SolrInputDocument>() {
+                  new DoFn<IndexRecord, SolrInputDocument>() {
                     @DoFn.ProcessElement
                     public void processElement(
-                        @DoFn.Element KV<String, IndexRecord> kvIndexRecord,
+                        @DoFn.Element IndexRecord indexRecord,
                         OutputReceiver<SolrInputDocument> out) {
                       SolrInputDocument solrInputDocument =
                           IndexRecordTransform.convertIndexRecordToSolrDoc(
-                              kvIndexRecord.getValue(), schemaFields, dynamicFieldPrefixes);
+                              indexRecord, schemaFields, dynamicFieldPrefixes);
                       out.output(solrInputDocument);
                     }
                   }))
@@ -331,248 +269,249 @@ public class IndexRecordToSolrPipeline {
                           options.getSolrRetryMaxAttempts(),
                           Duration.standardMinutes(options.getSolrRetryDurationInMins()))));
     } else {
-      kvIndexRecords
-          .apply(Values.create())
-          .apply(AvroIO.write(IndexRecord.class).to(options.getOutputAvroToFilePath()));
+      indexRecords.apply(AvroIO.write(IndexRecord.class).to(options.getOutputAvroToFilePath()));
     }
   }
 
-  private static DoFn<KV<String, KV<IndexRecord, JackKnifeOutlierRecord>>, KV<String, IndexRecord>>
-      addJackknifeInfo() {
-
-    return new DoFn<
-        KV<String, KV<IndexRecord, JackKnifeOutlierRecord>>, KV<String, IndexRecord>>() {
-
-      @ProcessElement
-      public void processElement(ProcessContext c) {
-
-        KV<String, KV<IndexRecord, JackKnifeOutlierRecord>> e = c.element();
-        IndexRecord indexRecord = e.getValue().getKey();
-        JackKnifeOutlierRecord jkor = e.getValue().getValue();
-        Map<String, Integer> ints = indexRecord.getInts();
-
-        if (ints == null) {
-          ints = new HashMap<>();
-          indexRecord.setInts(ints);
-        }
-
-        if (jkor != nullJkor && !EMPTY.equals(jkor.getId())) {
-
-          ints.put(OUTLIER_LAYER_COUNT, jkor.getItems().size());
-
-          Map<String, List<String>> multiValues = indexRecord.getMultiValues();
-          if (multiValues == null) {
-            multiValues = new HashMap<>();
-            indexRecord.setMultiValues(multiValues);
-          }
-
-          multiValues.put(OUTLIER_LAYER, jkor.getItems());
-        } else {
-          ints.put(OUTLIER_LAYER_COUNT, 0);
-        }
-
-        c.output(KV.of(indexRecord.getId(), indexRecord));
-      }
-    };
+  private static void addOutlierInfo(
+      IndexRecord indexRecord, DistributionOutlierRecord outlierRecord) {
+    indexRecord
+        .getDoubles()
+        .put(DISTANCE_FROM_EXPERT_DISTRIBUTION, outlierRecord.getDistanceOutOfEDL());
   }
 
-  private static DoFn<KV<String, KV<IndexRecord, Relationships>>, KV<String, IndexRecord>>
-      addClusteringInfo() {
+  private static void addJackKnifeInfo(IndexRecord indexRecord, JackKnifeOutlierRecord jkor) {
 
-    return new DoFn<KV<String, KV<IndexRecord, Relationships>>, KV<String, IndexRecord>>() {
-      @ProcessElement
-      public void processElement(ProcessContext c) {
+    Map<String, Integer> ints = indexRecord.getInts();
 
-        KV<String, KV<IndexRecord, Relationships>> e = c.element();
+    if (ints == null) {
+      ints = new HashMap<>();
+      indexRecord.setInts(ints);
+    }
 
-        IndexRecord indexRecord = e.getValue().getKey();
-        String id = indexRecord.getId();
+    if (jkor != nullJkor && !EMPTY.equals(jkor.getId())) {
 
-        Relationships jkor = e.getValue().getValue();
+      ints.put(OUTLIER_LAYER_COUNT, jkor.getItems().size());
 
-        Map<String, List<String>> multiValues = indexRecord.getMultiValues();
-        Map<String, Boolean> booleans = indexRecord.getBooleans();
-        Map<String, String> strings = indexRecord.getStrings();
-        Map<String, Integer> ints = indexRecord.getInts();
-
-        if (multiValues == null) {
-          multiValues = new HashMap<>();
-          indexRecord.setMultiValues(multiValues);
-        }
-
-        if (booleans == null) {
-          booleans = new HashMap<>();
-          indexRecord.setBooleans(booleans);
-        }
-
-        if (strings == null) {
-          strings = new HashMap<>();
-          indexRecord.setStrings(strings);
-        }
-
-        if (ints == null) {
-          ints = new HashMap<>();
-          indexRecord.setInts(ints);
-        }
-
-        if (jkor != nullClustering
-            && !EMPTY.equals(jkor.getId())
-            && !jkor.getRelationships().isEmpty()) {
-
-          booleans.put(IS_IN_CLUSTER, true);
-
-          boolean isRepresentative = false;
-
-          Set<String> duplicateType = new HashSet<>();
-          for (Relationship relationship : jkor.getRelationships()) {
-
-            // A record may end up being marked as both associative
-            // and representative in two or more separate clusters.
-            // The important thing here is that if it is marked
-            // as representative in any relationship we mark is as such
-            // as the sole purpose of representative/associative markers
-            // is to allow users to filter out duplicates.
-            boolean linkingError = false;
-            if (relationship.getRepId().equals(id)) {
-              isRepresentative = true;
-            }
-
-            if (relationship.getDupDataset().equals(relationship.getRepDataset())) {
-              duplicateType.add(SAME_DATASET);
-            } else if (!linkingError) {
-              duplicateType.add(DIFFERENT_DATASET);
-            } else {
-              duplicateType.add(LINKING_ERROR);
-            }
-          }
-
-          String duplicateStatus = IndexValues.ASSOCIATED;
-          if (isRepresentative) {
-            duplicateStatus = IndexValues.REPRESENTATIVE;
-          }
-
-          // a record may be representative of several records
-          List<String> isRepresentativeOf =
-              jkor.getRelationships().stream()
-                  .map(Relationship::getDupId)
-                  .distinct()
-                  .filter(recordId -> !recordId.equals(id))
-                  .collect(Collectors.toList());
-
-          // a record is a duplicate of a single representative record
-          List<Relationship> isDuplicateOf =
-              jkor.getRelationships().stream()
-                  .distinct()
-                  .filter(relationship -> relationship.getDupId().equals(id))
-                  .collect(Collectors.toList());
-
-          if (!isRepresentativeOf.isEmpty()) {
-            multiValues.put(IndexFields.IS_REPRESENTATIVE_OF, isRepresentativeOf);
-            strings.put(
-                DwcTerm.associatedOccurrences.simpleName(), String.join("|", isRepresentativeOf));
-          }
-
-          if (!isDuplicateOf.isEmpty()) {
-            strings.put(IS_DUPLICATE_OF, isDuplicateOf.get(0).getRepId());
-            String[] justification = isDuplicateOf.get(0).getJustification().split(",");
-            multiValues.put(DUPLICATE_JUSTIFICATION, Arrays.asList(justification));
-            strings.put(
-                DwcTerm.associatedOccurrences.simpleName(), isDuplicateOf.get(0).getRepId());
-          }
-
-          // set the status
-          strings.put(DUPLICATE_STATUS, duplicateStatus);
-
-          // add duplicate types
-          List<String> duplicateTypeList = new ArrayList<>(duplicateType);
-          multiValues.put(DUPLICATE_TYPE, duplicateTypeList);
-
-        } else {
-          booleans.put(IS_IN_CLUSTER, false);
-        }
-        c.output(KV.of(indexRecord.getId(), indexRecord));
+      Map<String, List<String>> multiValues = indexRecord.getMultiValues();
+      if (multiValues == null) {
+        multiValues = new HashMap<>();
+        indexRecord.setMultiValues(multiValues);
       }
-    };
+
+      multiValues.put(OUTLIER_LAYER, jkor.getItems());
+    } else {
+      ints.put(OUTLIER_LAYER_COUNT, 0);
+    }
   }
 
-  private static DoFn<KV<String, CoGbkResult>, KV<String, IndexRecord>> joinSampling(
+  private static void addClusteringInfo(IndexRecord indexRecord, Relationships jkor) {
+
+    String id = indexRecord.getId();
+
+    Map<String, List<String>> multiValues = indexRecord.getMultiValues();
+    Map<String, Boolean> booleans = indexRecord.getBooleans();
+    Map<String, String> strings = indexRecord.getStrings();
+    Map<String, Integer> ints = indexRecord.getInts();
+
+    if (multiValues == null) {
+      multiValues = new HashMap<>();
+      indexRecord.setMultiValues(multiValues);
+    }
+
+    if (booleans == null) {
+      booleans = new HashMap<>();
+      indexRecord.setBooleans(booleans);
+    }
+
+    if (strings == null) {
+      strings = new HashMap<>();
+      indexRecord.setStrings(strings);
+    }
+
+    if (ints == null) {
+      ints = new HashMap<>();
+      indexRecord.setInts(ints);
+    }
+
+    if (jkor != nullClustering
+        && !EMPTY.equals(jkor.getId())
+        && !jkor.getRelationships().isEmpty()) {
+
+      booleans.put(IS_IN_CLUSTER, true);
+
+      boolean isRepresentative = false;
+
+      Set<String> duplicateType = new HashSet<>();
+      for (Relationship relationship : jkor.getRelationships()) {
+
+        // A record may end up being marked as both associative
+        // and representative in two or more separate clusters.
+        // The important thing here is that if it is marked
+        // as representative in any relationship we mark is as such
+        // as the sole purpose of representative/associative markers
+        // is to allow users to filter out duplicates.
+        boolean linkingError = false;
+        if (relationship.getRepId().equals(id)) {
+          isRepresentative = true;
+        }
+
+        if (relationship.getDupDataset().equals(relationship.getRepDataset())) {
+          duplicateType.add(SAME_DATASET);
+        } else if (!linkingError) {
+          duplicateType.add(DIFFERENT_DATASET);
+        } else {
+          duplicateType.add(LINKING_ERROR);
+        }
+      }
+
+      String duplicateStatus = IndexValues.ASSOCIATED;
+      if (isRepresentative) {
+        duplicateStatus = IndexValues.REPRESENTATIVE;
+      }
+
+      // a record may be representative of several records
+      List<String> isRepresentativeOf =
+          jkor.getRelationships().stream()
+              .map(Relationship::getDupId)
+              .distinct()
+              .filter(recordId -> !recordId.equals(id))
+              .collect(Collectors.toList());
+
+      // a record is a duplicate of a single representative record
+      List<Relationship> isDuplicateOf =
+          jkor.getRelationships().stream()
+              .distinct()
+              .filter(relationship -> relationship.getDupId().equals(id))
+              .collect(Collectors.toList());
+
+      if (!isRepresentativeOf.isEmpty()) {
+        multiValues.put(IndexFields.IS_REPRESENTATIVE_OF, isRepresentativeOf);
+        strings.put(
+            DwcTerm.associatedOccurrences.simpleName(), String.join("|", isRepresentativeOf));
+      }
+
+      if (!isDuplicateOf.isEmpty()) {
+        strings.put(IS_DUPLICATE_OF, isDuplicateOf.get(0).getRepId());
+        String[] justification = isDuplicateOf.get(0).getJustification().split(",");
+        multiValues.put(DUPLICATE_JUSTIFICATION, Arrays.asList(justification));
+        strings.put(DwcTerm.associatedOccurrences.simpleName(), isDuplicateOf.get(0).getRepId());
+      }
+
+      // set the status
+      strings.put(DUPLICATE_STATUS, duplicateStatus);
+
+      // add duplicate types
+      List<String> duplicateTypeList = new ArrayList<>(duplicateType);
+      multiValues.put(DUPLICATE_TYPE, duplicateTypeList);
+
+    } else {
+      booleans.put(IS_IN_CLUSTER, false);
+    }
+  }
+
+  private static DoFn<KV<String, CoGbkResult>, IndexRecord> joinSampling(
       TupleTag<IndexRecord> indexRecordTag, TupleTag<SampleRecord> samplingTag) {
 
-    return new DoFn<KV<String, CoGbkResult>, KV<String, IndexRecord>>() {
+    return new DoFn<KV<String, CoGbkResult>, IndexRecord>() {
+
       @ProcessElement
       public void processElement(ProcessContext c) {
 
         KV<String, CoGbkResult> e = c.element();
 
-        SampleRecord sampleRecord = e.getValue().getOnly(samplingTag, nullSampling);
         Iterable<IndexRecord> indexRecordIterable = e.getValue().getAll(indexRecordTag);
-
-        if (sampleRecord.getStrings() == null && sampleRecord.getDoubles() == null) {
-          log.error("Sampling was empty for point: {}", e.getKey());
-        }
+        SampleRecord sampleRecord = e.getValue().getOnly(samplingTag, nullSampling);
 
         indexRecordIterable.forEach(
             indexRecord -> {
-              Map<String, String> strings =
-                  indexRecord.getStrings() != null ? indexRecord.getStrings() : new HashMap<>();
-              Map<String, Double> doubles =
-                  indexRecord.getDoubles() != null ? indexRecord.getDoubles() : new HashMap<>();
+              if (sampleRecord != null && !sampleRecord.equals(nullSampling)) {
 
-              Map<String, String> stringsToPersist =
-                  ImmutableMap.<String, String>builder()
-                      .putAll(strings)
-                      .putAll(sampleRecord.getStrings())
-                      .build();
+                Map<String, String> strings =
+                    indexRecord.getStrings() != null ? indexRecord.getStrings() : new HashMap<>();
+                Map<String, Double> doubles =
+                    indexRecord.getDoubles() != null ? indexRecord.getDoubles() : new HashMap<>();
 
-              Map<String, Double> doublesToPersist =
-                  ImmutableMap.<String, Double>builder()
-                      .putAll(doubles)
-                      .putAll(sampleRecord.getDoubles())
-                      .build();
+                Map<String, String> stringsToPersist =
+                    ImmutableMap.<String, String>builder()
+                        .putAll(strings)
+                        .putAll(sampleRecord.getStrings())
+                        .build();
 
-              IndexRecord ir =
-                  IndexRecord.newBuilder()
-                      .setId(indexRecord.getId())
-                      .setTaxonID(indexRecord.getTaxonID())
-                      .setLatLng(indexRecord.getLatLng())
-                      .setMultiValues(indexRecord.getMultiValues())
-                      .setDates(indexRecord.getDates())
-                      .setLongs(indexRecord.getLongs())
-                      .setBooleans(indexRecord.getBooleans())
-                      .setInts(indexRecord.getInts())
-                      .setStrings(stringsToPersist)
-                      .setDoubles(doublesToPersist)
-                      .setDynamicProperties(indexRecord.getDynamicProperties())
-                      .build();
+                Map<String, Double> doublesToPersist =
+                    ImmutableMap.<String, Double>builder()
+                        .putAll(doubles)
+                        .putAll(sampleRecord.getDoubles())
+                        .build();
 
-              c.output(KV.of(indexRecord.getId(), ir));
+                IndexRecord ir =
+                    IndexRecord.newBuilder()
+                        .setId(indexRecord.getId())
+                        .setTaxonID(indexRecord.getTaxonID())
+                        .setLatLng(indexRecord.getLatLng())
+                        .setMultiValues(indexRecord.getMultiValues())
+                        .setDates(indexRecord.getDates())
+                        .setLongs(indexRecord.getLongs())
+                        .setBooleans(indexRecord.getBooleans())
+                        .setInts(indexRecord.getInts())
+                        .setStrings(stringsToPersist)
+                        .setDoubles(doublesToPersist)
+                        .setDynamicProperties(indexRecord.getDynamicProperties())
+                        .build();
+                c.output(ir);
+              } else {
+                c.output(indexRecord);
+              }
             });
       }
     };
   }
 
-  private static DoFn<
-          KV<String, KV<IndexRecord, DistributionOutlierRecord>>, KV<String, IndexRecord>>
-      addOutlierInfo() {
+  /**
+   * Join processing outputs which are all key-ed on OccurrenceID.
+   *
+   * @param indexRecordTag
+   * @param jackKnifeTag
+   * @param clusteringTag
+   * @param outlierTag
+   * @return
+   */
+  private static DoFn<KV<String, CoGbkResult>, KV<String, IndexRecord>> joinProcessing(
+      TupleTag<IndexRecord> indexRecordTag,
+      TupleTag<JackKnifeOutlierRecord> jackKnifeTag,
+      TupleTag<Relationships> clusteringTag,
+      TupleTag<DistributionOutlierRecord> outlierTag) {
 
-    return new DoFn<
-        KV<String, KV<IndexRecord, DistributionOutlierRecord>>, KV<String, IndexRecord>>() {
+    return new DoFn<KV<String, CoGbkResult>, KV<String, IndexRecord>>() {
+
       @ProcessElement
       public void processElement(ProcessContext c) {
 
-        KV<String, KV<IndexRecord, DistributionOutlierRecord>> e = c.element();
-        String id = e.getKey();
+        KV<String, CoGbkResult> e = c.element();
+        IndexRecord indexRecord = e.getValue().getOnly(indexRecordTag, nullIndexRecord);
 
-        DistributionOutlierRecord outlierRecord = e.getValue().getValue();
-        IndexRecord indexRecord = e.getValue().getKey();
+        if (indexRecord != null && !indexRecord.equals(nullIndexRecord)) {
 
-        if (outlierRecord != null) {
-          indexRecord
-              .getDoubles()
-              .put(DISTANCE_FROM_EXPERT_DISTRIBUTION, outlierRecord.getDistanceOutOfEDL());
+          JackKnifeOutlierRecord jackKnife = e.getValue().getOnly(jackKnifeTag, nullJkor);
+          Relationships clustering = e.getValue().getOnly(clusteringTag, nullClustering);
+          DistributionOutlierRecord outlierRecord = e.getValue().getOnly(outlierTag, nullOutlier);
+
+          if (jackKnife != null) {
+            addJackKnifeInfo(indexRecord, jackKnife);
+          }
+
+          if (clustering != null) {
+            addClusteringInfo(indexRecord, clustering);
+          }
+
+          if (outlierRecord != null) {
+            addOutlierInfo(indexRecord, outlierRecord);
+          }
+
+          c.output(KV.of(indexRecord.getId(), indexRecord));
+        } else {
+          log.error("Join null for key " + e.getKey());
         }
-
-        c.output(KV.of(id, indexRecord));
       }
     };
   }
@@ -592,28 +531,41 @@ public class IndexRecordToSolrPipeline {
   }
 
   private static PCollection<KV<String, SampleRecord>> loadSampleRecords(
-      AllDatasetsPipelinesOptions options, Pipeline p) {
+      AllDatasetsPipelinesOptions options, Pipeline p, final int partitions) {
     String samplingPath =
         String.join("/", ALAFsUtils.buildPathSamplingUsingTargetPath(options), "*.avro");
     log.info("Loading sampling from {}", samplingPath);
     return p.apply(AvroIO.read(SampleRecord.class).from(samplingPath))
         .apply(
-            MapElements.via(
-                new SimpleFunction<SampleRecord, KV<String, SampleRecord>>() {
-                  @Override
-                  public KV<String, SampleRecord> apply(SampleRecord input) {
-                    return KV.of(input.getLatLng(), input);
+            ParDo.of(
+                new DoFn<SampleRecord, KV<String, SampleRecord>>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    SampleRecord s = c.element();
+                    for (int i = 0; i < partitions; i++) {
+                      SampleRecord s1 =
+                          SampleRecord.newBuilder()
+                              .setLatLng(s.getLatLng())
+                              .setDoubles(s.getDoubles())
+                              .setStrings(s.getStrings())
+                              .build();
+                      c.output(KV.of(i + "-" + s.getLatLng(), s1));
+                    }
                   }
                 }));
   }
 
   private static PCollection<KV<String, JackKnifeOutlierRecord>> loadJackKnifeRecords(
       SolrPipelineOptions options, Pipeline p) {
+
+    if (!options.getIncludeJackKnife()) {
+      return p.apply(Create.empty(new TypeDescriptor<KV<String, JackKnifeOutlierRecord>>() {}));
+    }
+
     String jackknifePath =
         PathBuilder.buildPath(options.getJackKnifePath(), "outliers", "*" + AVRO_EXTENSION)
             .toString();
     log.info("Loading jackknife from {}", jackknifePath);
-
     return p.apply(AvroIO.read(JackKnifeOutlierRecord.class).from(jackknifePath))
         .apply(
             MapElements.via(
@@ -627,6 +579,11 @@ public class IndexRecordToSolrPipeline {
 
   private static PCollection<KV<String, Relationships>> loadClusteringRecords(
       SolrPipelineOptions options, Pipeline p) {
+
+    if (!options.getIncludeClustering()) {
+      return p.apply(Create.empty(new TypeDescriptor<KV<String, Relationships>>() {}));
+    }
+
     String path =
         PathBuilder.buildPath(
                 options.getClusteringPath() + "/relationships/", "relationships-*" + AVRO_EXTENSION)
@@ -646,6 +603,10 @@ public class IndexRecordToSolrPipeline {
 
   private static PCollection<KV<String, DistributionOutlierRecord>> loadOutlierRecords(
       SolrPipelineOptions options, Pipeline p) {
+
+    if (!options.getIncludeOutlier()) {
+      return p.apply(Create.empty(new TypeDescriptor<KV<String, DistributionOutlierRecord>>() {}));
+    }
 
     String dataResourceFolder = options.getDatasetId();
     if (dataResourceFolder == null || "all".equalsIgnoreCase(dataResourceFolder)) {

--- a/livingatlas/pipelines/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
+++ b/livingatlas/pipelines/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -44,12 +45,11 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
-import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
@@ -64,7 +64,6 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CursorMarkParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -188,27 +187,15 @@ public class SolrIO {
       builder.addIfNotNull(DisplayData.item("username", getUsername()));
     }
 
-    private HttpClient createHttpClient() {
-      // This is bug in Solr, if we don't create a customize HttpClient,
-      // UpdateRequest with commit flag will throw an authentication error.
-      ModifiableSolrParams params = new ModifiableSolrParams();
-      params.set(HttpClientUtil.PROP_BASIC_AUTH_USER, getUsername());
-      params.set(HttpClientUtil.PROP_BASIC_AUTH_PASS, getPassword());
-      return HttpClientUtil.createClient(params);
-    }
-
     AuthorizedSolrClient<CloudSolrClient> createClient() {
-      CloudSolrClient solrClient = new CloudSolrClient.Builder().withZkHost(getZkHost()).build();
+      CloudSolrClient solrClient =
+          new CloudSolrClient.Builder(ImmutableList.of(getZkHost()), Optional.empty()).build();
       solrClient.setZkClientTimeout(180000);
       return new AuthorizedSolrClient<>(solrClient, this);
     }
 
     AuthorizedSolrClient<HttpSolrClient> createClient(String shardUrl) {
-      HttpSolrClient solrClient =
-          new HttpSolrClient.Builder()
-              .withHttpClient(createHttpClient())
-              .withBaseSolrUrl(shardUrl)
-              .build();
+      HttpSolrClient solrClient = new HttpSolrClient.Builder(shardUrl).build();
       return new AuthorizedSolrClient<>(solrClient, this);
     }
   }


### PR DESCRIPTION
See #685 

This is a re-work of the SOLR indexing pipeline due to problems with running with the new distribution outliers.
This version does a full index of ALA on EMR in about 3 hours against the test SOLR cluster (4 SOLR cloud nodes - m2xg instances).
Previously this was taking 5hrs (with 4 SOLR cloud nodes - 3hrs in production with 8 nodes).

It avoids the partitioning of index record, and instead uses hashing of sampling records to avoid hot keys.
Includes an updated version of SOLRIO.java from beam with the addition of setting the ZK timeout.




