### PR TITLE
Allow custom external stateProvinces file

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/StateProvinceParser.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/StateProvinceParser.java
@@ -1,5 +1,8 @@
 package au.org.ala.pipelines.vocabulary;
 
+import com.google.common.base.Strings;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import org.gbif.common.parsers.core.FileBasedDictionaryParser;
@@ -17,14 +20,18 @@ public class StateProvinceParser extends FileBasedDictionaryParser<String> {
     synchronized (StateProvinceParser.class) {
       if (singletonObject == null) {
         String filePath = dictFile;
-        if (dictFile == null) {
+        InputStream is;
+        if (Strings.isNullOrEmpty(dictFile)) {
           filePath = "/stateProvinces.tsv";
+          is = StateProvinceParser.class.getResourceAsStream(filePath);
+        } else {
+          File externalFile = new File(dictFile);
+          is = new FileInputStream(externalFile);
         }
-        InputStream in = StateProvinceParser.class.getResourceAsStream(filePath);
-        if (in == null) {
+        if (is == null) {
           throw new FileNotFoundException("" + filePath);
         }
-        singletonObject = new StateProvinceParser(in);
+        singletonObject = new StateProvinceParser(is);
       }
     }
     return singletonObject;

--- a/livingatlas/pipelines/src/test/java/au/org/ala/parser/LocationExtResourceParserTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/parser/LocationExtResourceParserTest.java
@@ -1,0 +1,37 @@
+package au.org.ala.parser;
+
+import au.org.ala.kvs.ALAPipelinesConfig;
+import au.org.ala.kvs.LocationInfoConfig;
+import au.org.ala.pipelines.vocabulary.CentrePoints;
+import au.org.ala.pipelines.vocabulary.CountryCentrePoints;
+import au.org.ala.pipelines.vocabulary.StateProvinceCentrePoints;
+import au.org.ala.pipelines.vocabulary.StateProvinceParser;
+import java.io.File;
+import java.io.FileNotFoundException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LocationExtResourceParserTest {
+
+  private ALAPipelinesConfig alaConfig;
+
+  @Before
+  public void setup() {
+    String absolutePath = new File("src/test/resources").getAbsolutePath();
+    LocationInfoConfig extLiConfig =
+        new LocationInfoConfig(null, null, absolutePath + "/stateProvincesTest.tsv");
+    alaConfig = new ALAPipelinesConfig();
+    alaConfig.setLocationInfoConfig(extLiConfig);
+  }
+
+  @Test
+  public void stateNameMatchingTest() throws FileNotFoundException {
+    Assert.assertEquals(
+        "New Yorkistan",
+        StateProvinceParser.getInstance(
+                alaConfig.getLocationInfoConfig().getStateProvinceNamesFile())
+            .parse("New Yorkistan")
+            .getPayload());
+  }
+}

--- a/livingatlas/pipelines/src/test/resources/stateProvincesTest.tsv
+++ b/livingatlas/pipelines/src/test/resources/stateProvincesTest.tsv
@@ -1,0 +1,1 @@
+New Yorkistan	New Yorkistan


### PR DESCRIPTION
This PR allows custom external stateProvince file as [StateProvinceCentrePoints](https://github.com/gbif/pipelines/blob/dev/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/StateProvinceCentrePoints.java) and [CountryCentrePoints](https://github.com/gbif/pipelines/blob/dev/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/vocabulary/CountryCentrePoints.java).

Added a testing resource using the fictional https://en.wikipedia.org/wiki/New_Yorkistan