### PR TITLE
Fix for 772

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/utils/DumpDatasetSize.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/utils/DumpDatasetSize.java
@@ -81,15 +81,20 @@ public class DumpDatasetSize {
       throws IOException {
     Map<String, Long> counts = new HashMap<>();
     FileStatus[] fileStatuses = fs.listStatus(new Path(inputPath));
+    log.info("Datasets counts from {}", inputPath);
     for (FileStatus fileStatus : fileStatuses) {
       if (fileStatus.isDirectory()) {
-
         String datasetID =
             fileStatus
                 .getPath()
                 .toString()
                 .substring(fileStatus.getPath().toString().lastIndexOf('/') + 1);
-        counts.put(datasetID, ValidationUtils.readVerbatimCount(fs, inputPath, datasetID, 1));
+        try {
+          counts.put(datasetID, ValidationUtils.readVerbatimCount(fs, inputPath, datasetID, 1));
+        } catch (Exception e) {
+          log.error("Dataset count of {} failed", datasetID);
+          throw (e);
+        }
       }
     }
     return counts;

--- a/livingatlas/pipelines/src/main/java/au/org/ala/utils/ValidationUtils.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/utils/ValidationUtils.java
@@ -324,9 +324,15 @@ public class ValidationUtils {
       return -1L;
     }
 
-    // the YAML files created by metrics are UTF-16 encoded
-    Map<String, Object> metrics =
-        yaml.load(new InputStreamReader(fs.open(validationMetrics), StandardCharsets.UTF_16));
+    Map<String, Object> metrics;
+    try {
+      // the YAML files created by metrics should be UTF-16 encoded
+      metrics =
+          yaml.load(new InputStreamReader(fs.open(validationMetrics), StandardCharsets.UTF_16));
+    } catch (ClassCastException e) {
+      // but let's try with default encoding if not
+      metrics = yaml.load(new InputStreamReader(fs.open(validationMetrics)));
+    }
 
     return Long.parseLong(metrics.getOrDefault("archiveToErCountAttempted", "-1").toString());
   }


### PR DESCRIPTION
This PR fixes #772.

Without this PR:
```
[main] DEBUG org.apache.htrace.core.Tracer  - sampler.classes = ; loaded no samplers
[main] DEBUG org.apache.htrace.core.Tracer  - span.receiver.classes = ; loaded no span receivers
Exception in thread "main" java.lang.ClassCastException: java.lang.String cannot be cast to java.util.Map
	at au.org.ala.utils.ValidationUtils.readVerbatimCount(ValidationUtils.java:329)
	at au.org.ala.utils.DumpDatasetSize.readDatasetCounts(DumpDatasetSize.java:92)
	at au.org.ala.utils.DumpDatasetSize.run(DumpDatasetSize.java:64)
	at au.org.ala.utils.DumpDatasetSize.main(DumpDatasetSize.java:55)
```

With this PR:

```
[main] DEBUG org.apache.htrace.core.Tracer  - sampler.classes = ; loaded no samplers
[main] DEBUG org.apache.htrace.core.Tracer  - span.receiver.classes = ; loaded no span receivers
INFO  [2022-08-25 19:30:19,599+0200] [main] au.org.ala.utils.DumpDatasetSize: Datasets counts from /data/pipelines-data
INFO  [2022-08-25 19:30:19,636+0200] [main] au.org.ala.utils.DumpDatasetSize: Dataset list of size 3 written to /tmp/dataset-counts.csv

Process finished with exit code 0
```