### PR TITLE
Moved copyPath config in la-pipelines.yaml to a self section away from Pipelines general options

### DIFF
--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -30,6 +30,8 @@ fs:
   hdfs:
     fsPath: hdfs://localhost:8020
 
+copy:
+  copyPath: "/data/dwca-export"
 recordedByConfig:
   cacheSizeMb: 64
 alaNameMatch:
@@ -112,7 +114,6 @@ general:
   hdfsSiteConfig: ""
   # Path to core-site-config.xml
   coreSiteConfig: ""
-  copyPath: "/data/dwca-export"
 
 # class: au.org.ala.pipelines.beam.ALADwcaToVerbatimPipeline
 dwca-avro:

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -305,7 +305,7 @@ ARGS="$ARGS $FS_PATH_ARG"
 
 COLLECTORY_WS_URL=$(getConf collectory.wsUrl);
 COLLECTORY_WS_API_KEY=$(getConf collectory.httpHeaders.Authorization);
-COPY_DEST=$(getConf general.copyPath)
+COPY_DEST=$(getConf copy.copyPath)
 
 # Uncomment this to debug log4j
 # if ( $debug) ; then EXTRA_JVM_CLI_ARGS="-Dlog4j.debug"; fi


### PR DESCRIPTION
I introduced an issue with #725 adding the new configuration to the `general` section:

![image](https://user-images.githubusercontent.com/180085/173771563-4b26b1dd-e6db-4a5f-a59a-6fba2bd251b5.png)

So I moved the new copy command configuration `copyPath` to a different location instead of the general pipelines section.