### PR TITLE
#733 Improve NCBI clustering

### DIFF
--- a/gbif/pipelines/clustering-gbif/src/main/java/org/gbif/pipelines/clustering/RowOccurrenceFeatures.java
+++ b/gbif/pipelines/clustering-gbif/src/main/java/org/gbif/pipelines/clustering/RowOccurrenceFeatures.java
@@ -23,6 +23,16 @@ import scala.collection.Seq;
  * of a SQL select a.*,b.* from a join b).
  */
 public class RowOccurrenceFeatures implements OccurrenceFeatures {
+
+  // Dataset keys are considered reliable over time
+  private static final List<String> SEQUENCE_REPOSITORY_KEYS =
+      Arrays.asList(
+          "d8cd16ba-bb74-4420-821e-083f2bac17c2", // INSDC sequences
+          "393b8c26-e4e0-4dd0-a218-93fc074ebf4e", // INSDC host organisms
+          "583d91fe-bbc0-4b4a-afe1-801f88263016", // INSDC environmental samples
+          "040c5662-da76-4782-a48e-cdea1892d14c" // iBOL
+          );
+
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
@@ -226,6 +236,11 @@ public class RowOccurrenceFeatures implements OccurrenceFeatures {
   @Override
   public String getCollectionCode() {
     return get("collectionCode");
+  }
+
+  @Override
+  public boolean isFromSequenceRepository() {
+    return SEQUENCE_REPOSITORY_KEYS.contains(getDatasetKey().toLowerCase());
   }
 
   List<String> listOrNull(String field) {

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeatures.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeatures.java
@@ -91,4 +91,16 @@ public interface OccurrenceFeatures {
       return null;
     }
   }
+
+  /**
+   * Allows implementations to declare that the record originates from a sequence repository.
+   * Default behaviour is false, meaning that consumers may receive false negatives. This hook was
+   * introduced to allow a relaxation of the rules to accommodate the sparse metadata seen in
+   * repositories like NCBI.
+   *
+   * @see <a href="https://github.com/gbif/pipelines/issues/733">Pipelines issue 733</a>
+   */
+  default boolean isFromSequenceRepository() {
+    return false;
+  }
 }

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeaturesPojo.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceFeaturesPojo.java
@@ -29,6 +29,8 @@ public class OccurrenceFeaturesPojo implements OccurrenceFeatures {
   private final String institutionCode;
   private final String collectionCode;
 
+  private final boolean isFromSequenceRepository;
+
   @Override
   public String getId() {
     return id;
@@ -137,5 +139,10 @@ public class OccurrenceFeaturesPojo implements OccurrenceFeatures {
   @Override
   public String getCollectionCode() {
     return collectionCode;
+  }
+
+  @Override
+  public boolean isFromSequenceRepository() {
+    return isFromSequenceRepository;
   }
 }

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceRelationshipsTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/parsers/clustering/OccurrenceRelationshipsTest.java
@@ -307,6 +307,31 @@ public class OccurrenceRelationshipsTest {
     assertFalse(runCompareIdentifier("s.n.", "S/N").justificationContains(IDENTIFIERS_OVERLAP));
   }
 
+  /** Test relaxed rules when record originates from a sequence repository */
+  @Test
+  public void testSequenceRepositories() {
+    OccurrenceFeatures o1 =
+        OccurrenceFeaturesPojo.builder().id("1").speciesKey("212").catalogNumber("ABC").build();
+
+    OccurrenceFeatures o2 =
+        OccurrenceFeaturesPojo.builder().id("2").speciesKey("212").catalogNumber("ABC").build();
+
+    OccurrenceFeatures o3 =
+        OccurrenceFeaturesPojo.builder()
+            .id("2")
+            .datasetKey("2")
+            .speciesKey("212")
+            .catalogNumber("ABC")
+            .isFromSequenceRepository(true) // should relax rules
+            .build();
+
+    RelationshipAssertion<OccurrenceFeatures> assertion = OccurrenceRelationships.generate(o1, o2);
+    assertNull(assertion);
+    assertion = OccurrenceRelationships.generate(o1, o3);
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContainsAll(SAME_ACCEPTED_SPECIES, IDENTIFIERS_OVERLAP));
+  }
+
   /** Generates assertions for the comparison of two identifiers only. */
   private RelationshipAssertion<OccurrenceFeatures> runCompareIdentifier(String id1, String id2) {
     OccurrenceFeatures o1 = OccurrenceFeaturesPojo.builder().catalogNumber(id1).build();


### PR DESCRIPTION
This relaxes the rules for the GBIF clustering to allow exceptions for the EMBL (NCBI) and iBOL datasets.
It does not affect the ALA implementation.

I've deliberately opted to code UUIDs inline for those datasets as using config here would be a more invasive change than would really help - plus they are stable and any changes would require some careful consideration anyway.