### PR TITLE
la-pipelines-bitmap docker utility

### DIFF
--- a/livingatlas/bitmap/docker/Dockerfile
+++ b/livingatlas/bitmap/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM postgis/postgis:13-master
+
+RUN apt-get update && \
+      apt-get install -y --no-install-recommends \
+      postgis ca-certificates curl \
+      && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L -o /tmp/jdk8.tgz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jre_x64_linux_hotspot_8u332b09.tar.gz
+
+RUN mkdir -p /usr/lib/jvm/
+
+RUN tar xfz /tmp/jdk8.tgz --directory /usr/lib/jvm/
+
+VOLUME ["/data/pipelines-shp"]
+
+COPY target/bitmap-2.12.0-SNAPSHOT-jar-with-dependencies.jar /usr/local/lib/la-pipelines-bitmap.jar

--- a/livingatlas/bitmap/pom.xml
+++ b/livingatlas/bitmap/pom.xml
@@ -17,6 +17,7 @@
     </description>
     <properties>
         <batik.version>1.13</batik.version>
+        <postgres.version>42.4.0</postgres.version>
     </properties>
     <dependencies>
 
@@ -37,6 +38,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-codec</artifactId>
+            <version>${batik.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
@@ -54,5 +60,38 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgres.version}</version>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>
+                                        au.org.ala.utils.BitMapGenerator
+                                    </mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/livingatlas/bitmap/scripts/la-pipelines-bitmap
+++ b/livingatlas/bitmap/scripts/la-pipelines-bitmap
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Generates bitmaps from shapefiles to minimize spatial web service calls in la-pipelines
+# See: https://github.com/gbif/pipelines/issues/250
+#
+
+CMD=$(basename $0)
+
+FIND_DOCOPTS=$(which docopts)
+
+if [[ -z $FIND_DOCOPTS ]]
+then
+    echo "ERROR: Please install docopts https://github.com/docopt/docopts an copy it in your PATH"
+    exit 1
+fi
+
+set -e
+
+colgrn='\033[0;32m' # Green
+colrst='\033[0m'    # Text Reset
+
+function log.info () { echo -e "${colgrn}$@${colrst}" ;}
+
+eval "$(docopts -V - -h - : "$@" <<EOF
+
+LA-Pipelines bitmap generation utility.
+
+The $CMD generates bitmaps from shapefiles to minimize spatial web service calls in la-pipelines
+
+Usage:
+  $CMD <layers_dir> <layer_name> <field_name> [--expose] [--nostop]
+
+Options:
+  -h --help            Show this help.
+----
+$CMD
+License Apache-2.0
+EOF
+)"
+
+CNT_NAME=la-pipelines-bitmap
+LAYERS_DIR=$layers_dir
+LAYER_NAME=$layer_name
+FIELD_NAME=$field_name
+TABLE_NAME=$LAYER_NAME
+P=postgres
+DB=$P
+
+function stop() {
+  set +e
+  docker stop $CNT_NAME >/dev/null 2>&1
+  docker rm $CNT_NAME >/dev/null 2>&1
+  set -e
+}
+
+stop
+
+log.info ">>> Running postgres with postgis via docker"
+
+if ($expose); then
+  PORTS="-p 5432:5432"
+else
+  PORTS=""
+fi
+
+docker run \
+  --interactive --tty -d \
+  --volume "$LAYERS_DIR":/data/pipelines-shp \
+  --name $CNT_NAME \
+  $PORTS \
+  -e POSTGRES_PASSWORD=$P \
+  -e POSTGRES_DB=$DB \
+  livingatlases/la-pipelines-bitmap:latest
+
+log.info ">>> Convert shape file into sql"
+
+docker exec -i $CNT_NAME shp2pgsql -d -i -I -s 4326 -W ISO-8859-1 /data/pipelines-shp/$LAYER_NAME.shp $LAYER_NAME > /tmp/$LAYER_NAME.sql
+
+timer=3
+until docker exec -i $CNT_NAME runuser -l $P -c 'pg_isready' 2>/dev/null; do
+  >&2 log.info "Postgres is unavailable - sleeping for $timer seconds"
+  sleep $timer
+done
+
+until docker exec -i $CNT_NAME psql -U $P -d $DB -c 'SELECT PostGIS_version();' 2>/dev/null; do
+  >&2 log.info "Postgis is unavailable - sleeping for $timer seconds"
+  sleep $timer
+done
+
+log.info ">>> Load resulting sql layer in postgres"
+
+docker exec -i -u postgres $CNT_NAME psql -U $P -d $DB < /tmp/$LAYER_NAME.sql
+
+log.info ">>> Removing $TABLE_NAME.png bitmap if exists"
+
+rm -f /data/pipelines-shp/$TABLE_NAME.png
+
+log.info ">>> Generating bitmap from sql table $TABLE_NAME"
+
+docker exec -i $CNT_NAME /usr/lib/jvm/jdk8u332-b09-jre/bin/java -Durl=jdbc:postgresql://127.0.0.1 -Ddb=$DB -Duser=$P -Dpassword=$P -jar /usr/local/lib/la-pipelines-bitmap.jar $TABLE_NAME $FIELD_NAME /data/pipelines-shp/
+
+log.info ">>> Bitmap generated in $LAYERS_DIR/$TABLE_NAME.png"
+
+if ($nostop); then
+  log.info ">>> Not stopping the postgres container"
+else
+  stop
+fi

