### PR TITLE
suggest to remove redundant dependencies already defined in dwca-io

### DIFF
--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -115,19 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.gbif</groupId>
-      <artifactId>dwc-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.gbif</groupId>
       <artifactId>gbif-parsers</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.gbif</groupId>
-      <artifactId>gbif-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.gbif</groupId>
-      <artifactId>gbif-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.gbif.pipelines</groupId>


### PR DESCRIPTION
dwca-io depends on dwc-api and gbif-common, so no need to declare all three as far as I can tell.