### PR TITLE
la-pipelines-migration packaged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,10 @@ examples/dwca-to-elasticsearch/configs/*.json
 # la-pipelines debian package
 livingatlas/debian/*.debhelper
 livingatlas/debian/*.debhelper.log
+livingatlas/debian/debhelper-build-stamp
 livingatlas/debian/*.buildinfo
 livingatlas/debian/*.substvars
 livingatlas/debian/files
 livingatlas/debian/la-pipelines
+livingatlas/debian/la-pipelines-migration/
 livingatlas/debian/maven-repo-local/

--- a/livingatlas/debian/control
+++ b/livingatlas/debian/control
@@ -22,3 +22,13 @@ Description: Utility for data processing and indexing of biodiversity data
  .
  This package contains the la-pipelines utility. The aim of this utility is
  the replacement to biocache-store for data ingress.
+
+Package: la-pipelines-migration
+Architecture: all
+Depends: ${misc:Depends}, openjdk-8-jdk
+Description: Utility for data processing and indexing of biodiversity data
+ This package contains the Pipelines Data ingress utility package from
+ GBIF and Living Atlases.
+ .
+ This package contains the la-pipelines migration utility. The aim of this
+ utility is to help in the migration from biocache-store.

--- a/livingatlas/debian/la-pipelines-migration.install
+++ b/livingatlas/debian/la-pipelines-migration.install
@@ -1,0 +1,2 @@
+# https://www.debian.org/doc/manuals/maint-guide/dother.en.html#install
+livingatlas/pipelines/target/la-pipelines-migration.jar usr/share/la-pipelines/

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -33,6 +33,7 @@ override_dh_auto_clean:
 override_dh_auto_install:
 #	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
 	cp $(CURDIR)/livingatlas/pipelines/target/pipelines-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines.jar
+	cp $(CURDIR)/livingatlas/migration/target/migration-$(CURVERSION)-shaded.jar $(DESTDIR)/la-pipelines-migration.jar
 	cp $(CURDIR)/livingatlas/scripts/la-pipelines-bash-completion.sh $(DESTDIR)/la-pipelines
 	cp $(CURDIR)/livingatlas/configs/la-pipelines-local.yaml $(DESTDIR)/la-pipelines-local.yaml.sample
 	dh_auto_install


### PR DESCRIPTION
This PR just create a new package with the migration jar, addressing https://github.com/AtlasOfLivingAustralia/ala-install/issues/584.

I created a new `la-pipelines-migration` package instead of including the [migration](https://github.com/gbif/pipelines/tree/dev/livingatlas/migration) jar in the existing `la-pipelines` package to reduce its size.

The package is quite simple:

```
$ dpkg -L la-pipelines-migration             
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/la-pipelines-migration
/usr/share/doc/la-pipelines-migration/changelog.Debian.gz
/usr/share/doc/la-pipelines-migration/copyright
/usr/share/la-pipelines
/usr/share/la-pipelines/la-pipelines-migration.jar
``` 

so people don't have to build pipelines to do this step when migrating from `biocache-store` (or can ignore it if it's a new LA portal).