--- a/livingatlas/bitmap/scripts/la-pipelines-bitmap
+++ b/livingatlas/bitmap/scripts/la-pipelines-bitmap
@@ -10,7 +10,7 @@ FIND_DOCOPTS=$(which docopts)
 
 if [[ -z $FIND_DOCOPTS ]]
 then
-    echo "ERROR: Please install docopts https://github.com/docopt/docopts an copy it in your PATH"
+    echo "ERROR: Please install docopts https://github.com/docopt/docopts and copy it in your PATH"
     exit 1
 fi
 

--- a/livingatlas/bitmap/scripts/la-pipelines-bitmap
+++ b/livingatlas/bitmap/scripts/la-pipelines-bitmap
@@ -45,12 +45,21 @@ FIELD_NAME=$field_name
 TABLE_NAME=$LAYER_NAME
 P=postgres
 DB=$P
+timer=3
 
 function stop() {
   set +e
   docker stop $CNT_NAME >/dev/null 2>&1
   docker rm $CNT_NAME >/dev/null 2>&1
   set -e
+}
+
+function check_pg() {
+  until docker exec -i $CNT_NAME runuser -l $P -c 'pg_isready' 2>/dev/null; do
+    log.info "Postgres is unavailable - sleeping for $timer seconds"
+    sleep $timer
+  done
+  log.info "Postgres available"
 }
 
 stop
@@ -76,20 +85,26 @@ log.info ">>> Convert shape file into sql"
 
 docker exec -i $CNT_NAME shp2pgsql -d -i -I -s 4326 -W ISO-8859-1 /data/pipelines-shp/$LAYER_NAME.shp $LAYER_NAME > /tmp/$LAYER_NAME.sql
 
-timer=3
-until docker exec -i $CNT_NAME runuser -l $P -c 'pg_isready' 2>/dev/null; do
-  >&2 log.info "Postgres is unavailable - sleeping for $timer seconds"
+check_pg
+
+until docker exec -i $CNT_NAME psql -U $P -d $DB -c 'SELECT PostGIS_version();' >/dev/null 2>&1; do
+  log.info "Postgis is unavailable - sleeping for $timer seconds"
   sleep $timer
 done
 
-until docker exec -i $CNT_NAME psql -U $P -d $DB -c 'SELECT PostGIS_version();' 2>/dev/null; do
-  >&2 log.info "Postgis is unavailable - sleeping for $timer seconds"
-  sleep $timer
-done
+log.info "Postgis available"
+
+sleep 10
+
+check_pg
 
 log.info ">>> Load resulting sql layer in postgres"
 
-docker exec -i -u postgres $CNT_NAME psql -U $P -d $DB < /tmp/$LAYER_NAME.sql
+# Removing DropGeometry as always fails
+sed '/DropGeometry/d' /tmp/$LAYER_NAME.sql > /tmp/$LAYER_NAME.tmp
+mv /tmp/$LAYER_NAME.tmp /tmp/$LAYER_NAME.sql
+
+docker exec -i -u postgres $CNT_NAME psql -U $P -d $DB < /tmp/$LAYER_NAME.sql > /dev/null
 
 log.info ">>> Removing $TABLE_NAME.png bitmap if exists"
 

--- a/livingatlas/bitmap/scripts/la-pipelines-bitmap
+++ b/livingatlas/bitmap/scripts/la-pipelines-bitmap
@@ -28,7 +28,7 @@ LA-Pipelines bitmap generation utility.
 The $CMD generates bitmaps from shapefiles to minimize spatial web service calls in la-pipelines
 
 Usage:
-  $CMD <layers_dir> <layer_name> <field_name> [--expose] [--nostop]
+  $CMD <layers_dir> <layer_name> <field_name> [--expose] [--nostop] [--memory=<mem>]
 
 Options:
   -h --help            Show this help.
@@ -72,6 +72,12 @@ else
   PORTS=""
 fi
 
