### PR TITLE
732 Handle types and multi values for custom terms

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/common/SolrFieldSchema.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/common/SolrFieldSchema.java
@@ -1,0 +1,45 @@
+package au.org.ala.pipelines.common;
+
+public class SolrFieldSchema implements java.io.Serializable {
+  public enum Types {
+    STRING("string"),
+    DOUBLE("double"),
+    INT("int"),
+    LONG("long"),
+    FLOAT("float"),
+    DATE("date"),
+    BOOLEAN("boolean");
+
+    private String type;
+
+    Types(String type) {
+      this.type = type;
+    }
+
+    public String getValue() {
+      return type;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(type);
+    }
+
+    public static Types valueOfType(String type) {
+      for (Types e : values()) {
+        if (e.type.equals(type)) {
+          return e;
+        }
+      }
+      return null;
+    }
+  }
+
+  public Types type = Types.STRING;
+  public boolean multiple = false;
+
+  public SolrFieldSchema(String type, boolean multiple) {
+    this.type = Types.valueOfType(type);
+    this.multiple = multiple;
+  }
+}


### PR DESCRIPTION
During the "solr" step, custom fields are correctly converted to the types specified in the SolR schema.
Multi values fields are split using | as separator.