+if [[ -n $memory ]]; then
+  JAVA_OPTS="-Xmx$memory"
+else
+  JAVA_OPTS=""
+fi
+
 docker run \
   --interactive --tty -d \
   --volume "$LAYERS_DIR":/data/pipelines-shp \
@@ -112,7 +118,7 @@ rm -f /data/pipelines-shp/$TABLE_NAME.png
 
 log.info ">>> Generating bitmap from sql table $TABLE_NAME"
 
-docker exec -i $CNT_NAME /usr/lib/jvm/jdk8u332-b09-jre/bin/java -Durl=jdbc:postgresql://127.0.0.1 -Ddb=$DB -Duser=$P -Dpassword=$P -jar /usr/local/lib/la-pipelines-bitmap.jar $TABLE_NAME $FIELD_NAME /data/pipelines-shp/
+docker exec -i $CNT_NAME /usr/lib/jvm/jdk8u332-b09-jre/bin/java $JAVA_OPTS -Durl=jdbc:postgresql://127.0.0.1 -Ddb=$DB -Duser=$P -Dpassword=$P -jar /usr/local/lib/la-pipelines-bitmap.jar $TABLE_NAME $FIELD_NAME /data/pipelines-shp/
 
 log.info ">>> Bitmap generated in $LAYERS_DIR/$TABLE_NAME.png"
 


### PR DESCRIPTION
Following https://github.com/gbif/pipelines/issues/250 and using https://github.com/gbif/pipelines/blob/dev/livingatlas/bitmap/src/main/java/au/org/ala/utils/BitMapGenerator.java

This PR basically:
- generates a usable jar
- create a docker image with that jar, java-jre-8 and `shp2pgsql` 
- an utility `la-pipelines-bitmap` to generate the bitmap using the previous deps.

Sample of use:

```
scripts/la-pipelines-bitmap -h

LA-Pipelines bitmap generation utility.

The la-pipelines-bitmap generates bitmaps from shapefiles to minimize spatial web service calls in la-pipelines

Usage:
  la-pipelines-bitmap <layers_dir> <layer_name> <field_name> [--expose] [--nostop]

Options:
  -h --help            Show this help.

$ ./scripts/la-pipelines-bitmap /data/pipelines-shp provincias nameunit          
>>> Running postgres with postgis via docker
5b9ce21642c4ec335d1b1b222637e4219698e425ecaba404cdc66b97d51b2b28
>>> Convert shape file into sql
Shapefile type: Polygon
Postgis type: MULTIPOLYGON[2]
/var/run/postgresql:5432 - no response
Postgres is unavailable - sleeping for 3 seconds
/var/run/postgresql:5432 - accepting connections
Postgis is unavailable - sleeping for 3 seconds
            postgis_version            
---------------------------------------
 3.2 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
(1 row)

>>> Load resulting sql layer in postgres
SET
(....)
INSERT 0 1
CREATE INDEX
COMMIT
ANALYZE
>>> Removing provincias.png bitmap if exists
>>> Generating bitmap from sql table provincias
INFO  [2022-06-20 11:01:39,112+0000] [main] au.org.ala.utils.BitMapGenerator: Successfully Connected.
INFO  [2022-06-20 11:01:39,933+0000] [main] au.org.ala.utils.BitMapGenerator: Generating bitmap for provincias
INFO  [2022-06-20 11:01:39,934+0000] [main] au.org.ala.utils.BitMapGenerator: → Generating SVG for provincias as /tmp/provincias2970877010667943779-filled.svg and /tmp/provincias1700832673557613814-hollow.svg
INFO  [2022-06-20 11:01:40,169+0000] [main] au.org.ala.utils.BitMapGenerator: → Converting SVG to PNG for provincias as /tmp/provincias6925864277262630605-hollow.png
INFO  [2022-06-20 11:01:49,735+0000] [main] au.org.ala.utils.BitMapGenerator: → Converting SVG to PNG for provincias as /tmp/provincias2576463636373332106-filled.png
INFO  [2022-06-20 11:01:57,824+0000] [main] au.org.ala.utils.BitMapGenerator: → Combining both PNGs for provincias as /data/pipelines-shp/provincias.png
>>> Bitmap generated in /data/pipelines-shp/provincias.png
```

It's working great in my computer but the last part fails in other test server (more slow). It thinks that is caused by some race condition in the postgres/postgis initialization. I'll marked a Draft while I fix it so others can test it too.

The image is published in https://hub.docker.com/repository/docker/livingatlases/la-pipelines-bitmap

I just used the bitmap to interpret non ALA state/provinces, as I configured our la-pipelines with:
```
geocodeConfig: 
(...)
  stateProvince:
    path: /data/pipelines-shp/provincias  
(...)

```
cc @sylmorin-gbif 