### PR TITLE
Merge of ALA extensions to support Event ingestion and indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ livingatlas/debian/files
 livingatlas/debian/la-pipelines
 livingatlas/debian/la-pipelines-migration/
 livingatlas/debian/maven-repo-local/
+dependency-reduced-pom.xml
+/**/dependency-reduced-pom.xml

--- a/livingatlas/configs/la-pipelines-emr.yaml
+++ b/livingatlas/configs/la-pipelines-emr.yaml
@@ -94,6 +94,11 @@ outlier:
   targetPath: hdfs:///pipelines-outlier
   allDatasetsInputPath: hdfs:////pipelines-all-datasets
 
+elastic:
+  inputPath: hdfs:///pipelines-data
+  targetPath: hdfs:///pipelines-data
+  esSchemaPath: /tmp/es-event-core-schema.json
+
 gbifConfig:
   vocabularyConfig:
     vocabulariesPath: /data/pipelines-vocabularies/
@@ -102,6 +107,8 @@ gbifConfig:
       http://rs.tdwg.org/dwc/terms/lifeStage: LifeStage
       http://rs.tdwg.org/dwc/terms/establishmentMeans: EstablishmentMeans
       http://rs.tdwg.org/dwc/terms/pathway: Pathway
+      http://rs.gbif.org/terms/1.0/eventType: EventType
+      http://rs.tdwg.org/dwc/terms/occurrenceStatus: OccurrenceStatus
 
 # class: DumpArchiveList
 dataset-archive-list:
@@ -118,7 +125,7 @@ collectory:
     Authorization: add-a-api-key-here
 
 alaNameMatch:
-  wsUrl: http://localhost:9179
+  wsUrl: https://namematching-ws-test.ala.org.au
   timeoutSec: 70
   retryConfig:
     maxAttempts: 5

--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -82,6 +82,31 @@ geocodeConfig:
     field: FEATURE
 
 gbifConfig:
+  extensionsAllowedForVerbatimSet:
+    - http://rs.tdwg.org/ac/terms/Multimedia
+    - http://data.ggbn.org/schemas/ggbn/terms/Amplification
+    - http://data.ggbn.org/schemas/ggbn/terms/Cloning
+    - http://data.ggbn.org/schemas/ggbn/terms/GelImage
+    - http://data.ggbn.org/schemas/ggbn/terms/Loan
+    - http://data.ggbn.org/schemas/ggbn/terms/MaterialSample
+    - http://data.ggbn.org/schemas/ggbn/terms/Permit
+    - http://data.ggbn.org/schemas/ggbn/terms/Preparation
+    - http://data.ggbn.org/schemas/ggbn/terms/Preservation
+    - http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact
+    - http://rs.tdwg.org/chrono/terms/ChronometricAge
+    - http://purl.org/germplasm/germplasmTerm#GermplasmAccession
+    - http://purl.org/germplasm/germplasmTerm#MeasurementScore
+    - http://purl.org/germplasm/germplasmTerm#MeasurementTrait
+    - http://purl.org/germplasm/germplasmTerm#MeasurementTrial
+    - http://rs.tdwg.org/dwc/terms/Identification
+    - http://rs.tdwg.org/dwc/terms/Occurrence
+    - http://rs.gbif.org/terms/1.0/Identifier
+    - http://rs.gbif.org/terms/1.0/Image
+    - http://rs.tdwg.org/dwc/terms/MeasurementOrFact
+    - http://rs.gbif.org/terms/1.0/Multimedia
+    - http://rs.gbif.org/terms/1.0/Reference
+    - http://rs.tdwg.org/dwc/terms/ResourceRelationship
+    - http://rs.gbif.org/terms/1.0/DNADerivedData
   vocabularyConfig:
     vocabulariesPath: /data/pipelines-vocabularies/
     vocabulariesNames:
@@ -219,6 +244,20 @@ solr:
   includeClustering: false
   runner: SparkRunner
   zkHost: localhost:9983
+
+# class: au.org.ala.pipelines.beam.IndexRecordToSolrPipeline
+elastic:
+  appName: Elastic indexing for {datasetId}
+  inputPath: '{fsPath}/pipelines-data'
+  targetPath: '{fsPath}/pipelines-data'
+  runner: SparkRunner
+  esHosts: http://localhost:9200
+  esSchemaPath: /tmp/es-parent-schema.json
+  esAlias: event
+  esIndexName: 'event_{datasetId}'
+  indexNumberShards: 1
+  indexNumberReplicas: 0
+  esDocumentId: internalId
 
 export:
   appName: DwCA export for {datasetId}
@@ -452,3 +491,16 @@ solr-sh-args:
     executor-cores: 8
     executor-memory: 22G
     driver-memory: 6G
+
+elastic-sh-args:
+  local:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-embedded:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-cluster:
+    conf: spark.default.parallelism=48
+    num-executors: 6
+    executor-cores: 8
+    executor-memory: 22G
+    driver-memory: 6G
+

--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -372,6 +372,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-elasticsearch</artifactId>
+      <version>${apache.beam.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-join-library</artifactId>
       <version>${apache.beam.version}</version>
     </dependency>
@@ -843,6 +848,7 @@
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven-plugin-annotations.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test -->
@@ -928,6 +934,10 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gbif.pipelines</groupId>
+      <artifactId>elasticsearch-tools</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAEventToEsIndexPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAEventToEsIndexPipeline.java
@@ -1,0 +1,465 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.ALL_AVRO;
+
+import au.org.ala.pipelines.transforms.ALADerivedMetadataTransform;
+import au.org.ala.pipelines.transforms.ALAMetadataTransform;
+import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
+import au.org.ala.pipelines.util.ElasticsearchTools;
+import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
+import au.org.ala.utils.ValidationUtils;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.elasticsearch.ElasticsearchIO;
+import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.common.beam.metrics.MetricsHandler;
+import org.gbif.pipelines.common.beam.options.EsIndexingPipelineOptions;
+import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
+import org.gbif.pipelines.common.beam.utils.PathBuilder;
+import org.gbif.pipelines.core.pojo.HdfsConfigs;
+import org.gbif.pipelines.core.utils.FsUtils;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.DerivedMetadataRecord;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+import org.gbif.pipelines.transforms.common.NotNullOrEmptyFilter;
+import org.gbif.pipelines.transforms.converters.ParentEventExpandTransform;
+import org.gbif.pipelines.transforms.core.ConvexHullFn;
+import org.gbif.pipelines.transforms.core.DerivedMetadataTransform;
+import org.gbif.pipelines.transforms.core.EventCoreTransform;
+import org.gbif.pipelines.transforms.core.InheritedFieldsTransform;
+import org.gbif.pipelines.transforms.core.LocationTransform;
+import org.gbif.pipelines.transforms.core.TemporalCoverageFn;
+import org.gbif.pipelines.transforms.core.TemporalTransform;
+import org.gbif.pipelines.transforms.core.VerbatimTransform;
+import org.gbif.pipelines.transforms.extension.AudubonTransform;
+import org.gbif.pipelines.transforms.extension.ImageTransform;
+import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
+import org.gbif.pipelines.transforms.extension.MultimediaTransform;
+import org.gbif.pipelines.transforms.specific.IdentifierTransform;
+import org.slf4j.MDC;
+
+/**
+ * Pipeline sequence:
+ *
+ * <pre>
+ *    1) Reads avro files:
+ *      {@link EventCoreRecord},
+ *      {@link IdentifierRecord},
+ *      {@link ExtendedRecord},
+ *    2) Joins avro files
+ *    3) Converts to json model (resources/elasticsearch/es-event-core-schema.json)
+ *    4) Pushes data to Elasticsearch instance
+ * </pre>
+ *
+ * <p>How to run:
+ *
+ * <pre>{@code
+ * java -jar target/examples-pipelines-BUILD_VERSION-shaded.jar
+ *  --pipelineStep=INTERPRETED_TO_ES_INDEX \
+ *  --datasetId=4725681f-06af-4b1e-8fff-e31e266e0a8f \
+ *  --attempt=1 \
+ *  --runner=SparkRunner \
+ *  --inputPath=/path \
+ *  --targetPath=/path \
+ *  --esIndexName=test2_java \
+ *  --esAlias=occurrence2_java \
+ *  --indexNumberShards=3 \
+ * --esHosts=http://ADDRESS:9200,http://ADDRESS:9200,http://ADDRESS:9200 \
+ * --esDocumentId=id
+ *
+ * }</pre>
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ALAEventToEsIndexPipeline {
+
+  // constrained until we figure out our needs and we can summarize it
+  private static final int MAX_TAXON_PER_EVENTS = 50;
+
+  public static void main(String[] args) throws IOException {
+    String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "elastic");
+    EsIndexingPipelineOptions options = PipelinesOptionsFactory.createIndexing(combinedArgs);
+    run(options);
+  }
+
+  public static void run(EsIndexingPipelineOptions options) {
+    run(options, Pipeline::create);
+  }
+
+  public static void run(
+      EsIndexingPipelineOptions options,
+      Function<EsIndexingPipelineOptions, Pipeline> pipelinesFn) {
+
+    MDC.put("datasetKey", options.getDatasetId());
+    MDC.put("attempt", options.getAttempt().toString());
+
+    String esDocumentId = options.getEsDocumentId();
+
+    ElasticsearchTools.createIndexAndAliasForDefault(options);
+
+    log.info("Adding step 1: Options");
+    UnaryOperator<String> eventsPathFn =
+        t -> PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Event, t, ALL_AVRO);
+
+    UnaryOperator<String> occurrencesPathFn =
+        t ->
+            PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Occurrence, t, ALL_AVRO);
+
+    UnaryOperator<String> identifiersPathFn =
+        t -> ALAFsUtils.buildPathIdentifiersUsingTargetPath(options, t, ALL_AVRO);
+
+    HdfsConfigs hdfsConfigs =
+        HdfsConfigs.create(options.getHdfsSiteConfig(), options.getCoreSiteConfig());
+    String occurrencesMetadataPath =
+        PathBuilder.buildDatasetAttemptPath(options, ValidationUtils.VERBATIM_METRICS, false);
+
+    boolean datasetHasOccurrences = FsUtils.fileExists(hdfsConfigs, occurrencesMetadataPath);
+
+    Pipeline p = pipelinesFn.apply(options);
+
+    log.info("Adding step 2: Creating transformations");
+    ALAMetadataTransform alaMetadataTransform = ALAMetadataTransform.builder().create();
+    // Core
+    EventCoreTransform eventCoreTransform = EventCoreTransform.builder().create();
+    IdentifierTransform identifierTransform = IdentifierTransform.builder().create();
+    VerbatimTransform verbatimTransform = VerbatimTransform.create();
+    TemporalTransform temporalTransform = TemporalTransform.builder().create();
+    LocationTransform locationTransform = LocationTransform.builder().create();
+    LocationTransform parentLocationTransform = LocationTransform.builder().create();
+    ALATaxonomyTransform alaTaxonomyTransform = ALATaxonomyTransform.builder().create();
+    MeasurementOrFactTransform measurementOrFactTransform =
+        MeasurementOrFactTransform.builder().create();
+
+    // Extension
+    MultimediaTransform multimediaTransform = MultimediaTransform.builder().create();
+    AudubonTransform audubonTransform = AudubonTransform.builder().create();
+    ImageTransform imageTransform = ImageTransform.builder().create();
+
+    log.info("Adding step 3: Creating beam pipeline");
+    PCollectionView<ALAMetadataRecord> metadataView =
+        p.apply("Read Metadata", alaMetadataTransform.read(eventsPathFn))
+            .apply("Convert to view", View.asSingleton());
+
+    PCollection<KV<String, ExtendedRecord>> verbatimCollection =
+        p.apply("Read Event Verbatim", verbatimTransform.read(eventsPathFn))
+            .apply("Map Verbatim to KV", verbatimTransform.toKv());
+
+    PCollection<KV<String, IdentifierRecord>> identifierCollection =
+        p.apply("Read Event identifiers", identifierTransform.read(eventsPathFn))
+            .apply("Map identifiers to KV", identifierTransform.toKv());
+
+    PCollection<KV<String, EventCoreRecord>> eventCoreCollection =
+        p.apply("Read Event core", eventCoreTransform.read(eventsPathFn))
+            .apply("Map Event core to KV", eventCoreTransform.toKv());
+
+    PCollection<KV<String, TemporalRecord>> temporalCollection =
+        p.apply("Read Event Temporal", temporalTransform.read(eventsPathFn))
+            .apply("Map Temporal to KV", temporalTransform.toKv());
+
+    PCollection<KV<String, LocationRecord>> locationCollection =
+        p.apply("Read Event Location", locationTransform.read(eventsPathFn))
+            .apply("Map Location to KV", locationTransform.toKv());
+
+    PCollection<KV<String, ALATaxonRecord>> taxonCollection =
+        p.apply("Read event taxon records", alaTaxonomyTransform.read(eventsPathFn))
+            .apply("Map event taxon records to KV", alaTaxonomyTransform.toCoreIdKv());
+
+    InheritedFields inheritedFields =
+        InheritedFields.builder()
+            .inheritedFieldsTransform(InheritedFieldsTransform.builder().build())
+            .locationCollection(locationCollection)
+            .locationTransform(locationTransform)
+            .temporalCollection(temporalCollection)
+            .temporalTransform(temporalTransform)
+            .eventCoreCollection(eventCoreCollection)
+            .eventCoreTransform(eventCoreTransform)
+            .build();
+
+    PCollection<KV<String, LocationInheritedRecord>> locationInheritedRecords =
+        inheritedFields.inheritLocationFields();
+
+    PCollection<KV<String, TemporalInheritedRecord>> temporalInheritedRecords =
+        inheritedFields.inheritTemporalFields();
+
+    PCollection<KV<String, EventInheritedRecord>> eventInheritedRecords =
+        inheritedFields.inheritEventFields();
+
+    PCollection<KV<String, DerivedMetadataRecord>> derivedMetadataRecordCollection =
+        DerivedMetadata.builder()
+            .pipeline(p)
+            .verbatimTransform(verbatimTransform)
+            .temporalTransform(temporalTransform)
+            .parentLocationTransform(parentLocationTransform)
+            .taxonomyTransform(alaTaxonomyTransform)
+            .locationTransform(locationTransform)
+            .eventCoreTransform(eventCoreTransform)
+            .verbatimCollection(verbatimCollection)
+            .temporalCollection(temporalCollection)
+            .locationCollection(locationCollection)
+            .taxonCollection(taxonCollection)
+            .eventCoreCollection(eventCoreCollection)
+            .occurrencesPathFn(occurrencesPathFn)
+            .datasetHasOccurrences(datasetHasOccurrences)
+            .build()
+            .calculate();
+
+    PCollection<KV<String, MultimediaRecord>> multimediaCollection =
+        p.apply("Read Event Multimedia", multimediaTransform.read(eventsPathFn))
+            .apply("Map Multimedia to KV", multimediaTransform.toKv());
+
+    PCollection<KV<String, ImageRecord>> imageCollection =
+        p.apply("Read Event Image", imageTransform.read(eventsPathFn))
+            .apply("Map Image to KV", imageTransform.toKv());
+
+    PCollection<KV<String, AudubonRecord>> audubonCollection =
+        p.apply("Read Event Audubon", audubonTransform.read(eventsPathFn))
+            .apply("Map Audubon to KV", audubonTransform.toKv());
+
+    PCollection<KV<String, MeasurementOrFactRecord>> measurementOrFactCollection =
+        p.apply("Read Measurement or fact", measurementOrFactTransform.read(eventsPathFn))
+            .apply("Map Measurement or fact to KV", measurementOrFactTransform.toKv());
+
+    log.info("Adding step 3: Converting into a json object");
+    SingleOutput<KV<String, CoGbkResult>, String> eventJsonDoFn =
+        ALAParentJsonTransform.builder()
+            .extendedRecordTag(verbatimTransform.getTag())
+            .identifierRecordTag(identifierTransform.getTag())
+            .eventCoreRecordTag(eventCoreTransform.getTag())
+            .temporalRecordTag(temporalTransform.getTag())
+            .locationRecordTag(locationTransform.getTag())
+            .multimediaRecordTag(multimediaTransform.getTag())
+            .imageRecordTag(imageTransform.getTag())
+            .audubonRecordTag(audubonTransform.getTag())
+            .derivedMetadataRecordTag(DerivedMetadataTransform.tag())
+            .measurementOrFactRecordTag(measurementOrFactTransform.getTag())
+            .locationInheritedRecordTag(InheritedFieldsTransform.LIR_TAG)
+            .temporalInheritedRecordTag(InheritedFieldsTransform.TIR_TAG)
+            .eventInheritedRecordTag(InheritedFieldsTransform.EIR_TAG)
+            .metadataView(metadataView)
+            .build()
+            .converter();
+
+    PCollection<String> eventJsonCollection =
+        KeyedPCollectionTuple
+            // Core
+            .of(verbatimTransform.getTag(), verbatimCollection)
+            .and(identifierTransform.getTag(), identifierCollection)
+            .and(eventCoreTransform.getTag(), eventCoreCollection)
+            .and(temporalTransform.getTag(), temporalCollection)
+            .and(locationTransform.getTag(), locationCollection)
+            .and(multimediaTransform.getTag(), multimediaCollection)
+            .and(imageTransform.getTag(), imageCollection)
+            .and(audubonTransform.getTag(), audubonCollection)
+            .and(DerivedMetadataTransform.tag(), derivedMetadataRecordCollection)
+            .and(measurementOrFactTransform.getTag(), measurementOrFactCollection)
+            .and(InheritedFieldsTransform.LIR_TAG, locationInheritedRecords)
+            .and(InheritedFieldsTransform.TIR_TAG, temporalInheritedRecords)
+            .and(InheritedFieldsTransform.EIR_TAG, eventInheritedRecords)
+            // Apply
+            .apply("Grouping objects", CoGroupByKey.create())
+            .apply("Merging to json", eventJsonDoFn);
+
+    PCollection<String> occurrenceJsonCollection =
+        datasetHasOccurrences
+            ? ALAOccurrenceToEsIndexPipeline.IndexingTransform.builder()
+                .pipeline(p)
+                .identifiersPathFn(identifiersPathFn)
+                .occurrencePathFn(occurrencesPathFn)
+                .eventsPathFn(eventsPathFn)
+                .asParentChildRecord(true)
+                .build()
+                .apply()
+            : p.apply("Create empty occurrenceJsonCollection", Create.empty(StringUtf8Coder.of()));
+
+    // Merge events and occurrences
+    PCollection<String> jsonCollection =
+        PCollectionList.of(eventJsonCollection)
+            .and(occurrenceJsonCollection)
+            .apply("Join event and occurrence Json records", Flatten.pCollections());
+
+    log.info("Adding step 6: Elasticsearch indexing");
+    ElasticsearchIO.ConnectionConfiguration esConfig =
+        ElasticsearchIO.ConnectionConfiguration.create(
+                options.getEsHosts(), options.getEsIndexName(), "_doc")
+            .withConnectTimeout(180000);
+
+    if (Objects.nonNull(options.getEsUsername()) && Objects.nonNull(options.getEsPassword())) {
+      esConfig =
+          esConfig.withUsername(options.getEsUsername()).withPassword(options.getEsPassword());
+    }
+
+    ElasticsearchIO.Write writeIO =
+        ElasticsearchIO.write()
+            .withConnectionConfiguration(esConfig)
+            .withMaxBatchSizeBytes(options.getEsMaxBatchSizeBytes())
+            .withRoutingFn(
+                input ->
+                    Optional.of(input)
+                        .filter(i -> i.hasNonNull("joinRecord"))
+                        .map(i -> i.get("joinRecord"))
+                        .filter(i -> i.hasNonNull("parent"))
+                        .map(i -> i.get("parent").asText())
+                        .orElse(input.get("internalId").asText()))
+            .withMaxBatchSize(options.getEsMaxBatchSize());
+
+    // Ignore gbifID as ES doc ID, useful for validator
+    if (esDocumentId != null && !esDocumentId.isEmpty()) {
+      writeIO = writeIO.withIdFn(input -> input.get(esDocumentId).asText());
+    }
+
+    jsonCollection.apply("Push records to ES", writeIO);
+
+    // run the AVRO builder
+    ALAEventToSearchAvroPipeline.run(options);
+
+    log.info("Running the pipeline");
+    try {
+      PipelineResult result = p.run();
+      result.waitUntilFinish();
+      log.info("Save metrics into the file and set files owner");
+      MetricsHandler.saveCountersToTargetPathFile(options, result.metrics());
+    } catch (Exception e) {
+      log.error("Exception thrown", e);
+      e.printStackTrace();
+    }
+
+    log.info("Pipeline has been finished");
+  }
+
+  @Builder
+  static class DerivedMetadata {
+    private final Pipeline pipeline;
+    private final VerbatimTransform verbatimTransform;
+    private final TemporalTransform temporalTransform;
+    private final LocationTransform parentLocationTransform;
+    private final ALATaxonomyTransform taxonomyTransform;
+    private final EventCoreTransform eventCoreTransform;
+    private final LocationTransform locationTransform;
+    private final PCollection<KV<String, ExtendedRecord>> verbatimCollection;
+    private final PCollection<KV<String, TemporalRecord>> temporalCollection;
+    private final PCollection<KV<String, LocationRecord>> locationCollection;
+    private final PCollection<KV<String, ALATaxonRecord>> taxonCollection;
+    private final PCollection<KV<String, EventCoreRecord>> eventCoreCollection;
+    private final UnaryOperator<String> occurrencesPathFn;
+    private final boolean datasetHasOccurrences;
+
+    /** Calculates the simple Temporal Coverage of an Event. */
+    private PCollection<KV<String, EventDate>> temporalCoverage() {
+      PCollection<KV<String, TemporalRecord>> eventOccurrenceTemporalCollection =
+          datasetHasOccurrences
+              ? pipeline
+                  .apply(
+                      "Read occurrence event temporal records",
+                      temporalTransform.read(occurrencesPathFn))
+                  .apply(
+                      "Remove temporal records with null core ids",
+                      Filter.by(NotNullOrEmptyFilter.of(TemporalRecord::getCoreId)))
+                  .apply(
+                      "Map occurrence events temporal records to KV",
+                      temporalTransform.toCoreIdKv())
+              : pipeline.apply(
+                  "Create empty eventOccurrenceTemporalCollection",
+                  Create.empty(new TypeDescriptor<KV<String, TemporalRecord>>() {}));
+
+      // Creates a Map of all events and its sub events
+      PCollection<KV<String, TemporalRecord>> temporalRecordsOfSubEvents =
+          ParentEventExpandTransform.createTemporalTransform(
+                  temporalTransform.getTag(),
+                  eventCoreTransform.getTag(),
+                  temporalTransform.getEdgeTag())
+              .toSubEventsRecords("Temporal", temporalCollection, eventCoreCollection);
+
+      return PCollectionList.of(temporalCollection)
+          .and(eventOccurrenceTemporalCollection)
+          .and(temporalRecordsOfSubEvents)
+          .apply("Joining temporal records", Flatten.pCollections())
+          .apply("Calculate the temporal coverage", Combine.perKey(new TemporalCoverageFn()));
+    }
+
+    private PCollection<KV<String, String>> convexHull() {
+      PCollection<KV<String, LocationRecord>> eventOccurrenceLocationCollection =
+          datasetHasOccurrences
+              ? pipeline
+                  .apply(
+                      "Read occurrence events locations",
+                      parentLocationTransform.read(occurrencesPathFn))
+                  .apply(
+                      "Remove location records with null core ids",
+                      Filter.by(NotNullOrEmptyFilter.of(LocationRecord::getCoreId)))
+                  .apply(
+                      "Map occurrence events locations to KV", parentLocationTransform.toCoreIdKv())
+              : pipeline.apply(
+                  "Create empty eventOccurrenceLocationCollection",
+                  Create.empty(new TypeDescriptor<KV<String, LocationRecord>>() {}));
+
+      PCollection<KV<String, LocationRecord>> locationRecordsOfSubEvents =
+          ParentEventExpandTransform.createLocationTransform(
+                  locationTransform.getTag(),
+                  eventCoreTransform.getTag(),
+                  locationTransform.getEdgeTag())
+              .toSubEventsRecords("Location", locationCollection, eventCoreCollection);
+
+      return PCollectionList.of(locationCollection)
+          .and(eventOccurrenceLocationCollection)
+          .and(locationRecordsOfSubEvents)
+          .apply("Joining location records", Flatten.pCollections())
+          .apply(
+              "Calculate the WKT Convex Hull of all records", Combine.perKey(new ConvexHullFn()));
+    }
+
+    PCollection<KV<String, DerivedMetadataRecord>> calculate() {
+
+      PCollection<KV<String, ExtendedRecord>> eventOccurrenceVerbatimCollection =
+          datasetHasOccurrences
+              ? pipeline
+                  .apply(
+                      "Read event occurrences verbatim", verbatimTransform.read(occurrencesPathFn))
+                  .apply(
+                      "Remove verbatim records with null parent ids",
+                      Filter.by(NotNullOrEmptyFilter.of((ExtendedRecord er) -> er.getCoreId())))
+                  .apply("Map event occurrences verbatim to KV", verbatimTransform.toParentKv())
+              : pipeline.apply(
+                  "Create empty eventOccurrenceVerbatimCollection",
+                  Create.empty(new TypeDescriptor<KV<String, ExtendedRecord>>() {}));
+
+      return KeyedPCollectionTuple.of(ConvexHullFn.tag(), convexHull())
+          .and(TemporalCoverageFn.tag(), temporalCoverage())
+          .and(
+              verbatimTransform.getTag(),
+              PCollectionList.of(eventOccurrenceVerbatimCollection)
+                  .and(verbatimCollection)
+                  .apply("Join event and occurrence verbatim records", Flatten.pCollections()))
+          .apply("Grouping derived metadata data", CoGroupByKey.create())
+          .apply(
+              "Creating derived metadata records",
+              ALADerivedMetadataTransform.builder()
+                  .convexHullTag(ConvexHullFn.tag())
+                  .temporalCoverageTag(TemporalCoverageFn.tag())
+                  .extendedRecordTag(verbatimTransform.getTag())
+                  .build()
+                  .converter());
+    }
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAEventToSearchAvroPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAEventToSearchAvroPipeline.java
@@ -1,0 +1,247 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.ALL_AVRO;
+
+import au.org.ala.pipelines.transforms.ALAEventToSearchTransform;
+import au.org.ala.pipelines.transforms.ALAMetadataTransform;
+import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
+import au.org.ala.utils.CombinedYamlConfiguration;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.file.CodecFactory;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.AvroIO;
+import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.*;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.common.beam.metrics.MetricsHandler;
+import org.gbif.pipelines.common.beam.options.EsIndexingPipelineOptions;
+import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
+import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
+import org.gbif.pipelines.common.beam.utils.PathBuilder;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+import org.gbif.pipelines.transforms.core.*;
+import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
+import org.slf4j.MDC;
+
+/**
+ * Pipeline that generates an AVRO index that will support a Spark SQL query interface for
+ * downloads.
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ALAEventToSearchAvroPipeline {
+
+  private static final CodecFactory BASE_CODEC = CodecFactory.snappyCodec();
+
+  private static final TupleTag<Iterable<String>> TAXON_IDS_TAG = new TupleTag<>();
+
+  public static void main(String[] args) throws IOException {
+    String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "interpret");
+    EsIndexingPipelineOptions options = PipelinesOptionsFactory.createIndexing(combinedArgs);
+    run(options);
+  }
+
+  public static void run(InterpretationPipelineOptions options) {
+    run(options, Pipeline::create);
+  }
+
+  public static void run(
+      InterpretationPipelineOptions options,
+      Function<InterpretationPipelineOptions, Pipeline> pipelinesFn) {
+
+    MDC.put("datasetKey", options.getDatasetId());
+    MDC.put("attempt", options.getAttempt().toString());
+
+    log.info("Adding step 1: Options");
+    UnaryOperator<String> eventPathFn =
+        t -> PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Event, t, ALL_AVRO);
+
+    UnaryOperator<String> occurrencesPathFn =
+        t ->
+            PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Occurrence, t, ALL_AVRO);
+
+    options.setAppName("Event indexing of " + options.getDatasetId());
+    Pipeline p = pipelinesFn.apply(options);
+
+    log.info("Adding step 2: Creating transformations");
+    ALAMetadataTransform alaMetadataTransform = ALAMetadataTransform.builder().create();
+    // Core
+    EventCoreTransform eventCoreTransform = EventCoreTransform.builder().create();
+    TemporalTransform temporalTransform = TemporalTransform.builder().create();
+    LocationTransform locationTransform = LocationTransform.builder().create();
+
+    // Taxonomy transform for loading occurrence taxonomy info
+    ALATaxonomyTransform alaTaxonomyTransform = ALATaxonomyTransform.builder().create();
+
+    MeasurementOrFactTransform measurementOrFactTransform =
+        MeasurementOrFactTransform.builder().create();
+
+    log.info("Adding step 3: Creating beam pipeline");
+    PCollectionView<ALAMetadataRecord> metadataView =
+        p.apply("Read Metadata", alaMetadataTransform.read(eventPathFn))
+            .apply("Convert to view", View.asSingleton());
+
+    PCollection<KV<String, EventCoreRecord>> eventCoreCollection =
+        p.apply("Read Event core", eventCoreTransform.read(eventPathFn))
+            .apply("Map Event core to KV", eventCoreTransform.toKv());
+
+    PCollection<KV<String, TemporalRecord>> temporalCollection =
+        p.apply("Read Temporal", temporalTransform.read(eventPathFn))
+            .apply("Map Temporal to KV", temporalTransform.toKv());
+
+    PCollection<KV<String, LocationRecord>> locationCollection =
+        p.apply("Read Location", locationTransform.read(eventPathFn))
+            .apply("Map Location to KV", locationTransform.toKv());
+
+    PCollection<KV<String, MeasurementOrFactRecord>> measurementOrFactCollection =
+        p.apply("Read Measurement or fact", measurementOrFactTransform.read(eventPathFn))
+            .apply("Map Measurement or fact to KV", measurementOrFactTransform.toKv());
+
+    InheritedFields inheritedFields =
+        InheritedFields.builder()
+            .inheritedFieldsTransform(InheritedFieldsTransform.builder().build())
+            .locationCollection(locationCollection)
+            .locationTransform(locationTransform)
+            .temporalCollection(temporalCollection)
+            .temporalTransform(temporalTransform)
+            .eventCoreCollection(eventCoreCollection)
+            .eventCoreTransform(eventCoreTransform)
+            .build();
+
+    PCollection<KV<String, LocationInheritedRecord>> locationInheritedRecords =
+        inheritedFields.inheritLocationFields();
+
+    PCollection<KV<String, TemporalInheritedRecord>> temporalInheritedRecords =
+        inheritedFields.inheritTemporalFields();
+
+    PCollection<KV<String, EventInheritedRecord>> eventInheritedRecords =
+        inheritedFields.inheritEventFields();
+
+    // load the taxonomy from the occurrence records
+    PCollection<KV<String, ALATaxonRecord>> taxonCollection =
+        p.apply("Read taxa", alaTaxonomyTransform.read(occurrencesPathFn))
+            .apply("Map taxa to KV", alaTaxonomyTransform.toCoreIdKv());
+
+    PCollection<KV<String, Iterable<String>>> taxonIDCollection = keyByParentID(taxonCollection, p);
+
+    log.info("Adding step 3: Converting into a json object");
+    ParDo.SingleOutput<KV<String, CoGbkResult>, EventSearchRecord> eventSearchAvroFn =
+        ALAEventToSearchTransform.builder()
+            .eventCoreRecordTag(eventCoreTransform.getTag())
+            .temporalRecordTag(temporalTransform.getTag())
+            .locationRecordTag(locationTransform.getTag())
+            .measurementOrFactRecordTag(measurementOrFactTransform.getTag())
+            .taxonIDsTag(TAXON_IDS_TAG)
+            .locationInheritedRecordTag(InheritedFieldsTransform.LIR_TAG)
+            .temporalInheritedRecordTag(InheritedFieldsTransform.TIR_TAG)
+            .eventInheritedRecordTag(InheritedFieldsTransform.EIR_TAG)
+            .metadataView(metadataView)
+            .build()
+            .converter();
+
+    PCollection<EventSearchRecord> eventSearchCollection =
+        KeyedPCollectionTuple
+            // Core
+            .of(eventCoreTransform.getTag(), eventCoreCollection)
+            .and(temporalTransform.getTag(), temporalCollection)
+            .and(locationTransform.getTag(), locationCollection)
+            .and(measurementOrFactTransform.getTag(), measurementOrFactCollection)
+            .and(TAXON_IDS_TAG, taxonIDCollection)
+            // Inherited
+            .and(InheritedFieldsTransform.LIR_TAG, locationInheritedRecords)
+            .and(InheritedFieldsTransform.TIR_TAG, temporalInheritedRecords)
+            .and(InheritedFieldsTransform.EIR_TAG, eventInheritedRecords)
+            // Apply
+            .apply("Grouping objects", CoGroupByKey.create())
+            .apply("Merging to json", eventSearchAvroFn);
+
+    String avroPath =
+        String.join(
+            "/",
+            options.getInputPath(),
+            options.getDatasetId(),
+            options.getAttempt().toString(),
+            "search",
+            "event",
+            "search");
+
+    eventSearchCollection.apply(
+        AvroIO.write(EventSearchRecord.class)
+            .to(avroPath)
+            .withSuffix(".avro")
+            .withCodec(BASE_CODEC));
+
+    log.info("Running the pipeline");
+    try {
+      PipelineResult result = p.run();
+      result.waitUntilFinish();
+      log.info("Save metrics into the file and set files owner");
+      MetricsHandler.saveCountersToTargetPathFile(options, result.metrics());
+    } catch (Exception e) {
+      log.error("Exception thrown", e);
+    }
+
+    log.info("Pipeline has been finished");
+  }
+
+  private static PCollection<KV<String, Iterable<String>>> keyByParentID(
+      PCollection<KV<String, ALATaxonRecord>> taxonCollection, Pipeline p) {
+    return taxonCollection
+        .apply(
+            ParDo.of(
+                new DoFn<KV<String, ALATaxonRecord>, KV<String, Iterable<String>>>() {
+                  @ProcessElement
+                  public void processElement(
+                      @Element KV<String, ALATaxonRecord> source,
+                      OutputReceiver<KV<String, Iterable<String>>> out,
+                      ProcessContext c) {
+                    ALATaxonRecord taxon = source.getValue();
+                    List<String> taxonID = new ArrayList<>();
+                    taxonID.add(taxon.getKingdomID());
+                    taxonID.add(taxon.getPhylumID());
+                    taxonID.add(taxon.getOrderID());
+                    taxonID.add(taxon.getClassID());
+                    taxonID.add(taxon.getFamilyID());
+                    taxonID.add(taxon.getGenusID());
+                    taxonID.add(taxon.getSpeciesID());
+                    taxonID.stream().filter(x -> x != null);
+                    out.output(
+                        KV.of(
+                            taxon.getParentId(),
+                            taxonID.stream().filter(x -> x != null).collect(Collectors.toList())));
+                  }
+                })
+            // group by eventID, distinct
+            )
+        .apply(GroupByKey.create())
+        .apply(
+            ParDo.of(
+                new DoFn<KV<String, Iterable<Iterable<String>>>, KV<String, Iterable<String>>>() {
+                  @ProcessElement
+                  public void processElement(
+                      @Element KV<String, Iterable<Iterable<String>>> in,
+                      OutputReceiver<KV<String, Iterable<String>>> out,
+                      ProcessContext c) {
+                    Iterable<Iterable<String>> taxonIDs = in.getValue();
+                    Set<String> taxonIDSet = new HashSet<String>();
+                    taxonIDs.forEach(list -> list.forEach(taxonIDSet::add));
+                    out.output(
+                        KV.of(in.getKey(), taxonIDSet.stream().collect(Collectors.toList())));
+                  }
+                }));
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
@@ -121,7 +121,7 @@ public class ALAInterpretedToSensitivePipeline {
 
     PCollection<KV<String, ALATaxonRecord>> inputAlaTaxonCollection =
         p.apply("Read Taxon", alaTaxonomyTransform.read(inputPathFn))
-            .apply("Map Taxon to KV", alaTaxonomyTransform.toKv());
+            .apply("Map Taxon to KV", alaTaxonomyTransform.toCoreIdKv());
 
     KeyedPCollectionTuple<String> inputTuples =
         KeyedPCollectionTuple

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAOccurrenceToEsIndexPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAOccurrenceToEsIndexPipeline.java
@@ -1,0 +1,365 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.ALL_AVRO;
+
+import au.org.ala.pipelines.transforms.ALAMetadataTransform;
+import au.org.ala.pipelines.transforms.ALAOccurrenceJsonTransform;
+import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
+import au.org.ala.pipelines.transforms.ALAUUIDTransform;
+import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.extensions.joinlibrary.Join;
+import org.apache.beam.sdk.io.elasticsearch.ElasticsearchIO;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.*;
+import org.gbif.api.model.pipelines.StepType;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.common.beam.metrics.MetricsHandler;
+import org.gbif.pipelines.common.beam.options.EsIndexingPipelineOptions;
+import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
+import org.gbif.pipelines.common.beam.utils.PathBuilder;
+import org.gbif.pipelines.core.pojo.HdfsConfigs;
+import org.gbif.pipelines.core.utils.FsUtils;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.grscicoll.GrscicollRecord;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+import org.gbif.pipelines.transforms.core.*;
+import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
+import org.gbif.pipelines.transforms.extension.MultimediaTransform;
+import org.slf4j.MDC;
+
+/**
+ * Pipeline sequence:
+ *
+ * <pre>
+ *    1) Reads avro files:
+ *      {@link MetadataRecord},
+ *      {@link BasicRecord},
+ *      {@link TemporalRecord},
+ *      {@link MultimediaRecord},
+ *      {@link ImageRecord},
+ *      {@link TaxonRecord},
+ *      {@link GrscicollRecord},
+ *      {@link LocationRecord}
+ *    2) Joins avro files
+ *    3) Converts to json model (resources/elasticsearch/es-occurrence-schema.json)
+ *    4) Pushes data to Elasticsearch instance
+ * </pre>
+ *
+ * <p>How to run:
+ *
+ * <pre>{@code
+ * java -jar target/ingest-gbif-standalone-BUILD_VERSION-shaded.jar some.properties
+ *
+ * or pass all parameters:
+ *
+ * java -jar target/ingest-gbif-standalone-BUILD_VERSION-shaded.jar
+ *  --pipelineStep=INTERPRETED_TO_ES_INDEX \
+ *  --datasetId=4725681f-06af-4b1e-8fff-e31e266e0a8f \
+ *  --attempt=1 \
+ *  --runner=SparkRunner \
+ *  --inputPath=/path \
+ *  --targetPath=/path \
+ *  --esIndexName=test2_java \
+ *  --esAlias=occurrence2_java \
+ *  --indexNumberShards=3 \
+ * --esHosts=http://ADDRESS:9200,http://ADDRESS:9200,http://ADDRESS:9200 \
+ * --properties=/home/nvolik/Projects/GBIF/gbif-configuration/cli/dev/config/pipelines.properties \
+ * --esDocumentId=id
+ *
+ * }</pre>
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ALAOccurrenceToEsIndexPipeline {
+
+  public static void main(String[] args) throws Exception {
+    String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "elastic");
+    EsIndexingPipelineOptions options = PipelinesOptionsFactory.createIndexing(combinedArgs);
+    run(options);
+  }
+
+  public static void run(EsIndexingPipelineOptions options) {
+    run(options, Pipeline::create);
+  }
+
+  public static void run(
+      EsIndexingPipelineOptions options,
+      Function<EsIndexingPipelineOptions, Pipeline> pipelinesFn) {
+
+    String datasetId = options.getDatasetId();
+    Integer attempt = options.getAttempt();
+
+    MDC.put("datasetKey", datasetId);
+    MDC.put("attempt", attempt.toString());
+    MDC.put("step", StepType.INTERPRETED_TO_INDEX.name());
+
+    String esDocumentId = options.getEsDocumentId();
+
+    log.info("Adding step 1: Options");
+    UnaryOperator<String> occurrencesPathFn =
+        t ->
+            PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Occurrence, t, ALL_AVRO);
+
+    UnaryOperator<String> eventsPathFn =
+        t -> PathBuilder.buildPathInterpretUsingTargetPath(options, DwcTerm.Event, t, ALL_AVRO);
+
+    UnaryOperator<String> identifiersPathFn =
+        t -> ALAFsUtils.buildPathIdentifiersUsingTargetPath(options, t, ALL_AVRO);
+
+    String denormPath =
+        String.join(
+            "/",
+            options.getTargetPath(),
+            options.getDatasetId().trim(),
+            options.getAttempt().toString(),
+            "event",
+            "event_hierarchy",
+            "*.avro");
+
+    System.out.println("Using denorm events path  " + denormPath);
+
+    Pipeline p = pipelinesFn.apply(options);
+
+    PCollection<String> jsonCollection =
+        IndexingTransform.builder()
+            .pipeline(p)
+            .occurrencePathFn(occurrencesPathFn)
+            .eventsPathFn(eventsPathFn)
+            .identifiersPathFn(identifiersPathFn)
+            .asParentChildRecord(false)
+            .build()
+            .apply();
+
+    log.info("Adding step 4: Elasticsearch indexing");
+    ElasticsearchIO.ConnectionConfiguration esConfig =
+        ElasticsearchIO.ConnectionConfiguration.create(
+            options.getEsHosts(), options.getEsIndexName(), "_doc");
+
+    ElasticsearchIO.Write writeIO =
+        ElasticsearchIO.write()
+            .withConnectionConfiguration(esConfig)
+            .withMaxBatchSizeBytes(options.getEsMaxBatchSizeBytes())
+            .withMaxBatchSize(options.getEsMaxBatchSize());
+
+    // Ignore gbifID as ES doc ID, useful for validator
+    if (esDocumentId != null && !esDocumentId.isEmpty()) {
+      writeIO = writeIO.withIdFn(input -> input.get("id").asText());
+    }
+
+    jsonCollection.apply(writeIO);
+
+    log.info("Running the pipeline");
+    PipelineResult result = p.run();
+    result.waitUntilFinish();
+
+    log.info("Save metrics into the file and set files owner");
+    MetricsHandler.saveCountersToTargetPathFile(options, result.metrics());
+    String metadataPath =
+        PathBuilder.buildDatasetAttemptPath(options, options.getMetaFileName(), false);
+    FsUtils.setOwner(
+        HdfsConfigs.create(options.getHdfsSiteConfig(), options.getCoreSiteConfig()),
+        metadataPath,
+        "crap",
+        "supergroup");
+
+    log.info("Pipeline has been finished");
+  }
+
+  @Builder
+  static class IndexingTransform {
+
+    private final Pipeline pipeline;
+    private final UnaryOperator<String> occurrencePathFn;
+
+    private final UnaryOperator<String> identifiersPathFn;
+
+    private final UnaryOperator<String> eventsPathFn;
+
+    private final boolean asParentChildRecord;
+
+    // Init transforms
+    private final EventCoreTransform eventCoreTransform = EventCoreTransform.builder().create();
+    private final ALAUUIDTransform uuidTransform = ALAUUIDTransform.create();
+    private final BasicTransform basicTransform = BasicTransform.builder().create();
+    private final ALAMetadataTransform metadataTransform = ALAMetadataTransform.builder().create();
+    private final VerbatimTransform verbatimTransform = VerbatimTransform.create();
+    private final TemporalTransform temporalTransform = TemporalTransform.builder().create();
+    private final ALATaxonomyTransform taxonomyTransform = ALATaxonomyTransform.builder().create();
+    private final LocationTransform locationTransform = LocationTransform.builder().create();
+    private final MultimediaTransform multimediaTransform = MultimediaTransform.builder().create();
+    private final MeasurementOrFactTransform measurementOrFactTransform =
+        MeasurementOrFactTransform.builder().create();
+
+    PCollection<String> apply() {
+
+      PCollectionView<ALAMetadataRecord> metadataView =
+          pipeline
+              .apply("Read occurrence Metadata", metadataTransform.read(occurrencePathFn))
+              .apply("Convert to occurrence view", View.asSingleton());
+
+      PCollection<KV<String, ALAUUIDRecord>> uuidCollection =
+          pipeline
+              .apply("Read occurrence Verbatim", uuidTransform.read(identifiersPathFn))
+              .apply("Map occurrence Verbatim to KV", uuidTransform.toKv());
+
+      PCollection<KV<String, ExtendedRecord>> verbatimCollection =
+          pipeline
+              .apply("Read occurrence Verbatim", verbatimTransform.read(occurrencePathFn))
+              .apply("Map occurrence Verbatim to KV", verbatimTransform.toKv());
+
+      PCollection<KV<String, BasicRecord>> basicCollection =
+          pipeline
+              .apply("Read occurrence Basic", basicTransform.read(occurrencePathFn))
+              .apply("Map occurrence Basic to KV", basicTransform.toKv());
+
+      PCollection<KV<String, TemporalRecord>> temporalCollection =
+          pipeline
+              .apply("Read occurrence Temporal", temporalTransform.read(occurrencePathFn))
+              .apply("Map occurrence Temporal to KV", temporalTransform.toKv());
+
+      PCollection<KV<String, LocationRecord>> locationCollection =
+          pipeline
+              .apply("Read occurrence Location", locationTransform.read(occurrencePathFn))
+              .apply("Map occurrence Location to KV", locationTransform.toKv());
+
+      PCollection<KV<String, ALATaxonRecord>> taxonCollection =
+          pipeline
+              .apply("Read occurrence Taxon", taxonomyTransform.read(occurrencePathFn))
+              .apply("Map occurrence Taxon to KV", taxonomyTransform.toCoreIdKv());
+
+      PCollection<KV<String, MultimediaRecord>> multimediaCollection =
+          pipeline
+              .apply("Read occurrence Multimedia", multimediaTransform.read(occurrencePathFn))
+              .apply("Map occurrence Multimedia to KV", multimediaTransform.toKv());
+
+      PCollection<KV<String, MeasurementOrFactRecord>> measurementOrFactCollection =
+          pipeline
+              .apply(
+                  "Read occurrence Multimedia", measurementOrFactTransform.read(occurrencePathFn))
+              .apply("Map occurrence Multimedia to KV", measurementOrFactTransform.toKv());
+
+      PCollection<KV<String, String>> occMapping = getEventIDToOccurrenceID(verbatimCollection);
+
+      PCollection<KV<String, EventCoreRecord>> eventCoreCollection =
+          pipeline
+              .apply("Read occurrence Temporal", eventCoreTransform.read(eventsPathFn))
+              .apply("Map occurrence Temporal to KV", eventCoreTransform.toKv());
+
+      PCollection<KV<String, TemporalRecord>> eventTemporalCollection =
+          pipeline
+              .apply("Read occurrence Temporal", temporalTransform.read(eventsPathFn))
+              .apply("Map occurrence Temporal to KV", temporalTransform.toKv());
+
+      PCollection<KV<String, LocationRecord>> eventLocationCollection =
+          pipeline
+              .apply("Read occurrence Location", locationTransform.read(eventsPathFn))
+              .apply("Map occurrence Location to KV", locationTransform.toKv());
+
+      InheritedFields inheritedFields =
+          InheritedFields.builder()
+              .inheritedFieldsTransform(InheritedFieldsTransform.builder().build())
+              .locationCollection(eventLocationCollection)
+              .temporalCollection(eventTemporalCollection)
+              .eventCoreCollection(eventCoreCollection)
+              .locationTransform(locationTransform)
+              .temporalTransform(temporalTransform)
+              .eventCoreTransform(eventCoreTransform)
+              .build();
+
+      log.info("Adding step: Converting into a occurrence json object");
+      SingleOutput<KV<String, CoGbkResult>, String> occurrenceJsonDoFn =
+          ALAOccurrenceJsonTransform.builder()
+              .uuidRecordTag(uuidTransform.getTag())
+              .extendedRecordTag(verbatimTransform.getTag())
+              .basicRecordTag(basicTransform.getTag())
+              .temporalRecordTag(temporalTransform.getTag())
+              .locationRecordTag(locationTransform.getTag())
+              .taxonRecordTag(taxonomyTransform.getTag())
+              .multimediaRecordTag(multimediaTransform.getTag())
+              .measurementOrFactRecordTupleTag(measurementOrFactTransform.getTag())
+              .locationInheritedRecordTag(InheritedFieldsTransform.LIR_TAG)
+              .temporalInheritedRecordTag(InheritedFieldsTransform.TIR_TAG)
+              .eventInheritedRecordTag(InheritedFieldsTransform.EIR_TAG)
+              .eventCoreRecordTag(eventCoreTransform.getTag())
+              .metadataView(metadataView)
+              .asParentChildRecord(asParentChildRecord)
+              .build()
+              .converter();
+
+      PCollection<KV<String, EventCoreRecord>> eventCoreRecords =
+          Join.innerJoin(occMapping, eventCoreCollection).apply(Values.create());
+
+      PCollection<KV<String, LocationInheritedRecord>> locationInheritedRecords =
+          Join.innerJoin(occMapping, inheritedFields.inheritLocationFields())
+              .apply(Values.create());
+
+      PCollection<KV<String, TemporalInheritedRecord>> temporalInheritedRecords =
+          Join.innerJoin(occMapping, inheritedFields.inheritTemporalFields())
+              .apply(Values.create());
+
+      PCollection<KV<String, EventInheritedRecord>> eventInheritedRecords =
+          Join.innerJoin(occMapping, inheritedFields.inheritEventFields()).apply(Values.create());
+
+      return KeyedPCollectionTuple
+          // Core
+          .of(basicTransform.getTag(), basicCollection)
+          .and(uuidTransform.getTag(), uuidCollection)
+          .and(temporalTransform.getTag(), temporalCollection)
+          .and(locationTransform.getTag(), locationCollection)
+          .and(taxonomyTransform.getTag(), taxonCollection)
+          // Extension
+          .and(multimediaTransform.getTag(), multimediaCollection)
+          // Raw
+          .and(verbatimTransform.getTag(), verbatimCollection)
+          .and(measurementOrFactTransform.getTag(), measurementOrFactCollection)
+          .and(eventCoreTransform.getTag(), eventCoreRecords)
+          //          // Inherited
+          .and(InheritedFieldsTransform.LIR_TAG, locationInheritedRecords)
+          .and(InheritedFieldsTransform.TIR_TAG, temporalInheritedRecords)
+          .and(InheritedFieldsTransform.EIR_TAG, eventInheritedRecords)
+          // Apply
+          .apply("Grouping occurrence objects", CoGroupByKey.create())
+          .apply("Merging to occurrence json", occurrenceJsonDoFn);
+    }
+  }
+
+  /** Load eventID -> occurrenceID map */
+  public static PCollection<KV<String, String>> getEventIDToOccurrenceID(
+      PCollection<KV<String, ExtendedRecord>> verbatimCollection) {
+
+    // eventID -> occurrenceCore.id map
+    PCollection<KV<String, String>> eventIDToOccurrenceID =
+        verbatimCollection
+            .apply(
+                Filter.by(
+                    tr ->
+                        tr.getValue().getCoreTerms().get(DwcTerm.eventID.qualifiedName()) != null))
+            .apply(
+                MapElements.into(new TypeDescriptor<KV<String, String>>() {})
+                    .via(
+                        kv ->
+                            KV.of(
+                                kv.getValue().getCoreTerms().get(DwcTerm.eventID.qualifiedName()),
+                                kv.getKey())));
+
+    return eventIDToOccurrenceID;
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAParentJsonTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAParentJsonTransform.java
@@ -1,0 +1,135 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.EVENTS_AVRO_TO_JSON_COUNT;
+
+import au.org.ala.pipelines.converters.ALAParentJsonConverter;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.NonNull;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.gbif.pipelines.core.converters.MultimediaConverter;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.DerivedMetadataRecord;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+
+/** ALA version of ParentJsonTransform */
+@SuppressWarnings("ConstantConditions")
+@Builder
+public class ALAParentJsonTransform implements Serializable {
+
+  private static final long serialVersionUID = 1279313941024805871L;
+
+  // Core
+  @NonNull private final TupleTag<ExtendedRecord> extendedRecordTag;
+  @NonNull private final TupleTag<EventCoreRecord> eventCoreRecordTag;
+  @NonNull private final TupleTag<IdentifierRecord> identifierRecordTag;
+  @NonNull private final TupleTag<TemporalRecord> temporalRecordTag;
+  @NonNull private final TupleTag<LocationRecord> locationRecordTag;
+  private final TupleTag<TaxonRecord> taxonRecordTag;
+  // Extension
+  @NonNull private final TupleTag<MultimediaRecord> multimediaRecordTag;
+  @NonNull private final TupleTag<ImageRecord> imageRecordTag;
+  @NonNull private final TupleTag<AudubonRecord> audubonRecordTag;
+  @NonNull private final PCollectionView<ALAMetadataRecord> metadataView;
+  @NonNull private final TupleTag<DerivedMetadataRecord> derivedMetadataRecordTag;
+  @NonNull private final TupleTag<MeasurementOrFactRecord> measurementOrFactRecordTag;
+  private final TupleTag<String[]> samplingProtocolsTag;
+
+  @NonNull private final TupleTag<LocationInheritedRecord> locationInheritedRecordTag;
+  @NonNull private final TupleTag<TemporalInheritedRecord> temporalInheritedRecordTag;
+  @NonNull private final TupleTag<EventInheritedRecord> eventInheritedRecordTag;
+
+  public SingleOutput<KV<String, CoGbkResult>, String> converter() {
+
+    DoFn<KV<String, CoGbkResult>, String> fn =
+        new DoFn<KV<String, CoGbkResult>, String>() {
+
+          private final Counter counter =
+              Metrics.counter(ALAParentJsonTransform.class, EVENTS_AVRO_TO_JSON_COUNT);
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            CoGbkResult v = c.element().getValue();
+            String k = c.element().getKey();
+
+            // Core
+            ALAMetadataRecord mdr = c.sideInput(metadataView);
+            ExtendedRecord er =
+                v.getOnly(extendedRecordTag, ExtendedRecord.newBuilder().setId(k).build());
+            EventCoreRecord ecr =
+                v.getOnly(eventCoreRecordTag, EventCoreRecord.newBuilder().setId(k).build());
+            IdentifierRecord ir =
+                v.getOnly(identifierRecordTag, IdentifierRecord.newBuilder().setId(k).build());
+            TemporalRecord tr =
+                v.getOnly(temporalRecordTag, TemporalRecord.newBuilder().setId(k).build());
+            LocationRecord lr =
+                v.getOnly(locationRecordTag, LocationRecord.newBuilder().setId(k).build());
+
+            // Extension
+            MultimediaRecord mr =
+                v.getOnly(multimediaRecordTag, MultimediaRecord.newBuilder().setId(k).build());
+            ImageRecord imr = v.getOnly(imageRecordTag, ImageRecord.newBuilder().setId(k).build());
+            AudubonRecord ar =
+                v.getOnly(audubonRecordTag, AudubonRecord.newBuilder().setId(k).build());
+
+            // Inherited
+            EventInheritedRecord eir =
+                v.getOnly(
+                    eventInheritedRecordTag, EventInheritedRecord.newBuilder().setId(k).build());
+            LocationInheritedRecord lir =
+                v.getOnly(
+                    locationInheritedRecordTag,
+                    LocationInheritedRecord.newBuilder().setId(k).build());
+            TemporalInheritedRecord tir =
+                v.getOnly(
+                    temporalInheritedRecordTag,
+                    TemporalInheritedRecord.newBuilder().setId(k).build());
+
+            MeasurementOrFactRecord mofr =
+                v.getOnly(
+                    measurementOrFactRecordTag,
+                    MeasurementOrFactRecord.newBuilder().setId(k).build());
+
+            MultimediaRecord mmr = MultimediaConverter.merge(mr, imr, ar);
+
+            // Derived metadata
+            DerivedMetadataRecord dmr =
+                v.getOnly(
+                    derivedMetadataRecordTag, DerivedMetadataRecord.newBuilder().setId(k).build());
+
+            // Convert to JSON
+            String json =
+                ALAParentJsonConverter.builder()
+                    .metadata(mdr)
+                    .eventCore(ecr)
+                    .identifier(ir)
+                    .temporal(tr)
+                    .location(lr)
+                    .multimedia(mmr)
+                    .verbatim(er)
+                    .derivedMetadata(dmr)
+                    .measurementOrFactRecord(mofr)
+                    .locationInheritedRecord(lir)
+                    .temporalInheritedRecord(tir)
+                    .eventInheritedRecord(eir)
+                    .build()
+                    .toJson();
+
+            c.output(json);
+            counter.inc();
+          }
+        };
+
+    return ParDo.of(fn).withSideInputs(metadataView);
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAVerbatimToEventPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAVerbatimToEventPipeline.java
@@ -1,0 +1,273 @@
+package au.org.ala.pipelines.beam;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.RecordType.*;
+
+import au.org.ala.kvs.ALANameMatchConfig;
+import au.org.ala.kvs.ALAPipelinesConfig;
+import au.org.ala.kvs.cache.ALAAttributionKVStoreFactory;
+import au.org.ala.kvs.cache.ALANameCheckKVStoreFactory;
+import au.org.ala.kvs.cache.ALANameMatchKVStoreFactory;
+import au.org.ala.kvs.cache.GeocodeKvStoreFactory;
+import au.org.ala.pipelines.transforms.*;
+import au.org.ala.pipelines.transforms.LocationTransform;
+import au.org.ala.utils.CombinedYamlConfiguration;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.gbif.api.model.pipelines.StepType;
+import org.gbif.common.parsers.date.DateComponentOrdering;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.common.PipelinesVariables;
+import org.gbif.pipelines.common.beam.metrics.MetricsHandler;
+import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
+import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
+import org.gbif.pipelines.common.beam.utils.PathBuilder;
+import org.gbif.pipelines.core.pojo.HdfsConfigs;
+import org.gbif.pipelines.core.utils.FsUtils;
+import org.gbif.pipelines.factory.FileVocabularyFactory;
+import org.gbif.pipelines.io.avro.ALAMetadataRecord;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.transforms.core.*;
+import org.gbif.pipelines.transforms.extension.AudubonTransform;
+import org.gbif.pipelines.transforms.extension.ImageTransform;
+import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
+import org.gbif.pipelines.transforms.extension.MultimediaTransform;
+import org.gbif.pipelines.transforms.specific.IdentifierTransform;
+import org.slf4j.MDC;
+
+/**
+ * Pipeline sequence:
+ *
+ * <pre>
+ *    1) Reads verbatim.avro file
+ *    2) Interprets and converts avro {@link ExtendedRecord} file to:
+ *      {@link org.gbif.pipelines.io.avro.EventCoreRecord},
+ *      {@link ExtendedRecord}
+ *    3) Writes data to independent files
+ * </pre>
+ *
+ * <p>How to run:
+ *
+ * <pre>{@code
+ * java -jar target/examples-pipelines-BUILD_VERSION-shaded.jar
+ * --datasetId=0057a720-17c9-4658-971e-9578f3577cf5
+ * --attempt=1
+ * --runner=SparkRunner
+ * --targetPath=/some/path/to/output/
+ * --inputPath=/some/path/to/output/0057a720-17c9-4658-971e-9578f3577cf5/1/verbatim.avro
+ *
+ * }</pre>
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ALAVerbatimToEventPipeline {
+
+  private static final DwcTerm CORE_TERM = DwcTerm.Event;
+
+  public static void main(String[] args) throws IOException {
+    String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "interpret");
+    InterpretationPipelineOptions options =
+        PipelinesOptionsFactory.createInterpretation(combinedArgs);
+    run(options);
+  }
+
+  public static void run(InterpretationPipelineOptions options) {
+    run(options, Pipeline::create);
+  }
+
+  public static void run(
+      InterpretationPipelineOptions options,
+      Function<InterpretationPipelineOptions, Pipeline> pipelinesFn) {
+
+    String datasetId = options.getDatasetId();
+    Integer attempt = options.getAttempt();
+    Set<String> types = getEventTypes(options.getInterpretationTypes());
+    String targetPath = options.getTargetPath();
+
+    MDC.put("datasetKey", datasetId);
+    MDC.put("step", StepType.EVENTS_VERBATIM_TO_INTERPRETED.name());
+    MDC.put("attempt", attempt.toString());
+
+    HdfsConfigs hdfsConfigs =
+        HdfsConfigs.create(options.getHdfsSiteConfig(), options.getCoreSiteConfig());
+
+    ALAPipelinesConfig config =
+        FsUtils.readConfigFile(hdfsConfigs, options.getProperties(), ALAPipelinesConfig.class);
+
+    List<DateComponentOrdering> dateComponentOrdering =
+        options.getDefaultDateFormat() == null
+            ? config.getGbifConfig().getDefaultDateFormat()
+            : options.getDefaultDateFormat();
+
+    FsUtils.deleteInterpretIfExist(hdfsConfigs, targetPath, datasetId, attempt, CORE_TERM, types);
+
+    String id = Long.toString(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+
+    // Path to write
+    UnaryOperator<String> pathFn =
+        t -> PathBuilder.buildPathInterpretUsingTargetPath(options, CORE_TERM, t, id);
+
+    log.info("Creating a pipeline from options");
+    Pipeline p = pipelinesFn.apply(options);
+
+    // Used transforms
+    TransformsFactory transformsFactory = TransformsFactory.create(options);
+
+    // Metadata
+    ALAMetadataTransform metadataTransform =
+        ALAMetadataTransform.builder()
+            .dataResourceKvStoreSupplier(ALAAttributionKVStoreFactory.getInstanceSupplier(config))
+            .datasetId(datasetId)
+            .create();
+    LocationTransform locationTransform =
+        LocationTransform.builder()
+            .alaConfig(config)
+            .countryKvStoreSupplier(GeocodeKvStoreFactory.createCountrySupplier(config))
+            .stateProvinceKvStoreSupplier(GeocodeKvStoreFactory.createStateProvinceSupplier(config))
+            .biomeKvStoreSupplier(GeocodeKvStoreFactory.createBiomeSupplier(config))
+            .create();
+    VerbatimTransform verbatimTransform = VerbatimTransform.create();
+    ALATaxonomyTransform alaTaxonomyTransform =
+        ALATaxonomyTransform.builder()
+            .datasetId(datasetId)
+            .nameMatchStoreSupplier(ALANameMatchKVStoreFactory.getInstanceSupplier(config))
+            .kingdomCheckStoreSupplier(
+                ALANameCheckKVStoreFactory.getInstanceSupplier("kingdom", config))
+            .dataResourceStoreSupplier(ALAAttributionKVStoreFactory.getInstanceSupplier(config))
+            .alaNameMatchConfig(
+                config.getAlaNameMatchConfig() != null
+                    ? config.getAlaNameMatchConfig()
+                    : new ALANameMatchConfig())
+            .create();
+    ALATemporalTransform temporalTransform = ALATemporalTransform.builder().create();
+    MultimediaTransform multimediaTransform = transformsFactory.createMultimediaTransform();
+    AudubonTransform audubonTransform = transformsFactory.createAudubonTransform();
+    ImageTransform imageTransform = transformsFactory.createImageTransform();
+    EventCoreTransform eventCoreTransform =
+        EventCoreTransform.builder()
+            .vocabularyServiceSupplier(
+                FileVocabularyFactory.builder()
+                    .config(config.getGbifConfig())
+                    .hdfsConfigs(hdfsConfigs)
+                    .build()
+                    .getInstanceSupplier())
+            .create();
+    IdentifierTransform identifierTransform = transformsFactory.createIdentifierTransform();
+    MeasurementOrFactTransform measurementOrFactTransform =
+        MeasurementOrFactTransform.builder().create();
+    log.info("Creating beam pipeline");
+
+    PCollection<ALAMetadataRecord> metadataRecord =
+        p.apply("Create metadata collection", Create.of(options.getDatasetId()))
+            .apply("Interpret metadata", metadataTransform.interpret());
+
+    metadataRecord.apply("Write metadata to avro", metadataTransform.write(pathFn));
+
+    // Read raw records and filter duplicates
+    PCollection<ExtendedRecord> uniqueRawRecords =
+        p.apply("Read event  verbatim", verbatimTransform.read(options.getInputPath()))
+            .apply("Filter event duplicates", transformsFactory.createUniqueIdTransform())
+            .apply("Filter event extensions", transformsFactory.createExtensionFilterTransform());
+
+    // view with the records that have parents to find the hierarchy in the event core
+    // interpretation later
+    PCollectionView<Map<String, Map<String, String>>> erWithParentEventsView =
+        uniqueRawRecords
+            .apply(verbatimTransform.toParentEventsKv())
+            .apply("View to find parents", View.asMap());
+    eventCoreTransform.setErWithParentsView(erWithParentEventsView);
+
+    uniqueRawRecords
+        .apply("Interpret event identifiers", identifierTransform.interpret())
+        .apply("Write event identifiers to avro", identifierTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event core transform", eventCoreTransform.check(types))
+        .apply("Interpret event core", eventCoreTransform.interpret())
+        .apply("Write event core to avro", eventCoreTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event temporal transform", temporalTransform.check(types))
+        .apply("Interpret event temporal", temporalTransform.interpret())
+        .apply("Write event temporal to avro", temporalTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event taxonomy transform", alaTaxonomyTransform.check(types))
+        .apply("Interpret event taxonomy", alaTaxonomyTransform.interpret())
+        .apply("Write event taxon to avro", alaTaxonomyTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event multimedia transform", multimediaTransform.check(types))
+        .apply("Interpret event multimedia", multimediaTransform.interpret())
+        .apply("Write event multimedia to avro", multimediaTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event audubon transform", audubonTransform.check(types))
+        .apply("Interpret event audubon", audubonTransform.interpret())
+        .apply("Write event audubon to avro", audubonTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event image transform", imageTransform.check(types))
+        .apply("Interpret event image", imageTransform.interpret())
+        .apply("Write event image to avro", imageTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check location transform", locationTransform.check(types))
+        .apply("Interpret event location", locationTransform.interpret())
+        .apply("Write event location to avro", locationTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event measurementOrFact", measurementOrFactTransform.check(types))
+        .apply("Interpret event measurementOrFact", measurementOrFactTransform.interpret())
+        .apply("Write event measurementOrFact to avro", measurementOrFactTransform.write(pathFn));
+
+    uniqueRawRecords
+        .apply("Check event verbatim transform", verbatimTransform.check(types))
+        .apply("Write event verbatim to avro", verbatimTransform.write(pathFn));
+
+    log.info("Running the pipeline");
+    PipelineResult result = p.run();
+    result.waitUntilFinish();
+
+    log.info("Save metrics into the file and set files owner");
+    MetricsHandler.saveCountersToTargetPathFile(options, result.metrics());
+
+    log.info("Deleting beam temporal folders");
+    String tempPath = String.join("/", targetPath, datasetId, attempt.toString());
+    FsUtils.deleteDirectoryByPrefix(hdfsConfigs, tempPath, ".temp-beam");
+
+    log.info("Pipeline has been finished");
+  }
+
+  /** Remove directories with avro files for expected interpretation, except IDENTIFIER */
+  private static Set<String> getEventTypes(Set<String> types) {
+    Set<String> resultTypes = new HashSet<>(types);
+    if (types.contains(BASIC.name())) {
+      resultTypes.add(EVENT.name());
+    }
+    resultTypes.add(IDENTIFIER.name());
+    resultTypes.add(EVENT_IDENTIFIER.name());
+    resultTypes.remove(IDENTIFIER_ABSENT.name());
+    return resultTypes;
+  }
+
+  private static boolean useMetadataRecordWriteIO(Set<String> types) {
+    return types.contains(PipelinesVariables.Pipeline.Interpretation.RecordType.METADATA.name())
+        || types.contains(PipelinesVariables.Pipeline.Interpretation.RecordType.ALL.name());
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAVerbatimToInterpretedPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAVerbatimToInterpretedPipeline.java
@@ -50,6 +50,7 @@ import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.gbif.pipelines.io.avro.MetadataRecord;
 import org.gbif.pipelines.transforms.converters.OccurrenceExtensionTransform;
 import org.gbif.pipelines.transforms.core.VerbatimTransform;
+import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
 import org.gbif.pipelines.transforms.extension.MultimediaTransform;
 import org.gbif.pipelines.transforms.metadata.DefaultValuesTransform;
 import org.slf4j.MDC;
@@ -194,6 +195,10 @@ public class ALAVerbatimToInterpretedPipeline {
     MultimediaTransform multimediaTransform =
         MultimediaTransform.builder().orderings(dateComponentOrdering).create();
 
+    // Extension
+    MeasurementOrFactTransform measurementOrFactTransform =
+        MeasurementOrFactTransform.builder().create();
+
     // Create and write metadata
     PCollection<ALAMetadataRecord> metadataRecord =
         p.apply("Create metadata collection", Create.of(options.getDatasetId()))
@@ -285,6 +290,11 @@ public class ALAVerbatimToInterpretedPipeline {
         .apply("Check location transform condition", locationTransform.check(types))
         .apply("Interpret location", locationTransform.interpret())
         .apply("Write location to avro", locationTransform.write(pathFn));
+
+    uniqueRecords
+        .apply("Check location transform condition", measurementOrFactTransform.check(types))
+        .apply("Interpret location", measurementOrFactTransform.interpret())
+        .apply("Write location to avro", measurementOrFactTransform.write(pathFn));
 
     log.info("Running the pipeline");
     PipelineResult result = p.run();

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/IndexRecordPipeline.java
@@ -165,7 +165,7 @@ public class IndexRecordPipeline {
 
     PCollection<KV<String, ALATaxonRecord>> alaTaxonCollection =
         p.apply("Read Taxon", alaTaxonomyTransform.read(pathFn))
-            .apply("Map Taxon to KV", alaTaxonomyTransform.toKv());
+            .apply("Map Taxon to KV", alaTaxonomyTransform.toCoreIdKv());
 
     PCollection<KV<String, ALAAttributionRecord>> alaAttributionCollection =
         p.apply("Read attribution", alaAttributionTransform.read(pathFn))

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/InheritedFields.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/InheritedFields.java
@@ -1,0 +1,97 @@
+package au.org.ala.pipelines.beam;
+
+import lombok.Builder;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.gbif.pipelines.common.beam.coders.EdgeCoder;
+import org.gbif.pipelines.core.pojo.Edge;
+import org.gbif.pipelines.io.avro.EventCoreRecord;
+import org.gbif.pipelines.io.avro.LocationRecord;
+import org.gbif.pipelines.io.avro.TemporalRecord;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+import org.gbif.pipelines.transforms.converters.ParentEventExpandTransform;
+import org.gbif.pipelines.transforms.core.*;
+
+/**
+ * Copy of the inner class used in @{@link
+ * org.gbif.pipelines.ingest.pipelines.EventToEsIndexPipeline} Moved here to avoid dependency on
+ * ingest-gbif-beam
+ */
+@Builder
+final class InheritedFields {
+
+  private final InheritedFieldsTransform inheritedFieldsTransform;
+  private final TemporalTransform temporalTransform;
+  private final EventCoreTransform eventCoreTransform;
+  private final LocationTransform locationTransform;
+  private final PCollection<KV<String, TemporalRecord>> temporalCollection;
+  private final PCollection<KV<String, LocationRecord>> locationCollection;
+  private final PCollection<KV<String, EventCoreRecord>> eventCoreCollection;
+
+  PCollection<KV<String, LocationInheritedRecord>> inheritLocationFields() {
+    PCollection<KV<String, LocationRecord>> locationRecordsOfSubEvents =
+        ParentEventExpandTransform.createLocationTransform(
+                locationTransform.getTag(),
+                eventCoreTransform.getTag(),
+                locationTransform.getEdgeTag())
+            .toSubEventsRecordsFromLeaf("Location", locationCollection, eventCoreCollection);
+
+    return PCollectionList.of(locationCollection)
+        .and(locationRecordsOfSubEvents)
+        .apply("Joining location records for inheritance", Flatten.pCollections())
+        .apply(
+            "Inherit location fields of all records",
+            Combine.perKey(new LocationInheritedFieldsFn()));
+  }
+
+  PCollection<KV<String, TemporalInheritedRecord>> inheritTemporalFields() {
+    PCollection<KV<String, TemporalRecord>> temporalRecordsOfSubEvents =
+        ParentEventExpandTransform.createTemporalTransform(
+                temporalTransform.getTag(),
+                eventCoreTransform.getTag(),
+                temporalTransform.getEdgeTag())
+            .toSubEventsRecordsFromLeaf("Temporal", temporalCollection, eventCoreCollection);
+
+    return PCollectionList.of(temporalCollection)
+        .and(temporalRecordsOfSubEvents)
+        .apply("Joining temporal records for inheritance", Flatten.pCollections())
+        .apply(
+            "Inherit temporal fields of all records",
+            Combine.perKey(new TemporalInheritedFieldsFn()));
+  }
+
+  PCollection<KV<String, EventInheritedRecord>> inheritEventFields() {
+    PCollection<KV<String, Edge<EventCoreRecord>>> parentEdgeEvents =
+        eventCoreCollection
+            // Collection of EventCoreRecord
+            .apply("Get EventCoreRecord values", Values.create())
+            // Collection of KV<ParentId,Edge.of(ParentId,EventCoreRecord.id, EventCoreRecord)
+            .apply(
+                "Group by child and parent", inheritedFieldsTransform.childToParentEdgeConverter())
+            .setCoder(
+                KvCoder.of(
+                    StringUtf8Coder.of(), EdgeCoder.of(AvroCoder.of(EventCoreRecord.class))));
+
+    return KeyedPCollectionTuple.of(eventCoreTransform.getTag(), eventCoreCollection)
+        .and(eventCoreTransform.getEdgeTag(), parentEdgeEvents)
+        // Join EventCore collections with parents
+        .apply("Join events with parent collections", CoGroupByKey.<String>create())
+        // Extract the parents only
+        .apply(
+            "Extract the parents only",
+            inheritedFieldsTransform.childToParentConverter(eventCoreTransform))
+        .apply("Extract parent features", Combine.perKey(new EventInheritedFieldsFn()))
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), AvroCoder.of(EventInheritedRecord.class)));
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/SpeciesListPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/SpeciesListPipeline.java
@@ -128,7 +128,7 @@ public class SpeciesListPipeline {
     // generate a taxonID -> occurrenceID PCollection
     PCollection<KV<String, String>> alaTaxonID =
         p.apply("Read Taxon", alaTaxonomyTransform.read(pathFn))
-            .apply("Map Taxon to KV", alaTaxonomyTransform.toKv())
+            .apply("Map Taxon to KV", alaTaxonomyTransform.toCoreIdKv())
             .apply(Filter.by(record -> record.getValue().getTaxonConceptID() != null))
             .apply(
                 MapElements.via(

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/ALAOccurrenceJsonConverter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/ALAOccurrenceJsonConverter.java
@@ -1,0 +1,425 @@
+package au.org.ala.pipelines.converters;
+
+import static org.gbif.pipelines.core.utils.ModelUtils.extractOptValue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.pipelines.core.converters.JsonConverter;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.*;
+
+/** Converts AVRO occurrence record artefacts to a JSON for indexing. */
+@Slf4j
+@Builder
+public class ALAOccurrenceJsonConverter {
+
+  private final ALAMetadataRecord metadata;
+  private final ALAUUIDRecord uuid;
+  private final BasicRecord basic;
+  private final TemporalRecord temporal;
+  private final LocationRecord location;
+  private final ALATaxonRecord taxon;
+  private final MultimediaRecord multimedia;
+  private final ExtendedRecord verbatim;
+  private final EventCoreRecord eventCore;
+
+  private final EventInheritedRecord eventInheritedRecord;
+  private final LocationInheritedRecord locationInheritedRecord;
+  private final TemporalInheritedRecord temporalInheritedRecord;
+
+  private final MeasurementOrFactRecord measurementOrFact;
+
+  public OccurrenceJsonRecord convert() {
+
+    OccurrenceJsonRecord.Builder builder = OccurrenceJsonRecord.newBuilder();
+    builder.setId(uuid.getUuid());
+    builder.setCreated(uuid.getFirstLoaded().toString());
+    builder.setGbifId(1);
+    mapMetadataRecord(builder);
+    mapBasicRecord(builder);
+    mapTemporalRecord(builder);
+    mapLocationRecord(builder);
+    mapTaxonRecord(builder);
+    mapMultimediaRecord(builder);
+    mapExtendedRecord(builder);
+    mapMeasurementOrFactRecord(builder);
+    mapInherited(builder);
+
+    // synthesize a locationID if one isnt provided
+    if (builder.getLocationID() == null
+        && location.getDecimalLatitude() != null
+        && location.getDecimalLongitude() != null) {
+      builder.setLocationID(
+          Math.abs(location.getDecimalLatitude())
+              + (location.getDecimalLatitude() > 0 ? "N" : "S")
+              + ", "
+              + Math.abs(location.getDecimalLongitude())
+              + (location.getDecimalLongitude() > 0 ? "E" : "W"));
+    }
+
+    return builder.build();
+  }
+
+  public String toJson() {
+    return convert().toString();
+  }
+
+  private void mapMetadataRecord(OccurrenceJsonRecord.Builder builder) {
+    builder
+        .setDatasetKey(metadata.getDataResourceUid())
+        .setDatasetTitle(metadata.getDataResourceName());
+  }
+
+  private void mapInherited(OccurrenceJsonRecord.Builder builder) {
+
+    boolean hasCoordsInfo = builder.getDecimalLatitude() != null;
+    boolean hasCountryInfo = builder.getCountryCode() != null;
+    boolean hasStateInfo = builder.getStateProvince() != null;
+    boolean hasYearInfo = builder.getYear() != null;
+    boolean hasMonthInfo = builder.getMonth() != null;
+    boolean hasLocationID = builder.getLocationID() != null;
+
+    // extract location & temporal information from
+    if (!hasYearInfo && temporalInheritedRecord.getYear() != null) {
+      builder.setYear(temporalInheritedRecord.getYear());
+    }
+
+    if (!hasMonthInfo && temporalInheritedRecord.getMonth() != null) {
+      builder.setMonth(temporalInheritedRecord.getMonth());
+    }
+
+    if (!hasCountryInfo && locationInheritedRecord.getCountryCode() != null) {
+      builder.setCountryCode(locationInheritedRecord.getCountryCode());
+    }
+
+    if (!hasStateInfo && locationInheritedRecord.getStateProvince() != null) {
+      builder.setStateProvince(locationInheritedRecord.getStateProvince());
+    }
+
+    if (!hasCoordsInfo
+        && locationInheritedRecord.getDecimalLatitude() != null
+        && locationInheritedRecord.getDecimalLongitude() != null) {
+      builder
+          .setHasCoordinate(true)
+          .setDecimalLatitude(locationInheritedRecord.getDecimalLatitude())
+          .setDecimalLongitude(locationInheritedRecord.getDecimalLongitude())
+          // geo_point
+          .setCoordinates(
+              JsonConverter.convertCoordinates(
+                  locationInheritedRecord.getDecimalLongitude(),
+                  locationInheritedRecord.getDecimalLatitude()))
+          // geo_shape
+          .setScoordinates(
+              JsonConverter.convertScoordinates(
+                  locationInheritedRecord.getDecimalLongitude(),
+                  locationInheritedRecord.getDecimalLatitude()));
+    }
+
+    if (!hasLocationID && eventInheritedRecord.getLocationID() != null) {
+      builder.setLocationID(eventInheritedRecord.getLocationID());
+    }
+
+    if (eventCore != null
+        && eventCore.getParentsLineage() != null
+        && !eventCore.getParentsLineage().isEmpty()) {
+
+      List<String> eventIDs =
+          eventCore.getParentsLineage().stream()
+              .sorted(
+                  Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder).reversed())
+              .map(e -> e.getId())
+              .collect(Collectors.toList());
+      eventIDs.add(eventCore.getId());
+
+      List<String> eventTypes =
+          eventCore.getParentsLineage().stream()
+              .sorted(
+                  Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder).reversed())
+              .map(e -> e.getEventType())
+              .collect(Collectors.toList());
+
+      if (eventCore.getEventType() != null) {
+        eventTypes.add(eventCore.getEventType().getConcept());
+      } else {
+        String rawEventType = verbatim.getCoreTerms().get(GbifTerm.eventType.qualifiedName());
+        if (rawEventType != null) {
+          eventTypes.add(rawEventType);
+        }
+      }
+
+      // add the eventID / eventy
+      builder.setEventTypeHierarchy(eventTypes);
+      builder.setEventTypeHierarchyJoined(String.join(" / ", eventTypes));
+
+      builder.setEventHierarchy(eventIDs);
+      builder.setEventHierarchyJoined(String.join(" / ", eventIDs));
+      builder.setEventHierarchyLevels(eventIDs.size());
+
+    } else {
+      // add the eventID and parentEventID to hierarchy for consistency
+      List<String> eventHierarchy = new ArrayList<>();
+      if (builder.getParentEventId() != null) {
+        eventHierarchy.add(builder.getParentEventId());
+      }
+      if (builder.getEventId() != null) {
+        eventHierarchy.add(builder.getEventId());
+      }
+      builder.setEventHierarchy(eventHierarchy);
+
+      // add the single type to hierarchy for consistency
+      List<String> eventTypeHierarchy = new ArrayList<>();
+      eventTypeHierarchy.add("Occurrence");
+      builder.setEventTypeHierarchy(eventTypeHierarchy);
+    }
+  }
+
+  private void mapBasicRecord(OccurrenceJsonRecord.Builder builder) {
+
+    // Simple
+    builder
+        .setBasisOfRecord(basic.getBasisOfRecord())
+        .setSex(basic.getSex())
+        .setIndividualCount(basic.getIndividualCount())
+        .setTypeStatus(basic.getTypeStatus())
+        .setTypifiedName(basic.getTypifiedName())
+        .setSampleSizeValue(basic.getSampleSizeValue())
+        .setSampleSizeUnit(basic.getSampleSizeUnit())
+        .setOrganismQuantity(basic.getOrganismQuantity())
+        .setOrganismQuantityType(basic.getOrganismQuantityType())
+        .setRelativeOrganismQuantity(basic.getRelativeOrganismQuantity())
+        .setReferences(basic.getReferences())
+        .setIdentifiedBy(basic.getIdentifiedBy())
+        .setRecordedBy(basic.getRecordedBy())
+        .setOccurrenceStatus(basic.getOccurrenceStatus())
+        .setDatasetID(basic.getDatasetID())
+        .setDatasetName(basic.getDatasetName())
+        .setOtherCatalogNumbers(basic.getOtherCatalogNumbers())
+        .setPreparations(basic.getPreparations())
+        .setSamplingProtocol(basic.getSamplingProtocol());
+
+    // Agent
+    builder
+        .setIdentifiedByIds(JsonConverter.convertAgentList(basic.getIdentifiedByIds()))
+        .setRecordedByIds(JsonConverter.convertAgentList(basic.getRecordedByIds()));
+
+    // VocabularyConcept
+    JsonConverter.convertVocabularyConcept(basic.getLifeStage()).ifPresent(builder::setLifeStage);
+    JsonConverter.convertVocabularyConcept(basic.getEstablishmentMeans())
+        .ifPresent(builder::setEstablishmentMeans);
+    JsonConverter.convertVocabularyConcept(basic.getDegreeOfEstablishment())
+        .ifPresent(builder::setDegreeOfEstablishment);
+    JsonConverter.convertVocabularyConcept(basic.getPathway()).ifPresent(builder::setPathway);
+
+    // License
+    JsonConverter.convertLicense(basic.getLicense()).ifPresent(builder::setLicense);
+
+    // Multi-value fields
+    JsonConverter.convertToMultivalue(basic.getRecordedBy())
+        .ifPresent(builder::setRecordedByJoined);
+    JsonConverter.convertToMultivalue(basic.getIdentifiedBy())
+        .ifPresent(builder::setIdentifiedByJoined);
+    JsonConverter.convertToMultivalue(basic.getPreparations())
+        .ifPresent(builder::setPreparationsJoined);
+    JsonConverter.convertToMultivalue(basic.getSamplingProtocol())
+        .ifPresent(builder::setSamplingProtocolJoined);
+    JsonConverter.convertToMultivalue(basic.getOtherCatalogNumbers())
+        .ifPresent(builder::setOtherCatalogNumbersJoined);
+  }
+
+  private void mapTemporalRecord(OccurrenceJsonRecord.Builder builder) {
+
+    builder
+        .setYear(temporal.getYear())
+        .setMonth(temporal.getMonth())
+        .setDay(temporal.getDay())
+        .setStartDayOfYear(temporal.getStartDayOfYear())
+        .setEndDayOfYear(temporal.getEndDayOfYear())
+        .setModified(temporal.getModified())
+        .setDateIdentified(temporal.getDateIdentified());
+
+    JsonConverter.convertEventDate(temporal.getEventDate()).ifPresent(builder::setEventDate);
+    JsonConverter.convertEventDateSingle(temporal).ifPresent(builder::setEventDateSingle);
+  }
+
+  private void mapLocationRecord(OccurrenceJsonRecord.Builder builder) {
+
+    builder
+        .setContinent(location.getContinent())
+        .setWaterBody(location.getWaterBody())
+        .setCountry(location.getCountry())
+        .setCountryCode(location.getCountryCode())
+        .setPublishingCountry(location.getPublishingCountry())
+        .setStateProvince(location.getStateProvince())
+        .setMinimumElevationInMeters(location.getMinimumElevationInMeters())
+        .setMaximumElevationInMeters(location.getMaximumElevationInMeters())
+        .setElevation(location.getElevation())
+        .setElevationAccuracy(location.getElevationAccuracy())
+        .setDepth(location.getDepth())
+        .setDepthAccuracy(location.getDepthAccuracy())
+        .setMinimumDepthInMeters(location.getMinimumDepthInMeters())
+        .setMaximumDepthInMeters(location.getMaximumDepthInMeters())
+        .setMaximumDistanceAboveSurfaceInMeters(location.getMaximumDistanceAboveSurfaceInMeters())
+        .setMinimumDistanceAboveSurfaceInMeters(location.getMinimumDistanceAboveSurfaceInMeters())
+        .setCoordinateUncertaintyInMeters(location.getCoordinateUncertaintyInMeters())
+        .setCoordinatePrecision(location.getCoordinatePrecision())
+        .setHasCoordinate(location.getHasCoordinate())
+        .setRepatriated(location.getRepatriated())
+        .setHasGeospatialIssue(location.getHasGeospatialIssue())
+        .setLocality(location.getLocality())
+        .setFootprintWKT(location.getFootprintWKT());
+
+    // Coordinates
+    Double decimalLongitude = location.getDecimalLongitude();
+    Double decimalLatitude = location.getDecimalLatitude();
+    if (decimalLongitude != null && decimalLatitude != null) {
+      builder
+          .setDecimalLatitude(decimalLatitude)
+          .setDecimalLongitude(decimalLongitude)
+          // geo_point
+          .setCoordinates(JsonConverter.convertCoordinates(decimalLongitude, decimalLatitude))
+          // geo_shape
+          .setScoordinates(JsonConverter.convertScoordinates(decimalLongitude, decimalLatitude));
+    }
+
+    JsonConverter.convertGadm(location.getGadm()).ifPresent(builder::setGadm);
+  }
+
+  private void mapTaxonRecord(OccurrenceJsonRecord.Builder builder) {
+    // Set  GbifClassification
+    GbifClassification gc = convertClassification(verbatim, taxon);
+
+    List<Taxonomy> taxonomy = new ArrayList<>();
+
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getKingdom()).setTaxonKey(gc.getKingdomKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getPhylum()).setTaxonKey(gc.getPhylumKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getClass$()).setTaxonKey(gc.getClassKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getOrder()).setTaxonKey(gc.getOrderKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getFamily()).setTaxonKey(gc.getFamilyKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getGenus()).setTaxonKey(gc.getGenusKey()).build());
+    taxonomy.add(
+        Taxonomy.newBuilder().setName(gc.getSpecies()).setTaxonKey(gc.getSpeciesKey()).build());
+    if (gc.getAcceptedUsage() != null
+        && (gc.getAcceptedUsage().getGuid() != null || gc.getAcceptedUsage().getKey() != null)) {
+      taxonomy.add(
+          Taxonomy.newBuilder()
+              .setName(gc.getAcceptedUsage().getName())
+              .setTaxonKey(
+                  gc.getAcceptedUsage().getGuid() != null
+                      ? gc.getAcceptedUsage().getGuid()
+                      : gc.getAcceptedUsage().getKey().toString())
+              .build());
+    }
+
+    taxonomy =
+        taxonomy.stream().filter(tr -> tr.getTaxonKey() != null).collect(Collectors.toList());
+
+    // set taxonomy
+    builder.setTaxonomy(taxonomy);
+    gc.setTaxonKey(taxonomy.stream().map(t -> t.getTaxonKey()).collect(Collectors.toList()));
+    builder.setGbifClassification(gc);
+  }
+
+  public static GbifClassification convertClassification(
+      ExtendedRecord verbatim, ALATaxonRecord taxon) {
+
+    GbifClassification.Builder classificationBuilder =
+        GbifClassification.newBuilder().setTaxonID(taxon.getTaxonConceptID());
+
+    classificationBuilder.setAcceptedUsage(
+        org.gbif.pipelines.io.avro.json.RankedName.newBuilder()
+            .setKey(taxon.getLft())
+            .setGuid(taxon.getTaxonConceptID())
+            .setName(taxon.getScientificName())
+            .setRank(taxon.getTaxonRank())
+            .build());
+
+    classificationBuilder.setKingdom(taxon.getKingdom());
+    classificationBuilder.setKingdomKey(taxon.getKingdomID());
+    classificationBuilder.setPhylum(taxon.getPhylum());
+    classificationBuilder.setPhylumKey(taxon.getPhylumID());
+    classificationBuilder.setClass$(taxon.getClasss());
+    classificationBuilder.setClassKey(taxon.getClassID());
+    classificationBuilder.setOrder(taxon.getOrder());
+    classificationBuilder.setOrderKey(taxon.getOrderID());
+    classificationBuilder.setFamily(taxon.getFamily());
+    classificationBuilder.setFamilyKey(taxon.getFamilyID());
+    classificationBuilder.setGenus(taxon.getGenus());
+    classificationBuilder.setGenusKey(taxon.getGenusID());
+    classificationBuilder.setSpecies(taxon.getSpecies());
+    classificationBuilder.setSpeciesKey(taxon.getSpeciesID());
+
+    // Raw to index classification
+    extractOptValue(verbatim, DwcTerm.taxonID).ifPresent(classificationBuilder::setTaxonID);
+    extractOptValue(verbatim, DwcTerm.scientificName)
+        .ifPresent(classificationBuilder::setVerbatimScientificName);
+
+    return classificationBuilder.build();
+  }
+
+  private void mapMultimediaRecord(OccurrenceJsonRecord.Builder builder) {}
+
+  private void mapExtendedRecord(OccurrenceJsonRecord.Builder builder) {
+
+    builder
+        .setId(verbatim.getId())
+        .setAll(JsonConverter.convertFieldAll(verbatim))
+        .setExtensions(JsonConverter.convertExtensions(verbatim))
+        .setVerbatim(JsonConverter.convertVerbatimRecord(verbatim));
+
+    // Set raw as indexed
+    extractOptValue(verbatim, DwcTerm.recordNumber).ifPresent(builder::setRecordNumber);
+    extractOptValue(verbatim, DwcTerm.organismID).ifPresent(builder::setOrganismId);
+    extractOptValue(verbatim, DwcTerm.eventID).ifPresent(builder::setEventId);
+    extractOptValue(verbatim, DwcTerm.parentEventID).ifPresent(builder::setParentEventId);
+    extractOptValue(verbatim, DwcTerm.institutionCode).ifPresent(builder::setInstitutionCode);
+    extractOptValue(verbatim, DwcTerm.collectionCode).ifPresent(builder::setCollectionCode);
+    extractOptValue(verbatim, DwcTerm.catalogNumber).ifPresent(builder::setCatalogNumber);
+    extractOptValue(verbatim, DwcTerm.occurrenceID).ifPresent(builder::setOccurrenceId);
+  }
+
+  private void mapMeasurementOrFactRecord(OccurrenceJsonRecord.Builder builder) {
+
+    if (measurementOrFact != null) {
+      builder.setMeasurementOrFactMethods(
+          measurementOrFact.getMeasurementOrFactItems().stream()
+              .map(MeasurementOrFact::getMeasurementMethod)
+              .filter(x -> StringUtils.isNotEmpty(x))
+              .distinct()
+              .collect(Collectors.toList()));
+      builder.setMeasurementOrFactTypes(
+          measurementOrFact.getMeasurementOrFactItems().stream()
+              .map(MeasurementOrFact::getMeasurementType)
+              .filter(x -> StringUtils.isNotEmpty(x))
+              .distinct()
+              .collect(Collectors.toList()));
+
+      List<MeasurementOrFactJsonRecord> mofs =
+          measurementOrFact.getMeasurementOrFactItems().stream()
+              .map(
+                  mor -> {
+                    return MeasurementOrFactJsonRecord.newBuilder()
+                        .setMeasurementID(mor.getMeasurementID())
+                        .setMeasurementMethod(mor.getMeasurementMethod())
+                        .setMeasurementType(mor.getMeasurementType())
+                        .setMeasurementValue(mor.getMeasurementValue())
+                        .setMeasurementUnit(mor.getMeasurementUnit())
+                        .build();
+                  })
+              .collect(Collectors.toList());
+      builder.setMeasurementOrFacts(mofs);
+    }
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/ALAParentJsonConverter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/converters/ALAParentJsonConverter.java
@@ -1,0 +1,476 @@
+package au.org.ala.pipelines.converters;
+
+import static org.gbif.pipelines.core.utils.ModelUtils.extractOptValue;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.pipelines.core.converters.JsonConverter;
+import org.gbif.pipelines.core.factory.SerDeFactory;
+import org.gbif.pipelines.core.utils.HashConverter;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.*;
+import org.gbif.pipelines.io.avro.json.Parent;
+import org.gbif.pipelines.io.avro.json.VocabularyConcept;
+
+/**
+ * ALA version of ParentJsonConverter (see ingest-gbif-beam module) This converter will take AVRO
+ * record artefacts related to an event and produce a JSON document for indexing.
+ */
+@Slf4j
+@SuperBuilder
+public class ALAParentJsonConverter {
+
+  protected final ALAMetadataRecord metadata;
+  protected final IdentifierRecord identifier;
+  protected final EventCoreRecord eventCore;
+  protected final TemporalRecord temporal;
+  protected final LocationRecord location;
+  protected final MultimediaRecord multimedia;
+  protected final ExtendedRecord verbatim;
+  protected final DerivedMetadataRecord derivedMetadata;
+  protected final LocationInheritedRecord locationInheritedRecord;
+  protected final TemporalInheritedRecord temporalInheritedRecord;
+  protected final EventInheritedRecord eventInheritedRecord;
+  protected OccurrenceJsonRecord occurrenceJsonRecord;
+  protected MeasurementOrFactRecord measurementOrFactRecord;
+
+  public ParentJsonRecord convertToParent() {
+    return (occurrenceJsonRecord != null) ? convertToParentOccurrence() : convertToParentEvent();
+  }
+
+  @SneakyThrows
+  public String toJson() {
+    return SerDeFactory.avroEventsMapperNonNulls().writeValueAsString(convertToParent());
+  }
+
+  /** Converts to parent record based on an event record. */
+  private ParentJsonRecord convertToParentEvent() {
+    ParentJsonRecord.Builder builder =
+        convertToParentRecord()
+            .setId(verbatim.getId())
+            .setInternalId(identifier.getInternalId())
+            .setUniqueKey(identifier.getUniqueKey())
+            .setType("event")
+            .setEventBuilder(convertToEvent())
+            .setAll(JsonConverter.convertFieldAll(verbatim, false))
+            .setVerbatim(JsonConverter.convertVerbatimEventRecord(verbatim))
+            .setJoinRecordBuilder(JoinRecord.newBuilder().setName("event"));
+
+    mapCreated(builder);
+    mapDerivedMetadata(builder);
+    mapLocationInheritedFields(builder);
+    mapTemporalInheritedFields(builder);
+    mapEventInheritedFields(builder);
+
+    JsonConverter.convertToDate(identifier.getFirstLoaded()).ifPresent(builder::setFirstLoaded);
+
+    return builder.build();
+  }
+
+  /** Converts to a parent record based on an occurrence record. */
+  private ParentJsonRecord convertToParentOccurrence() {
+    return convertToParentRecord()
+        .setType("occurrence")
+        .setId(occurrenceJsonRecord.getId())
+        .setInternalId(
+            HashConverter.getSha1(
+                metadata.getDataResourceUid(),
+                occurrenceJsonRecord.getVerbatim().getCoreId(),
+                occurrenceJsonRecord.getOccurrenceId()))
+        .setJoinRecordBuilder(
+            JoinRecord.newBuilder()
+                .setName("occurrence")
+                .setParent(
+                    HashConverter.getSha1(
+                        metadata.getDataResourceUid(),
+                        occurrenceJsonRecord.getVerbatim().getCoreId())))
+        .setOccurrence(occurrenceJsonRecord)
+        .setAll(occurrenceJsonRecord.getAll())
+        .setVerbatim(occurrenceJsonRecord.getVerbatim())
+        .setCreated(occurrenceJsonRecord.getCreated())
+        .setMetadataBuilder(mapMetadataJsonRecord())
+        .build();
+  }
+
+  /** Converts to a parent record */
+  private ParentJsonRecord.Builder convertToParentRecord() {
+    ParentJsonRecord.Builder builder =
+        ParentJsonRecord.newBuilder()
+            .setId(verbatim.getId())
+            .setMetadataBuilder(mapMetadataJsonRecord());
+
+    mapCreated(builder);
+    mapDerivedMetadata(builder);
+    return builder;
+  }
+
+  private EventJsonRecord.Builder convertToEvent() {
+
+    EventJsonRecord.Builder builder = EventJsonRecord.newBuilder();
+
+    builder.setId(verbatim.getId());
+
+    mapEventCoreRecord(builder);
+    mapTemporalRecord(builder);
+    mapLocationRecord(builder);
+    mapMultimediaRecord(builder);
+    mapExtendedRecord(builder);
+    mapTaxonRecord(builder);
+    mapMeasurementOrFactRecord(builder);
+    mapInherited(builder);
+
+    // synthesize a locationID if one isnt provided
+    if (builder.getLocationID() == null
+        && location.getDecimalLatitude() != null
+        && location.getDecimalLongitude() != null) {
+      builder.setLocationID(
+          Math.abs(location.getDecimalLatitude())
+              + (location.getDecimalLatitude() > 0 ? "N" : "S")
+              + ", "
+              + Math.abs(location.getDecimalLongitude())
+              + (location.getDecimalLongitude() > 0 ? "E" : "W"));
+    }
+
+    // set the event type to the raw value, if the vocab not matched
+    if (builder.getEventType() == null) {
+      Optional<String> eventType = extractOptValue(verbatim, GbifTerm.eventType);
+      if (eventType.isPresent()) {
+        VocabularyConcept eventTypeVoc =
+            VocabularyConcept.newBuilder()
+                .setLineage(Arrays.asList("Event", eventType.get()))
+                .setConcept(eventType.get())
+                .build();
+        builder.setEventType(eventTypeVoc);
+      }
+    }
+
+    // populate with the type for this event at least
+    if (builder.getEventTypeHierarchy() == null || builder.getEventTypeHierarchy().isEmpty()) {
+      List<String> eventTypeHierarchy = new ArrayList<>();
+      if (builder.getEventType() != null) {
+        eventTypeHierarchy.add(builder.getEventType().getConcept());
+      }
+      builder.setEventTypeHierarchy(eventTypeHierarchy);
+      if (builder.getEventType() != null) {
+        builder.setEventTypeHierarchyJoined(builder.getEventType().getConcept());
+      }
+    }
+
+    // retrieve sampling protocol from occurrences, if nothing supplied in events
+    if (builder.getSamplingProtocol() == null && builder.getSamplingProtocol().isEmpty()) {
+      Optional<List<String>> samplingProtocols =
+          Optional.of(verbatim.getExtensions())
+              .map(exts -> exts.get(DwcTerm.Occurrence.qualifiedName()))
+              .map(ext -> extractValuesFromExtension(ext, DwcTerm.samplingProtocol));
+      builder.setSamplingProtocol(samplingProtocols.orElse(new ArrayList<>()));
+    }
+
+    return builder;
+  }
+
+  public static List<String> extractValuesFromExtension(
+      List<Map<String, String>> extension, DwcTerm term) {
+    return extension.stream()
+        .map(x -> x.getOrDefault(term.qualifiedName(), null))
+        .filter(x -> x != null)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  private MetadataJsonRecord.Builder mapMetadataJsonRecord() {
+    return MetadataJsonRecord.newBuilder()
+        .setDatasetKey(metadata.getDataResourceUid())
+        .setDatasetTitle(metadata.getDataResourceName());
+  }
+
+  private void mapInherited(EventJsonRecord.Builder builder) {
+
+    boolean hasCoordsInfo = builder.getDecimalLatitude() != null;
+    boolean hasCountryInfo = builder.getCountryCode() != null;
+    boolean hasStateInfo = builder.getStateProvince() != null;
+    boolean hasYearInfo = builder.getYear() != null;
+    boolean hasMonthInfo = builder.getMonth() != null;
+    boolean hasLocationID = builder.getLocationID() != null;
+
+    // extract location & temporal information from
+    if (!hasYearInfo && temporalInheritedRecord.getYear() != null) {
+      builder.setYear(temporalInheritedRecord.getYear());
+    }
+
+    if (!hasMonthInfo && temporalInheritedRecord.getMonth() != null) {
+      builder.setMonth(temporalInheritedRecord.getMonth());
+    }
+
+    if (!hasCountryInfo && locationInheritedRecord.getCountryCode() != null) {
+      builder.setCountryCode(locationInheritedRecord.getCountryCode());
+    }
+
+    if (!hasStateInfo && locationInheritedRecord.getStateProvince() != null) {
+      builder.setStateProvince(locationInheritedRecord.getStateProvince());
+    }
+
+    if (!hasCoordsInfo
+        && locationInheritedRecord.getDecimalLatitude() != null
+        && locationInheritedRecord.getDecimalLongitude() != null) {
+      builder
+          .setHasCoordinate(true)
+          .setDecimalLatitude(locationInheritedRecord.getDecimalLatitude())
+          .setDecimalLongitude(locationInheritedRecord.getDecimalLongitude())
+          // geo_point
+          .setCoordinates(
+              JsonConverter.convertCoordinates(
+                  locationInheritedRecord.getDecimalLongitude(),
+                  locationInheritedRecord.getDecimalLatitude()))
+          // geo_shape
+          .setScoordinates(
+              JsonConverter.convertScoordinates(
+                  locationInheritedRecord.getDecimalLongitude(),
+                  locationInheritedRecord.getDecimalLatitude()));
+    }
+
+    if (!hasLocationID && eventInheritedRecord.getLocationID() != null) {
+      builder.setLocationID(eventInheritedRecord.getLocationID());
+    }
+
+    if (eventCore.getParentsLineage() != null && !eventCore.getParentsLineage().isEmpty()) {
+
+      List<String> eventIDs =
+          eventCore.getParentsLineage().stream()
+              .sorted(
+                  Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder).reversed())
+              .map(e -> e.getId())
+              .collect(Collectors.toList());
+      eventIDs.add(eventCore.getId());
+
+      List<String> eventTypes =
+          eventCore.getParentsLineage().stream()
+              .sorted(
+                  Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder).reversed())
+              .map(e -> e.getEventType())
+              .collect(Collectors.toList());
+
+      if (eventCore.getEventType() != null) {
+        eventTypes.add(eventCore.getEventType().getConcept());
+      } else {
+        String rawEventType =
+            (String) verbatim.getCoreTerms().get(GbifTerm.eventType.qualifiedName());
+        if (rawEventType != null) {
+          eventTypes.add(rawEventType);
+        }
+      }
+
+      // add the eventID / eventy
+      builder.setEventTypeHierarchy(eventTypes);
+      builder.setEventTypeHierarchyJoined(String.join(" / ", eventTypes));
+
+      builder.setEventHierarchy(eventIDs);
+      builder.setEventHierarchyJoined(String.join(" / ", eventIDs));
+      builder.setEventHierarchyLevels(eventIDs.size());
+
+    } else {
+      // add the eventID and parentEventID to hierarchy for consistency
+      List<String> eventHierarchy = new ArrayList<>();
+      if (builder.getParentEventID() != null) {
+        eventHierarchy.add(builder.getParentEventID());
+      }
+      if (builder.getEventID() != null) {
+        eventHierarchy.add(builder.getEventID());
+      }
+      builder.setEventHierarchy(eventHierarchy);
+
+      // add the single type to hierarchy for consistency
+      List<String> eventTypeHierarchy = new ArrayList<>();
+      if (builder.getEventType() != null && builder.getEventType().getConcept() != null) {
+        eventTypeHierarchy.add(builder.getEventType().getConcept());
+      }
+      builder.setEventTypeHierarchy(eventTypeHierarchy);
+    }
+  }
+
+  private void mapEventCoreRecord(EventJsonRecord.Builder builder) {
+
+    // Simple
+    builder
+        .setSampleSizeValue(eventCore.getSampleSizeValue())
+        .setSampleSizeUnit(eventCore.getSampleSizeUnit())
+        .setReferences(eventCore.getReferences())
+        .setDatasetID(eventCore.getDatasetID())
+        .setDatasetName(eventCore.getDatasetName())
+        .setSamplingProtocol(eventCore.getSamplingProtocol())
+        .setParentsLineage(convertParents(eventCore.getParentsLineage()))
+        .setParentEventID(eventCore.getParentEventID())
+        .setLocationID(eventCore.getLocationID());
+
+    // Vocabulary
+    JsonConverter.convertVocabularyConcept(eventCore.getEventType())
+        .ifPresent(builder::setEventType);
+
+    // License
+    JsonConverter.convertLicense(eventCore.getLicense()).ifPresent(builder::setLicense);
+
+    // Multivalue fields
+    JsonConverter.convertToMultivalue(eventCore.getSamplingProtocol())
+        .ifPresent(builder::setSamplingProtocolJoined);
+  }
+
+  private void mapTemporalRecord(EventJsonRecord.Builder builder) {
+
+    builder
+        .setYear(temporal.getYear())
+        .setMonth(temporal.getMonth())
+        .setDay(temporal.getDay())
+        .setStartDayOfYear(temporal.getStartDayOfYear())
+        .setEndDayOfYear(temporal.getEndDayOfYear())
+        .setModified(temporal.getModified());
+
+    JsonConverter.convertEventDate(temporal.getEventDate()).ifPresent(builder::setEventDate);
+    JsonConverter.convertEventDateSingle(temporal).ifPresent(builder::setEventDateSingle);
+  }
+
+  private void mapLocationRecord(EventJsonRecord.Builder builder) {
+
+    builder
+        .setContinent(location.getContinent())
+        .setWaterBody(location.getWaterBody())
+        .setCountry(location.getCountry())
+        .setCountryCode(location.getCountryCode())
+        .setPublishingCountry(location.getPublishingCountry())
+        .setStateProvince(location.getStateProvince())
+        .setMinimumElevationInMeters(location.getMinimumElevationInMeters())
+        .setMaximumElevationInMeters(location.getMaximumElevationInMeters())
+        .setMinimumDepthInMeters(location.getMinimumDepthInMeters())
+        .setMaximumDepthInMeters(location.getMaximumDepthInMeters())
+        .setMaximumDistanceAboveSurfaceInMeters(location.getMaximumDistanceAboveSurfaceInMeters())
+        .setMinimumDistanceAboveSurfaceInMeters(location.getMinimumDistanceAboveSurfaceInMeters())
+        .setCoordinateUncertaintyInMeters(location.getCoordinateUncertaintyInMeters())
+        .setCoordinatePrecision(location.getCoordinatePrecision())
+        .setHasCoordinate(location.getHasCoordinate())
+        .setRepatriated(location.getRepatriated())
+        .setHasGeospatialIssue(location.getHasGeospatialIssue())
+        .setLocality(location.getLocality())
+        .setFootprintWKT(location.getFootprintWKT());
+
+    // Coordinates
+    Double decimalLongitude = location.getDecimalLongitude();
+    Double decimalLatitude = location.getDecimalLatitude();
+    if (decimalLongitude != null && decimalLatitude != null) {
+      builder
+          .setDecimalLatitude(decimalLatitude)
+          .setDecimalLongitude(decimalLongitude)
+          // geo_point
+          .setCoordinates(JsonConverter.convertCoordinates(decimalLongitude, decimalLatitude))
+          // geo_shape
+          .setScoordinates(JsonConverter.convertScoordinates(decimalLongitude, decimalLatitude));
+    }
+
+    JsonConverter.convertGadm(location.getGadm()).ifPresent(builder::setGadm);
+  }
+
+  protected void mapTaxonRecord(EventJsonRecord.Builder builder) {}
+
+  private void mapMultimediaRecord(EventJsonRecord.Builder builder) {
+    builder
+        .setMultimediaItems(JsonConverter.convertMultimediaList(multimedia))
+        .setMediaTypes(JsonConverter.convertMultimediaType(multimedia))
+        .setMediaLicenses(JsonConverter.convertMultimediaLicense(multimedia));
+  }
+
+  private void mapMeasurementOrFactRecord(EventJsonRecord.Builder builder) {
+    builder.setMeasurementOrFactMethods(
+        measurementOrFactRecord.getMeasurementOrFactItems().stream()
+            .map(MeasurementOrFact::getMeasurementMethod)
+            .filter(x -> StringUtils.isNotEmpty(x))
+            .distinct()
+            .collect(Collectors.toList()));
+    builder.setMeasurementOrFactTypes(
+        measurementOrFactRecord.getMeasurementOrFactItems().stream()
+            .map(MeasurementOrFact::getMeasurementType)
+            .filter(x -> StringUtils.isNotEmpty(x))
+            .distinct()
+            .collect(Collectors.toList()));
+
+    List<MeasurementOrFactJsonRecord> mofs =
+        measurementOrFactRecord.getMeasurementOrFactItems().stream()
+            .map(
+                mor -> {
+                  return MeasurementOrFactJsonRecord.newBuilder()
+                      .setMeasurementID(mor.getMeasurementID())
+                      .setMeasurementMethod(mor.getMeasurementMethod())
+                      .setMeasurementType(mor.getMeasurementType())
+                      .setMeasurementValue(mor.getMeasurementValue())
+                      .setMeasurementUnit(mor.getMeasurementUnit())
+                      .build();
+                })
+            .collect(Collectors.toList());
+    builder.setMeasurementOrFacts(mofs);
+  }
+
+  private void mapExtendedRecord(EventJsonRecord.Builder builder) {
+    builder.setExtensions(JsonConverter.convertExtensions(verbatim));
+
+    // set occurrence count
+    Integer occurrenceCount =
+        Optional.of(verbatim.getExtensions())
+            .map(exts -> exts.get(DwcTerm.Occurrence.qualifiedName()))
+            .map(ext -> ext.size())
+            .orElse(0);
+
+    builder.setOccurrenceCount(occurrenceCount);
+
+    // Set raw as indexed
+    extractOptValue(verbatim, DwcTerm.eventID).ifPresent(builder::setEventID);
+    extractOptValue(verbatim, DwcTerm.parentEventID).ifPresent(builder::setParentEventID);
+    extractOptValue(verbatim, DwcTerm.institutionCode).ifPresent(builder::setInstitutionCode);
+    extractOptValue(verbatim, DwcTerm.verbatimDepth).ifPresent(builder::setVerbatimDepth);
+    extractOptValue(verbatim, DwcTerm.verbatimElevation).ifPresent(builder::setVerbatimElevation);
+    extractOptValue(verbatim, DwcTerm.locationID).ifPresent(builder::setLocationID);
+
+    String eventName = verbatim.getCoreTerms().get("http://rs.gbif.org/terms/1.0/eventName");
+    if (eventName != null) {
+      builder.setEventName(eventName);
+    }
+  }
+
+  private void mapCreated(ParentJsonRecord.Builder builder) {
+    JsonConverter.getMaxCreationDate(metadata, eventCore, temporal, location, multimedia)
+        .ifPresent(builder::setCreated);
+  }
+
+  private void mapDerivedMetadata(ParentJsonRecord.Builder builder) {
+    builder.setDerivedMetadata(derivedMetadata);
+  }
+
+  private void mapLocationInheritedFields(ParentJsonRecord.Builder builder) {
+    if (locationInheritedRecord.getId() != null) {
+      builder.setLocationInherited(locationInheritedRecord);
+    }
+  }
+
+  private void mapTemporalInheritedFields(ParentJsonRecord.Builder builder) {
+    if (temporalInheritedRecord.getId() != null) {
+      builder.setTemporalInherited(temporalInheritedRecord);
+    }
+  }
+
+  private void mapEventInheritedFields(ParentJsonRecord.Builder builder) {
+    if (eventInheritedRecord.getId() != null) {
+      builder.setEventInherited(eventInheritedRecord);
+    }
+  }
+
+  protected static List<Parent> convertParents(List<org.gbif.pipelines.io.avro.Parent> parents) {
+    if (parents == null) {
+      return Collections.emptyList();
+    }
+
+    return parents.stream()
+        .map(p -> Parent.newBuilder().setId(p.getId()).setEventType(p.getEventType()).build())
+        .collect(Collectors.toList());
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/interpreters/ALATaxonomyInterpreter.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/interpreters/ALATaxonomyInterpreter.java
@@ -1,5 +1,7 @@
 package au.org.ala.pipelines.interpreters;
 
+import static org.gbif.pipelines.core.utils.ModelUtils.extractOptValue;
+
 import au.org.ala.kvs.client.ALACollectoryMetadata;
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
@@ -10,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -279,7 +282,7 @@ public class ALATaxonomyInterpreter {
   /**
    * Extract a value from a record, with a potential default value
    *
-   * @param er The extened record
+   * @param er The extended record
    * @param term The term to look up
    * @param defaults Any defaults that apply to this value
    * @return The resulting value, or null for not found
@@ -290,5 +293,15 @@ public class ALATaxonomyInterpreter {
       value = defaults.get(term.simpleName());
     }
     return value;
+  }
+
+  /** Sets the coreId field. */
+  public static void setCoreId(ExtendedRecord er, ALATaxonRecord tr) {
+    Optional.ofNullable(er.getCoreId()).ifPresent(tr::setCoreId);
+  }
+
+  /** Sets the parentEventId field. */
+  public static void setParentEventId(ExtendedRecord er, ALATaxonRecord tr) {
+    extractOptValue(er, DwcTerm.parentEventID).ifPresent(tr::setParentId);
   }
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/DwcaToVerbatimPipelineOptions.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/DwcaToVerbatimPipelineOptions.java
@@ -1,15 +1,6 @@
 package au.org.ala.pipelines.options;
 
-import org.apache.beam.sdk.options.Default;
-import org.apache.beam.sdk.options.Description;
 import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
 
 /** Options for running DwCA to Verbatim AVRO pipelines. */
-public interface DwcaToVerbatimPipelineOptions extends InterpretationPipelineOptions {
-
-  @Description("Delete lock file on exit")
-  @Default.Boolean(true)
-  boolean isDeleteLockFileOnExit();
-
-  void setDeleteLockFileOnExit(boolean deleteLockFileOnExit);
-}
+public interface DwcaToVerbatimPipelineOptions extends InterpretationPipelineOptions {}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALABasicTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALABasicTransform.java
@@ -119,6 +119,7 @@ public class ALABasicTransform extends Transform<ExtendedRecord, BasicRecord> {
         .via(BasicInterpreter::interpretIdentifiedBy)
         .via(BasicInterpreter::interpretPreparations)
         .via((e, r) -> CoreInterpreter.interpretSamplingProtocol(e, r::setSamplingProtocol))
+        .via(BasicInterpreter::setCoreId)
         .getOfNullable();
   }
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALADerivedMetadataTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALADerivedMetadataTransform.java
@@ -1,0 +1,88 @@
+package au.org.ala.pipelines.transforms;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.Builder;
+import lombok.NonNull;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.gbif.pipelines.io.avro.EventDate;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.TaxonRecord;
+import org.gbif.pipelines.io.avro.json.DerivedMetadataRecord;
+
+/**
+ * A version of the @{@link org.gbif.pipelines.transforms.core.DerivedMetadataTransform} without the
+ * taxonomic component (which is GBIF specific).
+ */
+@Builder
+public class ALADerivedMetadataTransform implements Serializable {
+
+  private static final TupleTag<DerivedMetadataRecord> TAG =
+      new TupleTag<DerivedMetadataRecord>() {};
+
+  @NonNull private final TupleTag<ExtendedRecord> extendedRecordTag;
+
+  @NonNull private final TupleTag<String> convexHullTag;
+
+  @NonNull private final TupleTag<EventDate> temporalCoverageTag;
+
+  public ParDo.SingleOutput<KV<String, CoGbkResult>, KV<String, DerivedMetadataRecord>>
+      converter() {
+
+    DoFn<KV<String, CoGbkResult>, KV<String, DerivedMetadataRecord>> fn =
+        new DoFn<KV<String, CoGbkResult>, KV<String, DerivedMetadataRecord>>() {
+
+          private ExtendedRecord getAssociatedVerbatim(
+              TaxonRecord taxonRecord, List<ExtendedRecord> verbatimRecords) {
+            return verbatimRecords.stream()
+                .filter(er -> er.getId().equals(taxonRecord.getId()))
+                .findFirst()
+                .orElse(null);
+          }
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            CoGbkResult result = c.element().getValue();
+            String key = c.element().getKey();
+            String convexHull = result.getOnly(convexHullTag);
+
+            EventDate temporalCoverage =
+                result.getOnly(temporalCoverageTag, EventDate.newBuilder().build());
+
+            DerivedMetadataRecord.Builder builder = DerivedMetadataRecord.newBuilder().setId(key);
+            if (convexHull != null && !convexHull.isEmpty()) {
+              builder.setWktConvexHull(convexHull);
+            }
+
+            if (temporalCoverage.getGte() != null || temporalCoverage.getLte() != null) {
+              builder.setTemporalCoverageBuilder(
+                  org.gbif.pipelines.io.avro.json.EventDate.newBuilder()
+                      .setGte(temporalCoverage.getGte())
+                      .setLte(temporalCoverage.getLte()));
+            }
+
+            c.output(KV.of(key, builder.build()));
+          }
+        };
+    return ParDo.of(fn);
+  }
+
+  public static TupleTag<DerivedMetadataRecord> tag() {
+    return TAG;
+  }
+
+  /**
+   * Maps {@link DerivedMetadataRecord} to key value, where key is {@link
+   * DerivedMetadataRecord#getId}
+   */
+  public MapElements<DerivedMetadataRecord, KV<String, DerivedMetadataRecord>> toKv() {
+    return MapElements.into(new TypeDescriptor<KV<String, DerivedMetadataRecord>>() {})
+        .via((DerivedMetadataRecord dmr) -> KV.of(dmr.getId(), dmr));
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAEventToSearchTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAEventToSearchTransform.java
@@ -1,0 +1,157 @@
+package au.org.ala.pipelines.transforms;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.EVENTS_AVRO_TO_JSON_COUNT;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.NonNull;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.commons.lang3.StringUtils;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+
+/**
+ * This converter will take AVRO record artefacts related to an event and produce a single AVRO
+ * document that will support Spark SQL searching.
+ */
+@SuppressWarnings("ConstantConditions")
+@Builder
+public class ALAEventToSearchTransform implements Serializable {
+
+  private static final long serialVersionUID = 1279313941024805871L;
+
+  // Core
+  @NonNull private final TupleTag<EventCoreRecord> eventCoreRecordTag;
+  @NonNull private final TupleTag<TemporalRecord> temporalRecordTag;
+  @NonNull private final TupleTag<LocationRecord> locationRecordTag;
+  // Extension
+  @NonNull private final PCollectionView<ALAMetadataRecord> metadataView;
+  @NonNull private final TupleTag<MeasurementOrFactRecord> measurementOrFactRecordTag;
+  @NonNull private final TupleTag<LocationInheritedRecord> locationInheritedRecordTag;
+  @NonNull private final TupleTag<TemporalInheritedRecord> temporalInheritedRecordTag;
+  @NonNull private final TupleTag<EventInheritedRecord> eventInheritedRecordTag;
+
+  private final TupleTag<Iterable<String>> taxonIDsTag;
+
+  public SingleOutput<KV<String, CoGbkResult>, EventSearchRecord> converter() {
+
+    DoFn<KV<String, CoGbkResult>, EventSearchRecord> fn =
+        new DoFn<KV<String, CoGbkResult>, EventSearchRecord>() {
+
+          private final Counter counter =
+              Metrics.counter(ALAEventToSearchTransform.class, EVENTS_AVRO_TO_JSON_COUNT);
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            CoGbkResult v = c.element().getValue();
+            String k = c.element().getKey();
+
+            ALAMetadataRecord mdr = c.sideInput(metadataView);
+            // Core
+            EventCoreRecord core =
+                v.getOnly(eventCoreRecordTag, EventCoreRecord.newBuilder().setId(k).build());
+            TemporalRecord tr =
+                v.getOnly(temporalRecordTag, TemporalRecord.newBuilder().setId(k).build());
+            LocationRecord lr =
+                v.getOnly(locationRecordTag, LocationRecord.newBuilder().setId(k).build());
+            MeasurementOrFactRecord mofr =
+                v.getOnly(
+                    measurementOrFactRecordTag,
+                    MeasurementOrFactRecord.newBuilder().setId(k).build());
+
+            List<String> taxonIDs = new ArrayList<>();
+
+            Iterable<String> retrievedTaxonIDs = v.getOnly(taxonIDsTag, null);
+
+            // Convert and
+            EventSearchRecord.Builder builder = EventSearchRecord.newBuilder().setId(core.getId());
+            // Inherited
+            EventInheritedRecord eir =
+                v.getOnly(
+                    eventInheritedRecordTag, EventInheritedRecord.newBuilder().setId(k).build());
+            LocationInheritedRecord lir =
+                v.getOnly(
+                    locationInheritedRecordTag,
+                    LocationInheritedRecord.newBuilder().setId(k).build());
+            TemporalInheritedRecord tir =
+                v.getOnly(
+                    temporalInheritedRecordTag,
+                    TemporalInheritedRecord.newBuilder().setId(k).build());
+
+            // set mof
+            builder.setMeasurementOrFactTypes(
+                mofr.getMeasurementOrFactItems().stream()
+                    .map(MeasurementOrFact::getMeasurementType)
+                    .filter(x -> StringUtils.isNotEmpty(x))
+                    .distinct()
+                    .collect(Collectors.toList()));
+            builder
+                .setDatasetKey(mdr.getDataResourceUid())
+                .setTaxonKey(taxonIDs)
+                .setLocationID(consolidate(core.getLocationID(), eir.getLocationID()))
+                .setYear(tr.getYear())
+                .setMonth(tr.getMonth())
+                .setCountryCode(consolidate(lr.getCountryCode(), lir.getCountryCode()))
+                .setStateProvince(consolidate(lr.getStateProvince(), lir.getStateProvince()));
+
+            List<String> eventIDs =
+                core.getParentsLineage().stream()
+                    .sorted(
+                        Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder)
+                            .reversed())
+                    .map(e -> e.getId())
+                    .collect(Collectors.toList());
+            eventIDs.add(core.getId());
+
+            List<String> eventTypes =
+                core.getParentsLineage().stream()
+                    .sorted(
+                        Comparator.comparingInt(org.gbif.pipelines.io.avro.Parent::getOrder)
+                            .reversed())
+                    .map(e -> e.getEventType())
+                    .collect(Collectors.toList());
+
+            if (core.getEventType() != null && core.getEventType().getConcept() != null) {
+              eventTypes.add(core.getEventType().getConcept());
+            }
+
+            builder.setEventTypeHierarchy(eventTypes).setEventHierarchy(eventIDs);
+
+            boolean hasYearInfo = builder.getYear() != null;
+            boolean hasMonthInfo = builder.getMonth() != null;
+
+            // extract location & temporal information from
+            if (!hasYearInfo && tir.getYear() != null) {
+              builder.setYear(tir.getYear());
+            }
+
+            if (!hasMonthInfo && tir.getMonth() != null) {
+              builder.setMonth(tir.getMonth());
+            }
+            c.output(builder.build());
+          }
+        };
+    return ParDo.of(fn).withSideInputs(metadataView);
+  }
+
+  public List<String> consolidate(String value, String denormedValue) {
+    List<String> list = new ArrayList<>();
+    if (value != null) list.add(value);
+    if (denormedValue != null) list.add(denormedValue);
+    return list;
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAMetadataTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAMetadataTransform.java
@@ -1,9 +1,9 @@
 package au.org.ala.pipelines.transforms;
 
 import static org.gbif.pipelines.common.PipelinesVariables.Metrics.METADATA_RECORDS_COUNT;
-import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretation.RecordType.METADATA;
 
 import au.org.ala.kvs.client.ALACollectoryMetadata;
+import au.org.ala.pipelines.common.ALARecordTypes;
 import au.org.ala.pipelines.interpreters.ALAAttributionInterpreter;
 import java.util.Optional;
 import lombok.Builder;
@@ -30,7 +30,7 @@ public class ALAMetadataTransform extends Transform<String, ALAMetadataRecord> {
       String datasetId) {
     super(
         ALAMetadataRecord.class,
-        METADATA,
+        ALARecordTypes.ALA_ATTRIBUTION,
         ALAMetadataRecord.class.getName(),
         METADATA_RECORDS_COUNT);
     this.dataResourceKvStoreSupplier = dataResourceKvStoreSupplier;

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAOccurrenceJsonTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALAOccurrenceJsonTransform.java
@@ -1,0 +1,182 @@
+package au.org.ala.pipelines.transforms;
+
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.AVRO_TO_JSON_COUNT;
+
+import au.org.ala.pipelines.converters.ALAOccurrenceJsonConverter;
+import au.org.ala.pipelines.converters.ALAParentJsonConverter;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.NonNull;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.gbif.pipelines.io.avro.*;
+import org.gbif.pipelines.io.avro.json.EventInheritedRecord;
+import org.gbif.pipelines.io.avro.json.LocationInheritedRecord;
+import org.gbif.pipelines.io.avro.json.TemporalInheritedRecord;
+
+/**
+ * Beam level transformation for the ES output json. The transformation consumes objects, which
+ * classes were generated from avro schema files and converts into json string object
+ *
+ * <p>Example:
+ *
+ * <p>
+ *
+ * <pre>{@code
+ * final TupleTag<ExtendedRecord> erTag = new TupleTag<ExtendedRecord>() {};
+ * final TupleTag<BasicRecord> brTag = new TupleTag<BasicRecord>() {};
+ * final TupleTag<TemporalRecord> trTag = new TupleTag<TemporalRecord>() {};
+ * final TupleTag<LocationRecord> lrTag = new TupleTag<LocationRecord>() {};
+ * final TupleTag<TaxonRecord> txrTag = new TupleTag<TaxonRecord>() {};
+ * final TupleTag<MultimediaRecord> mrTag = new TupleTag<MultimediaRecord>() {};
+ * final TupleTag<ImageRecord> irTag = new TupleTag<ImageRecord>() {};
+ * final TupleTag<AudubonRecord> arTag = new TupleTag<AudubonRecord>() {};
+ * final TupleTag<MeasurementOrFactRecord> mfrTag = new TupleTag<MeasurementOrFactRecord>() {};
+ *
+ * PCollectionView<MetadataRecord> metadataView = ...
+ * PCollection<KV<String, ExtendedRecord>> verbatimCollection = ...
+ * PCollection<KV<String, BasicRecord>> basicCollection = ...
+ * PCollection<KV<String, TemporalRecord>> temporalCollection = ...
+ * PCollection<KV<String, LocationRecord>> locationCollection = ...
+ * PCollection<KV<String, TaxonRecord>> taxonCollection = ...
+ * PCollection<KV<String, MultimediaRecord>> multimediaCollection = ...
+ * PCollection<KV<String, ImageRecord>> imageCollection = ...
+ * PCollection<KV<String, AudubonRecord>> audubonCollection = ...
+ * PCollection<KV<String, MeasurementOrFactRecord>> measurementCollection = ...
+ *
+ * SingleOutput<KV<String, CoGbkResult>, String> occurrenceJsonDoFn =
+ *     OccurrenceJsonTransform.create(erTag, brTag, trTag, lrTag, txrTag, mrTag, irTag, arTag, mfrTag, metadataView)
+ *         .converter();
+ *
+ * PCollection<String> jsonCollection =
+ *     KeyedPCollectionTuple
+ *         // Core
+ *         .of(brTag, basicCollection)
+ *         .and(trTag, temporalCollection)
+ *         .and(lrTag, locationCollection)
+ *         .and(txrTag, taxonCollection)
+ *         // Extension
+ *         .and(mrTag, multimediaCollection)
+ *         .and(irTag, imageCollection)
+ *         .and(arTag, audubonCollection)
+ *         .and(mfrTag, measurementCollection)
+ *         // Raw
+ *         .and(erTag, verbatimCollection)
+ *         // Apply
+ *         .apply("Grouping objects", CoGroupByKey.create())
+ *         .apply("Merging to json", occurrenceJsonDoFn);
+ * }</pre>
+ */
+@SuppressWarnings("ConstantConditions")
+@Builder
+public class ALAOccurrenceJsonTransform implements Serializable {
+
+  private static final long serialVersionUID = 1279313931024806171L;
+
+  // Core
+  @NonNull private final TupleTag<ALAUUIDRecord> uuidRecordTag;
+  @NonNull private final TupleTag<ExtendedRecord> extendedRecordTag;
+  @NonNull private final TupleTag<BasicRecord> basicRecordTag;
+  @NonNull private final TupleTag<TemporalRecord> temporalRecordTag;
+  @NonNull private final TupleTag<LocationRecord> locationRecordTag;
+  @NonNull private final TupleTag<ALATaxonRecord> taxonRecordTag;
+  @NonNull private final TupleTag<MultimediaRecord> multimediaRecordTag;
+  @NonNull private final TupleTag<EventCoreRecord> eventCoreRecordTag;
+  @NonNull private final PCollectionView<ALAMetadataRecord> metadataView;
+  @NonNull private final TupleTag<MeasurementOrFactRecord> measurementOrFactRecordTupleTag;
+
+  @NonNull private final TupleTag<LocationInheritedRecord> locationInheritedRecordTag;
+  @NonNull private final TupleTag<TemporalInheritedRecord> temporalInheritedRecordTag;
+  @NonNull private final TupleTag<EventInheritedRecord> eventInheritedRecordTag;
+
+  // Determines if the output record is a parent-child record
+  @Builder.Default private final boolean asParentChildRecord = false;
+
+  public SingleOutput<KV<String, CoGbkResult>, String> converter() {
+
+    DoFn<KV<String, CoGbkResult>, String> fn =
+        new DoFn<KV<String, CoGbkResult>, String>() {
+
+          private final Counter counter =
+              Metrics.counter(ALAOccurrenceJsonTransform.class, AVRO_TO_JSON_COUNT);
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            CoGbkResult v = c.element().getValue();
+            String k = c.element().getKey();
+
+            // Core
+            ALAMetadataRecord mdr = c.sideInput(metadataView);
+            ALAUUIDRecord uuidr =
+                v.getOnly(uuidRecordTag, ALAUUIDRecord.newBuilder().setId(k).build());
+
+            ExtendedRecord er =
+                v.getOnly(extendedRecordTag, ExtendedRecord.newBuilder().setId(k).build());
+            BasicRecord br = v.getOnly(basicRecordTag, BasicRecord.newBuilder().setId(k).build());
+            TemporalRecord tr =
+                v.getOnly(temporalRecordTag, TemporalRecord.newBuilder().setId(k).build());
+            LocationRecord lr =
+                v.getOnly(locationRecordTag, LocationRecord.newBuilder().setId(k).build());
+            ALATaxonRecord txr =
+                v.getOnly(taxonRecordTag, ALATaxonRecord.newBuilder().setId(k).build());
+            MeasurementOrFactRecord mfr =
+                v.getOnly(
+                    measurementOrFactRecordTupleTag,
+                    MeasurementOrFactRecord.newBuilder().setId(k).build());
+            EventCoreRecord ecr =
+                v.getOnly(eventCoreRecordTag, EventCoreRecord.newBuilder().setId(k).build());
+
+            // Inherited
+            EventInheritedRecord eir =
+                v.getOnly(
+                    eventInheritedRecordTag, EventInheritedRecord.newBuilder().setId(k).build());
+            LocationInheritedRecord lir =
+                v.getOnly(
+                    locationInheritedRecordTag,
+                    LocationInheritedRecord.newBuilder().setId(k).build());
+            TemporalInheritedRecord tir =
+                v.getOnly(
+                    temporalInheritedRecordTag,
+                    TemporalInheritedRecord.newBuilder().setId(k).build());
+
+            ALAOccurrenceJsonConverter occurrenceJsonConverter =
+                ALAOccurrenceJsonConverter.builder()
+                    .uuid(uuidr)
+                    .metadata(mdr)
+                    .basic(br)
+                    .temporal(tr)
+                    .location(lr)
+                    .taxon(txr)
+                    .verbatim(er)
+                    .measurementOrFact(mfr)
+                    .eventCore(ecr)
+                    .eventInheritedRecord(eir)
+                    .locationInheritedRecord(lir)
+                    .temporalInheritedRecord(tir)
+                    .build();
+            if (asParentChildRecord) {
+              c.output(
+                  ALAParentJsonConverter.builder()
+                      .occurrenceJsonRecord(occurrenceJsonConverter.convert())
+                      .metadata(mdr)
+                      .verbatim(er)
+                      .build()
+                      .toJson());
+            } else {
+              c.output(occurrenceJsonConverter.toJson());
+            }
+
+            counter.inc();
+          }
+        };
+
+    return ParDo.of(fn).withSideInputs(metadataView);
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALATemporalTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/ALATemporalTransform.java
@@ -1,5 +1,7 @@
 package au.org.ala.pipelines.transforms;
 
+import static org.gbif.pipelines.common.PipelinesVariables.Metrics.TEMPORAL_RECORDS_COUNT;
+
 import au.org.ala.pipelines.interpreters.ALATemporalInterpreter;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +16,15 @@ import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.gbif.pipelines.io.avro.TemporalRecord;
 import org.gbif.pipelines.transforms.Transform;
 
+/**
+ * ALA version of the Beam level transformations for the DWC Event, reads an avro, writes an avro,
+ * maps from value to keyValue and transforms form {@link ExtendedRecord} to {@link TemporalRecord}.
+ *
+ * <p>ParDo runs sequence of interpretations for {@link TemporalRecord} using {@link ExtendedRecord}
+ * as a source and {@link ALATemporalInterpreter} as interpretation steps
+ *
+ * @see <a href="https://dwc.tdwg.org/terms/#event">https://dwc.tdwg.org/terms/#event</a>
+ */
 public class ALATemporalTransform extends Transform<ExtendedRecord, TemporalRecord> {
 
   private final SerializableFunction<String, String> preprocessDateFn;
@@ -29,7 +40,7 @@ public class ALATemporalTransform extends Transform<ExtendedRecord, TemporalReco
         TemporalRecord.class,
         RecordType.TEMPORAL,
         ALATemporalTransform.class.getName(),
-        "alaTemporalCount");
+        TEMPORAL_RECORDS_COUNT);
     this.orderings = orderings;
     this.preprocessDateFn = preprocessDateFn;
   }
@@ -71,6 +82,7 @@ public class ALATemporalTransform extends Transform<ExtendedRecord, TemporalReco
         .via(alaTemporalInterpreter::checkDateIdentified)
         .via(alaTemporalInterpreter::checkGeoreferencedDate)
         .via(ALATemporalInterpreter::checkDatePrecision)
+        .via(TemporalInterpreter::setCoreId)
         .getOfNullable();
   }
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/LocationTransform.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/LocationTransform.java
@@ -177,6 +177,9 @@ public class LocationTransform extends Transform<ExtendedRecord, LocationRecord>
                     countryCentrePoints, stateProvinceCentrePoints, stateProvinceParser))
             .via(ALALocationInterpreter.validateStateProvince(stateProvinceParser))
             .via(LocationInterpreter::interpretLocality)
+            .via(LocationInterpreter::interpretFootprintWKT)
+            .via(LocationInterpreter::setCoreId)
+            .via(LocationInterpreter::setParentEventId)
             .get();
 
     result.ifPresent(r -> this.incCounter());

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/TransformsFactory.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/transforms/TransformsFactory.java
@@ -1,0 +1,82 @@
+package au.org.ala.pipelines.transforms;
+
+import java.util.List;
+import lombok.Getter;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.gbif.common.parsers.date.DateComponentOrdering;
+import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
+import org.gbif.pipelines.core.config.model.PipelinesConfig;
+import org.gbif.pipelines.core.functions.SerializableSupplier;
+import org.gbif.pipelines.core.pojo.HdfsConfigs;
+import org.gbif.pipelines.core.utils.FsUtils;
+import org.gbif.pipelines.core.ws.metadata.MetadataServiceClient;
+import org.gbif.pipelines.factory.MetadataServiceClientFactory;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.transforms.common.ExtensionFilterTransform;
+import org.gbif.pipelines.transforms.common.UniqueIdTransform;
+import org.gbif.pipelines.transforms.extension.AudubonTransform;
+import org.gbif.pipelines.transforms.extension.ImageTransform;
+import org.gbif.pipelines.transforms.extension.MultimediaTransform;
+import org.gbif.pipelines.transforms.metadata.DefaultValuesTransform;
+import org.gbif.pipelines.transforms.specific.IdentifierTransform;
+
+/** Factory class for initialising transforms. */
+@Getter
+public class TransformsFactory {
+
+  private final InterpretationPipelineOptions options;
+  private final HdfsConfigs hdfsConfigs;
+  private final PipelinesConfig config;
+  private final List<DateComponentOrdering> dateComponentOrdering;
+
+  private TransformsFactory(InterpretationPipelineOptions options) {
+    this.options = options;
+    this.hdfsConfigs = HdfsConfigs.create(options.getHdfsSiteConfig(), options.getCoreSiteConfig());
+    this.config =
+        FsUtils.readConfigFile(hdfsConfigs, options.getProperties(), PipelinesConfig.class);
+    this.dateComponentOrdering =
+        options.getDefaultDateFormat() == null
+            ? config.getDefaultDateFormat()
+            : options.getDefaultDateFormat();
+  }
+
+  public static TransformsFactory create(InterpretationPipelineOptions options) {
+    return new TransformsFactory(options);
+  }
+
+  public SingleOutput<ExtendedRecord, ExtendedRecord> createDefaultValuesTransform() {
+    SerializableSupplier<MetadataServiceClient> metadataServiceClientSupplier = null;
+    if (options.getUseMetadataWsCalls() && !options.getTestMode()) {
+      metadataServiceClientSupplier = MetadataServiceClientFactory.createSupplier(config);
+    }
+    return DefaultValuesTransform.builder()
+        .clientSupplier(metadataServiceClientSupplier)
+        .datasetId(options.getDatasetId())
+        .create()
+        .interpret();
+  }
+
+  public ExtensionFilterTransform createExtensionFilterTransform() {
+    return ExtensionFilterTransform.create(config.getExtensionsAllowedForVerbatimSet());
+  }
+
+  public IdentifierTransform createIdentifierTransform() {
+    return IdentifierTransform.builder().datasetKey(options.getDatasetId()).create();
+  }
+
+  public MultimediaTransform createMultimediaTransform() {
+    return MultimediaTransform.builder().orderings(dateComponentOrdering).create();
+  }
+
+  public AudubonTransform createAudubonTransform() {
+    return AudubonTransform.builder().orderings(dateComponentOrdering).create();
+  }
+
+  public ImageTransform createImageTransform() {
+    return ImageTransform.builder().orderings(dateComponentOrdering).create();
+  }
+
+  public UniqueIdTransform createUniqueIdTransform() {
+    return UniqueIdTransform.create();
+  }
+}

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/util/ElasticsearchTools.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/util/ElasticsearchTools.java
@@ -1,0 +1,86 @@
+package au.org.ala.pipelines.util;
+
+import static org.gbif.pipelines.estools.service.EsService.swapIndexes;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gbif.pipelines.common.beam.options.EsIndexingPipelineOptions;
+import org.gbif.pipelines.estools.client.EsClient;
+import org.gbif.pipelines.estools.client.EsConfig;
+import org.gbif.pipelines.estools.model.IndexParams;
+import org.gbif.pipelines.estools.service.EsConstants.Field;
+import org.gbif.pipelines.estools.service.EsConstants.Indexing;
+import org.gbif.pipelines.estools.service.EsService;
+
+/** Utilities for creating elastic search indices and aliases. */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ElasticsearchTools {
+
+  /** Connects to Elasticsearch instance and creates an index, if index doesn't exist */
+  public static void createIndexAndAliasForDefault(EsIndexingPipelineOptions options) {
+    EsConfig config =
+        EsConfig.from(options.getEsUsername(), options.getEsPassword(), options.getEsHosts());
+    IndexParams params = createIndexParams(options);
+
+    log.info("Creating index from params: {}", params);
+    try (EsClient esClient = EsClient.from(config)) {
+      if (!EsService.existsIndex(esClient, params.getIndexName())) {
+        EsService.createIndex(esClient, params);
+        addIndexAliasForDefault(esClient, options);
+      }
+    }
+  }
+
+  /** Add alias to index if the index is default/regular (it will contain many datasets) */
+  private static void addIndexAliasForDefault(
+      EsClient esClient, EsIndexingPipelineOptions options) {
+    String index = options.getEsIndexName();
+    Objects.requireNonNull(index, "index are required");
+    if (!index.startsWith(options.getDatasetId())) {
+      Set<String> aliases = new HashSet<>(Arrays.asList(options.getEsAlias()));
+
+      Objects.requireNonNull(aliases, "aliases are required");
+
+      Set<String> validAliases =
+          aliases.stream()
+              .filter(alias -> !Strings.isNullOrEmpty(alias))
+              .collect(Collectors.toSet());
+      Preconditions.checkArgument(!validAliases.isEmpty(), "aliases are required");
+
+      swapIndexes(esClient, validAliases, Collections.singleton(index), Collections.emptySet());
+    }
+  }
+
+  private static IndexParams createIndexParams(EsIndexingPipelineOptions options) {
+    Path mappingsPath = Paths.get(options.getEsSchemaPath());
+
+    boolean independentIndex = options.getEsIndexName().startsWith(options.getDatasetId());
+
+    Map<String, String> settings = new HashMap<>(5);
+    settings.put(
+        Field.INDEX_REFRESH_INTERVAL,
+        independentIndex ? Indexing.REFRESH_INTERVAL : options.getIndexRefreshInterval());
+    settings.put(Field.INDEX_NUMBER_SHARDS, options.getIndexNumberShards().toString());
+    settings.put(
+        Field.INDEX_NUMBER_REPLICAS,
+        independentIndex ? Indexing.NUMBER_REPLICAS : options.getIndexNumberReplicas().toString());
+    settings.put(Field.INDEX_ANALYSIS, Indexing.ANALYSIS);
+    settings.put(Field.INDEX_MAX_RESULT_WINDOW, options.getIndexMaxResultWindow().toString());
+
+    return IndexParams.builder()
+        .indexName(options.getEsIndexName())
+        .datasetKey(options.getDatasetId())
+        .attempt(options.getAttempt())
+        .pathMappings(mappingsPath)
+        .settings(settings)
+        .build();
+  }
+}

--- a/livingatlas/pipelines/src/main/resources/es-event-schema.json
+++ b/livingatlas/pipelines/src/main/resources/es-event-schema.json
@@ -1,0 +1,1329 @@
+{
+  "dynamic_templates": [
+    {
+      "verbatim": {
+        "path_match": "verbatim.*",
+        "mapping": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer",
+          "copy_to": "all"
+        }
+      }
+    }
+  ],
+  "properties": {
+
+    "all": {"type": "text", "index": true, "store":false},
+
+    "id": {"type": "keyword", "normalizer": "lowercase_normalizer"},
+    "type": {"type": "keyword", "normalizer": "lowercase_normalizer"},
+    "crawlId": {"type": "integer"},
+    "internalId": {"type": "keyword"},
+    "lastCrawled": {"type": "date"},
+    "created": {"type": "date"},
+    "uniqueKey": {"type": "keyword"},
+    "firstLoaded": {"type": "date"},
+
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "datasetKey": {"type": "keyword", "normalizer": "lowercase_normalizer"},
+        "datasetTitle": {"type": "keyword", "normalizer": "lowercase_normalizer", "copy_to": "all"},
+        "license": {"type": "keyword", "copy_to": "all"}
+      }
+    },
+
+    "event": {
+      "type": "object",
+      "properties": {
+        "references": {"type":"text", "copy_to": "all"},
+        "samplingProtocolJoined": {"type": "keyword", "normalizer": "lowercase_normalizer"},
+        "samplingProtocol":  {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword",  "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "eventId": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword", "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "parentEventId": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword", "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "parentEventIds": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword", "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "institutionCode":  {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword", "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "locality":  {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword",  "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "datasetID": {"type": "keyword", "normalizer": "lowercase_normalizer", "copy_to": "all"},
+        "datasetName": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword", "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+
+        "sampleSizeUnit": {"type": "keyword", "copy_to": "all"},
+        "sampleSizeValue": {"type": "double"},
+
+        "continent": {"type":"keyword", "copy_to": "all"},
+        "waterBody": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword",  "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "countryCode": {"type":"keyword", "copy_to": "all"},
+        "country": {"type":"text", "copy_to": "all"},
+        "stateProvince": {
+          "type": "text",
+          "fields": {
+            "suggest": {"type": "completion", "analyzer": "lowercase_analyzer", "preserve_separators": true, "preserve_position_increments": true, "max_input_length": 50},
+            "keyword": {"type": "keyword",  "normalizer": "lowercase_normalizer", "ignore_above": 1024},
+            "verbatim": {"type": "keyword", "ignore_above": 1024}
+          }
+        },
+        "minimumElevationInMeters": {"type": "double"},
+        "maximumElevationInMeters": {"type": "double"},
+        "minimumDepthInMeters": {"type": "double"},
+        "maximumDepthInMeters": {"type": "double"},
+        "minimumDistanceAboveSurfaceInMeters": {"type": "double"},
+        "maximumDistanceAboveSurfaceInMeters": {"type": "double"},
+        "coordinateUncertaintyInMeters": {"type": "double"},
+        "coordinatePrecision": {"type": "double"},
+        "coordinates": {"type": "geo_point"},
+        "scoordinates": {"type": "geo_shape"},
+        "decimalLatitude": {"type": "double"},
+        "decimalLongitude": {"type": "double"},
+        "verbatimElevation": {"type": "keyword"},
+        "verbatimDepth": {"type": "keyword"},
+        "hasCoordinate": {"type": "boolean"},
+        "repatriated": {"type": "boolean"},
+        "hasGeospatialIssue": {"type": "boolean"},
+        "footprintWKT": {"type": "text"},
+        "gadm": {
+          "type": "object",
+          "properties": {
+            "gids": {"type": "keyword"},
+            "level0Gid": {"type": "keyword"},
+            "level1Gid": {"type": "keyword"},
+            "level2Gid": {"type": "keyword"},
+            "level3Gid": {"type": "keyword"},
+            "level0Name": {"type": "keyword", "copy_to": "all"},
+            "level1Name": {"type": "keyword", "copy_to": "all"},
+            "level2Name": {"type": "keyword", "copy_to": "all"},
+            "level3Name": {"type": "keyword", "copy_to": "all"}
+          }
+        },
+
+        "year": {"type": "short"},
+        "month": {"type": "short"},
+        "day": {"type": "short"},
+        "eventDate": {"type": "date_range", "format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX||yyyy-MM-dd'T'HH:mm:ssXXX||yyyy-MM-dd'T'HH:mmXXX||yyyy-MM-dd'T'HH:mm:ss.SSS||yyyy-MM-dd'T'HH:mm:ss||yyyy-MM-dd'T'HH:mm||yyyy-MM-dd||yyyy-MM||yyyy"},
+        "eventDateSingle": {"type": "date"},
+        "startDayOfYear": {"type": "short"},
+        "endDayOfYear": {"type": "short"},
+        "modified": {"type": "date"},
+        "issues": {"type": "keyword"},
+        "notIssues": {"type": "keyword"},
+        "extensions": {"type": "keyword"},
+
+        "mediaTypes": {"type": "keyword", "copy_to": "all"},
+        "mediaLicenses": {"type": "keyword", "copy_to": "all"},
+        "multimediaItems": {"type": "nested", "enabled": false,
+          "properties": {
+            "license": {"type": "keyword"}
+          }
+        },
+        "gbifClassification": {
+          "type": "object",
+          "properties": {
+            "acceptedUsage": {
+              "properties": {
+                "key": {"type": "long" },
+                "name": {"type": "text", "index":  false, "boost": 100.0, "copy_to": "all"},
+                "rank": {"type": "keyword", "index":  false}
+              }
+            },
+            "classification": {
+              "properties": {
+                "key": {"type": "long"},
+                "name": {"type": "text", "boost": 90.0, "copy_to": "all"},
+                "rank": {"type": "keyword"},
+                "synonym": {"type": "boolean"}
+              }
+            },
+            "classificationPath": {"type": "keyword"},
+            "diagnostics": {
+              "properties": {
+                "matchType": {"type": "keyword"},
+                "note": {"type": "text","index":  false},
+                "status": {"type": "keyword"}
+              }
+            },
+            "kingdom": {"type": "text"},
+            "kingdomKey": {"type": "long"},
+            "phylum": {"type": "text"},
+            "phylumKey": {"type": "long"},
+            "class": {"type": "text"},
+            "classKey": {"type": "long"},
+            "order": {"type": "text"},
+            "orderKey": {"type": "long"},
+            "family": {"type": "text"},
+            "familyKey": {"type": "long"},
+            "genus": {"type": "text"},
+            "genusKey": {"type": "long"},
+            "species": {"type": "text"},
+            "speciesKey": {"type": "long"},
+            "synonym": {"type": "boolean"},
+            "taxonID": {"type": "keyword"},
+            "taxonKey": {"type": "long"},
+            "usage": {
+              "properties": {
+                "key": {"type": "long"},
+                "name": {"type": "keyword", "boost": 100.0, "copy_to": "all", "normalizer": "lowercase_normalizer"},
+                "rank": {"type": "keyword"}
+              }
+            },
+            "usageParsedName": {
+              "properties": {
+                "abbreviated": {"type": "boolean", "index":  false},
+                "autonym": {"type": "boolean", "index":  false},
+                "basionymAuthorship": {
+                  "enabled": false,
+                  "properties": {
+                    "authors": {"type": "text"},
+                    "empty": {"type": "boolean"},
+                    "exAuthors": {"type": "text"},
+                    "year": {"type": "keyword"}
+                  }
+                },
+                "binomial": {"type": "boolean", "index":  false},
+                "candidatus": {"type": "boolean", "index":  false},
+                "code": {"type": "text", "index":  false},
+                "combinationAuthorship": {
+                  "enabled": false,
+                  "properties": {
+                    "authors": {"type": "text"},
+                    "empty": {"type": "boolean"},
+                    "exAuthors": {"type": "text"},
+                    "year": {"type": "keyword"}
+                  }
+                },
+                "doubtful": {"type": "boolean", "index":  false},
+                "genericName": {"type": "text"},
+                "genus": {"type": "text", "index":  false},
+                "incomplete": {"type": "boolean", "index":  false},
+                "indetermined": {"type": "boolean", "index":  false},
+                "infraspecificEpithet": {"type": "text"},
+                "notho": {"type": "keyword", "index":  false},
+                "rank": {"type": "keyword", "index":  false},
+                "specificEpithet": {"type": "text"},
+                "state": {"type": "keyword", "index":  false},
+                "terminalEpithet": {"type": "text", "index":  false},
+                "trinomial": {"type": "boolean", "index":  false},
+                "type": {"type": "keyword", "index":  false},
+                "uninomial": {"type": "text", "index":  false}
+              }
+            },
+            "verbatimScientificName": {"type": "keyword", "boost": 100.0, "copy_to": "all", "normalizer": "lowercase_normalizer"},
+            "iucnRedListCategoryCode": {"type": "keyword"}
+          }
+        },
+        "derivedMetadata": {
+          "type": "object",
+          "properties": {
+            "wktConvexHull": {
+              "type": "geo_shape"
+            },
+            "temporalCoverage": {
+              "type": "date_range", "format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX||yyyy-MM-dd'T'HH:mm:ssXXX||yyyy-MM-dd'T'HH:mmXXX||yyyy-MM-dd'T'HH:mm:ss.SSS||yyyy-MM-dd'T'HH:mm:ss||yyyy-MM-dd'T'HH:mm||yyyy-MM-dd||yyyy-MM||yyyy"
+            },
+            "taxonomicCoverage": {
+              "type": "object",
+              "properties": {
+                "acceptedUsage": {
+                  "properties": {
+                    "key": {"type": "long" },
+                    "name": {"type": "text", "index":  false, "boost": 100.0, "copy_to": "all"},
+                    "rank": {"type": "keyword", "index":  false}
+                  }
+                },
+                "classification": {
+                  "properties": {
+                    "key": {"type": "long"},
+                    "name": {"type": "text", "boost": 90.0, "copy_to": "all"},
+                    "rank": {"type": "keyword"},
+                    "synonym": {"type": "boolean"}
+                  }
+                },
+                "classificationPath": {"type": "keyword"},
+                "diagnostics": {
+                  "properties": {
+                    "matchType": {"type": "keyword"},
+                    "note": {"type": "text","index":  false},
+                    "status": {"type": "keyword"}
+                  }
+                },
+                "kingdom": {"type": "text"},
+                "kingdomKey": {"type": "long"},
+                "phylum": {"type": "text"},
+                "phylumKey": {"type": "long"},
+                "class": {"type": "text"},
+                "classKey": {"type": "long"},
+                "order": {"type": "text"},
+                "orderKey": {"type": "long"},
+                "family": {"type": "text"},
+                "familyKey": {"type": "long"},
+                "genus": {"type": "text"},
+                "genusKey": {"type": "long"},
+                "species": {"type": "text"},
+                "speciesKey": {"type": "long"},
+                "synonym": {"type": "boolean"},
+                "taxonID": {"type": "keyword"},
+                "taxonKey": {"type": "long"},
+                "usage": {
+                  "properties": {
+                    "key": {"type": "long"},
+                    "name": {"type": "keyword", "boost": 100.0, "copy_to": "all", "normalizer": "lowercase_normalizer"},
+                    "rank": {"type": "keyword"}
+                  }
+                },
+                "usageParsedName": {
+                  "properties": {
+                    "abbreviated": {"type": "boolean", "index":  false},
+                    "autonym": {"type": "boolean", "index":  false},
+                    "basionymAuthorship": {
+                      "enabled": false,
+                      "properties": {
+                        "authors": {"type": "text"},
+                        "empty": {"type": "boolean"},
+                        "exAuthors": {"type": "text"},
+                        "year": {"type": "keyword"}
+                      }
+                    },
+                    "binomial": {"type": "boolean", "index":  false},
+                    "candidatus": {"type": "boolean", "index":  false},
+                    "code": {"type": "text", "index":  false},
+                    "combinationAuthorship": {
+                      "enabled": false,
+                      "properties": {
+                        "authors": {"type": "text"},
+                        "empty": {"type": "boolean"},
+                        "exAuthors": {"type": "text"},
+                        "year": {"type": "keyword"}
+                      }
+                    },
+                    "doubtful": {"type": "boolean", "index":  false},
+                    "genericName": {"type": "text"},
+                    "genus": {"type": "text", "index":  false},
+                    "incomplete": {"type": "boolean", "index":  false},
+                    "indetermined": {"type": "boolean", "index":  false},
+                    "infraspecificEpithet": {"type": "text"},
+                    "notho": {"type": "keyword", "index":  false},
+                    "rank": {"type": "keyword", "index":  false},
+                    "specificEpithet": {"type": "text"},
+                    "state": {"type": "keyword", "index":  false},
+                    "terminalEpithet": {"type": "text", "index":  false},
+                    "trinomial": {"type": "boolean", "index":  false},
+                    "type": {"type": "keyword", "index":  false},
+                    "uninomial": {"type": "text", "index":  false}
+                  }
+                },
+                "verbatimScientificName": {"type": "keyword", "boost": 100.0, "copy_to": "all", "normalizer": "lowercase_normalizer"},
+                "iucnRedListCategoryCode": {"type": "keyword"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "occurrence": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "lastCrawled": {
+          "type": "date"
+        },
+        "created": {
+          "type": "date"
+        },
+        "datasetKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "crawlId": {
+          "type": "integer"
+        },
+        "datasetTitle": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer",
+          "copy_to": "all"
+        },
+        "installationKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "hostingOrganizationKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "endorsingNodeKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "publisherTitle": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer",
+          "copy_to": "all"
+        },
+        "license": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "institutionKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "collectionKey": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "isClustered": {
+          "type": "boolean"
+        },
+        "basisOfRecord": {
+          "type": "keyword"
+        },
+        "sex": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "lifeStage": {
+          "type": "object",
+          "properties": {
+            "concept": {
+              "type": "keyword"
+            },
+            "lineage": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "establishmentMeans": {
+          "type": "object",
+          "properties": {
+            "concept": {
+              "type": "keyword"
+            },
+            "lineage": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "pathway": {
+          "type": "object",
+          "properties": {
+            "concept": {
+              "type": "keyword"
+            },
+            "lineage": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "degreeOfEstablishment": {
+          "type": "object",
+          "properties": {
+            "concept": {
+              "type": "keyword"
+            },
+            "lineage": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "individualCount": {
+          "type": "integer"
+        },
+        "typeStatus": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "typifiedName": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer",
+          "copy_to": "all"
+        },
+        "references": {
+          "type": "text",
+          "copy_to": "all"
+        },
+        "preparations": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "preparationsJoined": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "recordedByIds": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "value": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "identifiedByIds": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "value": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "recordedBy": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "recordedByJoined": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "identifiedBy": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "identifiedByJoined": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "recordNumber": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "organismId": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "samplingProtocol": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "samplingProtocolJoined": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "eventId": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "parentEventId": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "institutionCode": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "collectionCode": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "catalogNumber": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "locality": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "occurrenceId": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "datasetID": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer",
+          "copy_to": "all"
+        },
+        "datasetName": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "otherCatalogNumbers": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "otherCatalogNumbersJoined": {
+          "type": "keyword",
+          "normalizer": "lowercase_normalizer"
+        },
+        "occurrenceStatus": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "organismQuantity": {
+          "type": "double"
+        },
+        "organismQuantityType": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "sampleSizeUnit": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "sampleSizeValue": {
+          "type": "double"
+        },
+        "relativeOrganismQuantity": {
+          "type": "double"
+        },
+        "continent": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "waterBody": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "countryCode": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "country": {
+          "type": "text",
+          "copy_to": "all"
+        },
+        "stateProvince": {
+          "type": "text",
+          "fields": {
+            "suggest": {
+              "type": "completion",
+              "analyzer": "lowercase_analyzer",
+              "preserve_separators": true,
+              "preserve_position_increments": true,
+              "max_input_length": 50
+            },
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase_normalizer",
+              "ignore_above": 1024
+            },
+            "verbatim": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "minimumElevationInMeters": {
+          "type": "double"
+        },
+        "maximumElevationInMeters": {
+          "type": "double"
+        },
+        "elevation": {
+          "type": "double"
+        },
+        "elevationAccuracy": {
+          "type": "double"
+        },
+        "minimumDepthInMeters": {
+          "type": "double"
+        },
+        "maximumDepthInMeters": {
+          "type": "double"
+        },
+        "depth": {
+          "type": "double"
+        },
+        "depthAccuracy": {
+          "type": "double"
+        },
+        "minimumDistanceAboveSurfaceInMeters": {
+          "type": "double"
+        },
+        "maximumDistanceAboveSurfaceInMeters": {
+          "type": "double"
+        },
+        "coordinateUncertaintyInMeters": {
+          "type": "double"
+        },
+        "coordinatePrecision": {
+          "type": "double"
+        },
+        "coordinates": {
+          "type": "geo_point"
+        },
+        "scoordinates": {
+          "type": "geo_shape"
+        },
+        "decimalLatitude": {
+          "type": "double"
+        },
+        "decimalLongitude": {
+          "type": "double"
+        },
+        "gadm": {
+          "type": "object",
+          "properties": {
+            "gids": {
+              "type": "keyword"
+            },
+            "level0Gid": {
+              "type": "keyword"
+            },
+            "level1Gid": {
+              "type": "keyword"
+            },
+            "level2Gid": {
+              "type": "keyword"
+            },
+            "level3Gid": {
+              "type": "keyword"
+            },
+            "level0Name": {
+              "type": "keyword",
+              "copy_to": "all"
+            },
+            "level1Name": {
+              "type": "keyword",
+              "copy_to": "all"
+            },
+            "level2Name": {
+              "type": "keyword",
+              "copy_to": "all"
+            },
+            "level3Name": {
+              "type": "keyword",
+              "copy_to": "all"
+            }
+          }
+        },
+        "year": {
+          "type": "short"
+        },
+        "month": {
+          "type": "short"
+        },
+        "day": {
+          "type": "short"
+        },
+        "eventDate": {
+          "type": "date_range",
+          "format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX||yyyy-MM-dd'T'HH:mm:ssXXX||yyyy-MM-dd'T'HH:mmXXX||yyyy-MM-dd'T'HH:mm:ss.SSS||yyyy-MM-dd'T'HH:mm:ss||yyyy-MM-dd'T'HH:mm||yyyy-MM-dd||yyyy-MM||yyyy"
+        },
+        "startDayOfYear": {
+          "type": "short"
+        },
+        "endDayOfYear": {
+          "type": "short"
+        },
+        "modified": {
+          "type": "date"
+        },
+        "dateIdentified": {
+          "type": "date"
+        },
+        "eventDateSingle": {
+          "type": "date"
+        },
+        "issues": {
+          "type": "keyword"
+        },
+        "notIssues": {
+          "type": "keyword"
+        },
+        "extensions": {
+          "type": "keyword"
+        },
+        "gbifClassification": {
+          "properties": {
+            "acceptedUsage": {
+              "properties": {
+                "key": {
+                  "type": "long"
+                },
+                "name": {
+                  "type": "text",
+                  "index": false,
+                  "boost": 100.0,
+                  "copy_to": "all"
+                },
+                "rank": {
+                  "type": "keyword",
+                  "index": false
+                }
+              }
+            },
+            "classification": {
+              "properties": {
+                "key": {
+                  "type": "long"
+                },
+                "name": {
+                  "type": "text",
+                  "boost": 90.0,
+                  "copy_to": "all"
+                },
+                "rank": {
+                  "type": "keyword"
+                },
+                "synonym": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "classificationPath": {
+              "type": "keyword"
+            },
+            "diagnostics": {
+              "properties": {
+                "matchType": {
+                  "type": "keyword"
+                },
+                "note": {
+                  "type": "text",
+                  "index": false
+                },
+                "status": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "kingdom": {
+              "type": "text"
+            },
+            "kingdomKey": {
+              "type": "text"
+            },
+            "phylum": {
+              "type": "text"
+            },
+            "phylumKey": {
+              "type": "text"
+            },
+            "class": {
+              "type": "text"
+            },
+            "classKey": {
+              "type": "text"
+            },
+            "order": {
+              "type": "text"
+            },
+            "orderKey": {
+              "type": "text"
+            },
+            "family": {
+              "type": "text"
+            },
+            "familyKey": {
+              "type": "text"
+            },
+            "genus": {
+              "type": "text"
+            },
+            "genusKey": {
+              "type": "text"
+            },
+            "species": {
+              "type": "text"
+            },
+            "speciesKey": {
+              "type": "text"
+            },
+            "synonym": {
+              "type": "boolean"
+            },
+            "taxonID": {
+              "type": "keyword"
+            },
+            "taxonKey": {
+              "type": "text"
+            },
+            "usage": {
+              "properties": {
+                "key": {
+                  "type": "text"
+                },
+                "name": {
+                  "type": "keyword",
+                  "boost": 100.0,
+                  "copy_to": "all",
+                  "normalizer": "lowercase_normalizer"
+                },
+                "rank": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "usageParsedName": {
+              "properties": {
+                "abbreviated": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "autonym": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "basionymAuthorship": {
+                  "enabled": false,
+                  "properties": {
+                    "authors": {
+                      "type": "text"
+                    },
+                    "empty": {
+                      "type": "boolean"
+                    },
+                    "exAuthors": {
+                      "type": "text"
+                    },
+                    "year": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "binomial": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "candidatus": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "code": {
+                  "type": "text",
+                  "index": false
+                },
+                "combinationAuthorship": {
+                  "enabled": false,
+                  "properties": {
+                    "authors": {
+                      "type": "text"
+                    },
+                    "empty": {
+                      "type": "boolean"
+                    },
+                    "exAuthors": {
+                      "type": "text"
+                    },
+                    "year": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "doubtful": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "genericName": {
+                  "type": "text"
+                },
+                "genus": {
+                  "type": "text",
+                  "index": false
+                },
+                "incomplete": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "indetermined": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "infraspecificEpithet": {
+                  "type": "text"
+                },
+                "notho": {
+                  "type": "keyword",
+                  "index": false
+                },
+                "rank": {
+                  "type": "keyword",
+                  "index": false
+                },
+                "specificEpithet": {
+                  "type": "text"
+                },
+                "state": {
+                  "type": "keyword",
+                  "index": false
+                },
+                "terminalEpithet": {
+                  "type": "text",
+                  "index": false
+                },
+                "trinomial": {
+                  "type": "boolean",
+                  "index": false
+                },
+                "type": {
+                  "type": "keyword",
+                  "index": false
+                },
+                "uninomial": {
+                  "type": "text",
+                  "index": false
+                }
+              }
+            },
+            "verbatimScientificName": {
+              "type": "keyword",
+              "boost": 100.0,
+              "copy_to": "all",
+              "normalizer": "lowercase_normalizer"
+            },
+            "iucnRedListCategoryCode": {
+              "type": "keyword"
+            }
+          }
+        },
+        "mediaTypes": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "mediaLicenses": {
+          "type": "keyword",
+          "copy_to": "all"
+        },
+        "multimediaItems": {
+          "type": "nested",
+          "enabled": false,
+          "properties": {
+            "license": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "verbatim": {"type": "object", "enabled": false},
+    "joinRecord": { "type": "join", "relations": { "event": "occurrence" }, "eager_global_ordinals": false}
+  }
+}

--- a/livingatlas/pipelines/src/test/java/au/org/ala/outlier/DistributionOutlierTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/outlier/DistributionOutlierTest.java
@@ -13,7 +13,7 @@ public class DistributionOutlierTest {
   // String spatial_url = "http://devt.ala.org.au:8080/ws/";
   String spatial_url = "https://spatial-test.ala.org.au/ws/";
   String lsidGreyNurseShark =
-      "urn:lsid:biodiversity.org.au:afd.taxon:0c3e2403-05c4-4a43-8019-30e6d657a283";
+      "https://biodiversity.org.au/afd/taxa/0c3e2403-05c4-4a43-8019-30e6d657a283";
 
   @Test
   public void getMultiLayers() {
@@ -69,8 +69,7 @@ public class DistributionOutlierTest {
 
       Map<String, Double> results =
           impl.outliers(
-              "urn:lsid:biodiversity.org.au:afd.taxon:0c3e2403-05c4-4a43-8019-30e6d657a283",
-              points);
+              "https://biodiversity.org.au/afd/taxa/0c3e2403-05c4-4a43-8019-30e6d657a283", points);
       assertSame(1, results.size());
     } catch (Exception e) {
       e.printStackTrace();

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreTsvConverterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/CoreTsvConverterTest.java
@@ -783,14 +783,6 @@ public class CoreTsvConverterTest {
             .setVernacularName("atxr_VernacularName")
             .setSpeciesGroup(Collections.singletonList("atxr_SpeciesGroup"))
             .setSpeciesSubgroup(Collections.singletonList("atxr_SpeciesSubgroup"))
-            .setDiagnostics(
-                Diagnostic.newBuilder()
-                    .setConfidence(5555)
-                    .setStatus(Status.ACCEPTED)
-                    .setNote("atxr_Diagnostic_Note")
-                    .setMatchType(MatchType.EXACT)
-                    .setLineage(Collections.singletonList("atxr_Diagnostic_Lineage"))
-                    .build())
             .build();
 
     ALAAttributionRecord aar =

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/MultimediaCsvConverterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/converters/MultimediaCsvConverterTest.java
@@ -294,14 +294,6 @@ public class MultimediaCsvConverterTest {
             .setVernacularName("atxr_VernacularName")
             .setSpeciesGroup(Collections.singletonList("atxr_SpeciesGroup"))
             .setSpeciesSubgroup(Collections.singletonList("atxr_SpeciesSubgroup"))
-            .setDiagnostics(
-                Diagnostic.newBuilder()
-                    .setConfidence(5555)
-                    .setStatus(Status.ACCEPTED)
-                    .setNote("atxr_Diagnostic_Note")
-                    .setMatchType(MatchType.EXACT)
-                    .setLineage(Collections.singletonList("atxr_Diagnostic_Lineage"))
-                    .build())
             .build();
 
     ALAAttributionRecord aar =

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -82,6 +82,7 @@ dwca-avro --> interpret --> validate --> uuid --> sds --> image-load ... │
 -  'copy' downloads Dwc-A from collectory and copy it to local fs and optionally to hdfs (and an exclude list for 'all')
 -  'dwca-avro' reads a Dwc-A and converts it to an verbatim.avro file;
 -  'interpret' reads verbatim.avro, interprets it and writes the interpreted data and the issues to Avro files;
+-  'interpret-event' reads verbatim.avro, interprets it and writes the interpreted data and the issues to Avro files;
 -  'validate' validates the identifiers for a dataset, checking for duplicate and empty keys;
 -  'uuid' mints UUID on new records and rematches to existing UUIDs for records loaded before;
 -  'sds' runs the sensitive data checks;
@@ -93,6 +94,7 @@ dwca-avro --> interpret --> validate --> uuid --> sds --> image-load ... │
 -  'jackknife' adds an aggregated jackknife AVRO for all datasets. Requires samping-avro. After running a full 'index' is required.
 -  'solr' reads index records in AVRO and submits them to SOLR;
 -  'solr-schema' sync schema
+-  'elastic-event' reads index records in AVRO and submits them to ElasticSearch;
 -  'archive-list' dumps out a list of archives that can be ingested to '/tmp/dataset-archive-list.csv';
 -  'dataset-list' dumps out a list of datasets that have been ingested to '/tmp/dataset-counts.csv';
 -  'validation-report' dumps out a CSV list of datasets ready to be indexed to '/tmp/validation-report.csv';
@@ -107,6 +109,7 @@ Usage:
   $CMD [options] copy          (<dr>...|all) [--hdfs] [--exclude=<exc>]
   $CMD [options] dwca-avro     (<dr>...|all)
   $CMD [options] interpret     (<dr>...|all)         $WHEREL
+  $CMD [options] interpret-event     (<dr>...|all)         $WHERE
   $CMD [options] validate      (<dr>...|all)         $WHERE
   $CMD [options] uuid          (<dr>...|all)         $WHERE
   $CMD [options] sds           (<dr>...|all)         $WHEREL
@@ -118,6 +121,7 @@ Usage:
   $CMD [options] jackknife     (all)                 $WHERE
   $CMD [options] outlier       (<dr>...|all)         $WHERE
   $CMD [options] solr          (<dr>...|all)         $WHERE
+  $CMD [options] elastic-event     (<dr>...|all)         $WHERE
   $CMD [options] solr-schema   (<dr>...|all)         $WHERE
   $CMD [options] archive-list
   $CMD [options] dataset-list
@@ -453,7 +457,6 @@ function dwca-avro () {
           -Djava.io.tmpdir=$DWCA_TMP \
           -cp $LOCAL_PIPELINES_JAR $CLASS \
           --datasetId=$dr \
-          --deleteLockFileOnExit=true \
           --config=$config $ARGS \
           --experiments=use_deprecated_read
       logStepEnd "DWCA-AVRO conversion" $dr local $SECONDS
@@ -471,7 +474,6 @@ function dwca-avro () {
               -cp $LOCAL_PIPELINES_JAR $CLASS \
               --datasetId=$dr \
               --inputPath=$inputPath \
-              --deleteLockFileOnExit=false \
               --config=$config $ARGS
 
       done < /tmp/dataset-archive-list.csv
@@ -550,6 +552,46 @@ function interpret () {
     spark-cluster-pipeline $ltype $SH_ARGS $CLASS $dr "interpret $dr"
 
     logStepEnd "Interpretation" $dr $ltype $SECONDS
+}
+
+function interpret-event () {
+    local dr="$1" ltype="$2"
+
+    SECONDS=0
+    logStepStart "EventInterpretation" $dr
+
+    SH_ARGS=interpret-sh-args.local
+    CLASS=au.org.ala.pipelines.beam.ALAVerbatimToEventPipeline
+    java-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=interpret-sh-args.spark-embedded
+    CLASS=au.org.ala.pipelines.beam.ALAVerbatimToEventPipeline
+    spark-embed-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=interpret-sh-args.spark-cluster
+    spark-cluster-pipeline $ltype $SH_ARGS $CLASS $dr "interpret-event $dr"
+
+    logStepEnd "EventInterpretation" $dr $ltype $SECONDS
+}
+
+function elastic-event () {
+    local dr="$1" ltype="$2"
+
+    SECONDS=0
+    logStepStart "ElasticEvent" $dr
+
+    SH_ARGS=elastic-sh-args.local
+    CLASS=au.org.ala.pipelines.beam.ALAEventToEsIndexPipeline
+    java-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=elastic-sh-args.spark-embedded
+    CLASS=au.org.ala.pipelines.beam.ALAEventToEsIndexPipeline
+    spark-embed-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=elastic-sh-args.spark-cluster
+    spark-cluster-pipeline $ltype $SH_ARGS $CLASS $dr "elastic-event $dr"
+
+    logStepEnd "EventElastic" $dr $ltype $SECONDS
 }
 
 function validate () {
@@ -904,6 +946,14 @@ function do_step() {
 
 if ($interpret || $do_all); then
     do_step interpret
+fi
+
+if ($interpret_event || $do_all); then
+    do_step interpret-event
+fi
+
+if ($elastic_event || $do_all); then
+    do_step elastic-event
 fi
 
 if ($validate || $do_all); then

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/converters/EventJsonConverter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/converters/EventJsonConverter.java
@@ -3,6 +3,8 @@ package org.gbif.pipelines.core.converters;
 import static org.gbif.pipelines.core.utils.ModelUtils.extractOptValue;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.gbif.dwc.terms.DwcTerm;
@@ -144,6 +146,15 @@ public class EventJsonConverter {
     extractOptValue(verbatim, DwcTerm.institutionCode).ifPresent(builder::setInstitutionCode);
     extractOptValue(verbatim, DwcTerm.verbatimDepth).ifPresent(builder::setVerbatimDepth);
     extractOptValue(verbatim, DwcTerm.verbatimElevation).ifPresent(builder::setVerbatimElevation);
+
+    // set occurrence count
+    Integer occurrenceCount =
+        Optional.of(verbatim.getExtensions())
+            .map(exts -> exts.get(DwcTerm.Occurrence.qualifiedName()))
+            .map(List::size)
+            .orElse(0);
+
+    builder.setOccurrenceCount(occurrenceCount);
   }
 
   private void mapIssues(EventJsonRecord.Builder builder) {

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/converters/JsonConverter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/converters/JsonConverter.java
@@ -104,11 +104,11 @@ public class JsonConverter {
     return Optional.ofNullable(epoch).map(DATE_FN::apply).map(LocalDateTime::toString);
   }
 
-  protected static List<String> convertFieldAll(ExtendedRecord extendedRecord) {
+  public static List<String> convertFieldAll(ExtendedRecord extendedRecord) {
     return convertFieldAll(extendedRecord, true);
   }
 
-  protected static List<String> convertFieldAll(
+  public static List<String> convertFieldAll(
       ExtendedRecord extendedRecord, boolean includeExtensions) {
     Set<String> result = new HashSet<>();
 
@@ -136,7 +136,7 @@ public class JsonConverter {
         .collect(Collectors.toList());
   }
 
-  protected static List<String> convertExtensions(ExtendedRecord extendedRecord) {
+  public static List<String> convertExtensions(ExtendedRecord extendedRecord) {
     return extendedRecord.getExtensions().entrySet().stream()
         .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
         .map(Entry::getKey)
@@ -144,7 +144,7 @@ public class JsonConverter {
         .collect(Collectors.toList());
   }
 
-  protected static VerbatimRecord convertVerbatimRecord(ExtendedRecord extendedRecord) {
+  public static VerbatimRecord convertVerbatimRecord(ExtendedRecord extendedRecord) {
     return convertVerbatimRecord(extendedRecord, Collections.emptyList());
   }
 
@@ -157,7 +157,7 @@ public class JsonConverter {
         .build();
   }
 
-  protected static VerbatimRecord convertVerbatimEventRecord(ExtendedRecord extendedRecord) {
+  public static VerbatimRecord convertVerbatimEventRecord(ExtendedRecord extendedRecord) {
     return convertVerbatimRecord(extendedRecord, Collections.singletonList(OCCURRENCE_EXT));
   }
 
@@ -168,7 +168,7 @@ public class JsonConverter {
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
 
-  protected static Optional<String> convertToMultivalue(List<String> list) {
+  public static Optional<String> convertToMultivalue(List<String> list) {
     return list != null && !list.isEmpty()
         ? Optional.of(getEscapedText(String.join("|", list)))
         : Optional.empty();
@@ -178,20 +178,20 @@ public class JsonConverter {
     return list.stream().map(JsonConverter::getEscapedText).collect(Collectors.toList());
   }
 
-  protected static Optional<String> convertLicense(String license) {
+  public static Optional<String> convertLicense(String license) {
     return Optional.ofNullable(license)
         .filter(l -> !l.equals(License.UNSPECIFIED.name()))
         .filter(l -> !l.equals(License.UNSUPPORTED.name()));
   }
 
-  protected static List<AgentIdentifier> convertAgentList(
+  public static List<AgentIdentifier> convertAgentList(
       List<org.gbif.pipelines.io.avro.AgentIdentifier> list) {
     return list.stream()
         .map(x -> AgentIdentifier.newBuilder().setType(x.getType()).setValue(x.getValue()).build())
         .collect(Collectors.toList());
   }
 
-  protected static Optional<VocabularyConcept> convertVocabularyConcept(
+  public static Optional<VocabularyConcept> convertVocabularyConcept(
       org.gbif.pipelines.io.avro.VocabularyConcept concepts) {
     if (concepts == null) {
       return Optional.empty();

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/BasicInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/BasicInterpreter.java
@@ -304,4 +304,9 @@ public class BasicInterpreter {
   public static void interpretPreparations(ExtendedRecord er, BasicRecord br) {
     extractOptListValue(er, DwcTerm.preparations).ifPresent(br::setPreparations);
   }
+
+  /** Sets the coreId field. */
+  public static void setCoreId(ExtendedRecord er, BasicRecord br) {
+    Optional.ofNullable(er.getCoreId()).ifPresent(br::setCoreId);
+  }
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/CoreInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/CoreInterpreter.java
@@ -116,6 +116,13 @@ public class CoreInterpreter {
         VocabularyInterpreter.interpretVocabulary(
                 GbifTerm.eventType, parentValues.get(GbifTerm.eventType.name()), vocabularyService)
             .ifPresent(c -> parentBuilder.setEventType(c.getConcept()));
+
+        // allow the raw event type value through if not matched to vocab
+        // this is useful as vocab is a WIP
+        if (parentBuilder.getEventType() == null) {
+          parentBuilder.setEventType(parentValues.get(GbifTerm.eventType.name()));
+        }
+
         parentBuilder.setOrder(order++);
         parents.add(parentBuilder.build());
 

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/extension/MeasurementOrFactInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/extension/MeasurementOrFactInterpreter.java
@@ -1,6 +1,9 @@
 package org.gbif.pipelines.core.interpreters.extension;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.gbif.api.vocabulary.Extension;
@@ -34,6 +37,19 @@ public class MeasurementOrFactInterpreter {
           .map(DwcTerm.measurementMethod, MeasurementOrFact::setMeasurementMethod)
           .map(DwcTerm.measurementRemarks, MeasurementOrFact::setMeasurementRemarks);
 
+  private static final TargetHandler<MeasurementOrFact> EXTENDED_HANDLER =
+      ExtensionInterpretation.extension(Extension.EXTENDED_MEASUREMENT_OR_FACT)
+          .to(MeasurementOrFact::new)
+          .map(DwcTerm.measurementID, MeasurementOrFact::setMeasurementID)
+          .map(DwcTerm.measurementType, MeasurementOrFact::setMeasurementType)
+          .map(DwcTerm.measurementUnit, MeasurementOrFact::setMeasurementUnit)
+          .map(DwcTerm.measurementValue, MeasurementOrFact::setMeasurementValue)
+          .map(DwcTerm.measurementAccuracy, MeasurementOrFact::setMeasurementAccuracy)
+          .map(DwcTerm.measurementDeterminedBy, MeasurementOrFact::setMeasurementDeterminedBy)
+          .map(DwcTerm.measurementDeterminedDate, MeasurementOrFact::setMeasurementDeterminedDate)
+          .map(DwcTerm.measurementMethod, MeasurementOrFact::setMeasurementMethod)
+          .map(DwcTerm.measurementRemarks, MeasurementOrFact::setMeasurementRemarks);
+
   /**
    * Interprets measurements or facts of a {@link ExtendedRecord} and populates a {@link
    * MeasurementOrFactRecord} with the interpreted values.
@@ -43,8 +59,11 @@ public class MeasurementOrFactInterpreter {
     Objects.requireNonNull(mfr);
 
     Result<MeasurementOrFact> result = HANDLER.convert(er);
-
-    mfr.setMeasurementOrFactItems(result.getList());
+    Result<MeasurementOrFact> extendedResult = EXTENDED_HANDLER.convert(er);
+    mfr.setMeasurementOrFactItems(
+        Collections.unmodifiableList(
+            Stream.concat(result.getList().stream(), extendedResult.getList().stream())
+                .collect(Collectors.toList())));
     mfr.getIssues().setIssueList(result.getIssuesAsList());
   }
 }

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceJsonConverterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceJsonConverterTest.java
@@ -503,26 +503,30 @@ public class OccurrenceJsonConverterTest {
     assertEquals(expectedVerbatim, result.path("verbatim").toString());
 
     String expectedGbifClassification =
-        "{\"acceptedUsage\":{\"key\":11,\"name\":\"accepted usage\",\"rank\":\"SPECIES\"},\"classification\":"
-            + "[{\"key\":1,\"name\":\"KINGDOM\",\"rank\":\"KINGDOM\"},{\"key\":2,\"name\":\"PHYLUM\",\"rank\":\"PHYLUM\"},"
-            + "{\"key\":3,\"name\":\"CLASS\",\"rank\":\"CLASS\"},{\"key\":4,\"name\":\"ORDER\",\"rank\":\"ORDER\"},"
-            + "{\"key\":5,\"name\":\"FAMILY\",\"rank\":\"FAMILY\"},{\"key\":6,\"name\":\"GENUS\",\"rank\":\"GENUS\"},"
-            + "{\"key\":7,\"name\":\"SPECIES\",\"rank\":\"SPECIES\"}],\"classificationPath\":\"_1_2_3_4_5_6\",\"diagnostics\":"
-            + "{\"matchType\":\"EXACT\",\"note\":\"note\",\"status\":\"ACCEPTED\"},\"kingdom\":\"KINGDOM\","
-            + "\"kingdomKey\":\"1\",\"phylum\":\"PHYLUM\",\"phylumKey\":\"2\",\"classKey\":\"3\",\"order\":"
-            + "\"ORDER\",\"orderKey\":\"4\",\"family\":\"FAMILY\",\"familyKey\":\"5\",\"genus\":\"GENUS\",\"genusKey\":\"6\","
-            + "\"species\":\"SPECIES\",\"speciesKey\":\"7\",\"synonym\":true,\"taxonID\":\"taxonID\","
-            + "\"taxonKey\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"10\",\"11\"],"
-            + "\"usage\":{\"key\":10,\"name\":\"synonym\",\"rank\":\"SPECIES\"},\"usageParsedName\":{\"abbreviated\":false,"
-            + "\"autonym\":false,\"basionymAuthorship\":{\"authors\":[\"setBasionymAuthorship\"],\"exAuthors\""
-            + ":[\"setBasionymAuthorship\"],\"empty\":true,\"year\":\"2000\"},\"binomial\":false,\"candidatus\":"
-            + "false,\"code\":\"BACTERIAL\",\"combinationAuthorship\":{\"authors\":[\"setCombinationAuthorship\"],"
+        "{\"acceptedUsage\":{\"key\":11,\"guid\":null,\"name\":\"accepted usage\",\"rank\":\"SPECIES\"},"
+            + "\"classification\":[{\"key\":1,\"guid\":null,\"name\":\"KINGDOM\",\"rank\":\"KINGDOM\"},{\"key\":2,"
+            + "\"guid\":null,\"name\":\"PHYLUM\",\"rank\":\"PHYLUM\"},{\"key\":3,\"guid\":null,\"name\":\"CLASS\","
+            + "\"rank\":\"CLASS\"},{\"key\":4,\"guid\":null,\"name\":\"ORDER\",\"rank\":\"ORDER\"},{\"key\":5,"
+            + "\"guid\":null,\"name\":\"FAMILY\",\"rank\":\"FAMILY\"},{\"key\":6,\"guid\":null,\"name\":\"GENUS\","
+            + "\"rank\":\"GENUS\"},{\"key\":7,\"guid\":null,\"name\":\"SPECIES\",\"rank\":\"SPECIES\"}],"
+            + "\"classificationPath\":\"_1_2_3_4_5_6\",\"diagnostics\":{\"matchType\":\"EXACT\",\"note\":\"note\","
+            + "\"status\":\"ACCEPTED\"},\"kingdom\":\"KINGDOM\",\"kingdomKey\":\"1\",\"phylum\":\"PHYLUM\","
+            + "\"phylumKey\":\"2\",\"classKey\":\"3\",\"order\":\"ORDER\",\"orderKey\":\"4\",\"family\":\"FAMILY\","
+            + "\"familyKey\":\"5\",\"genus\":\"GENUS\",\"genusKey\":\"6\",\"species\":\"SPECIES\","
+            + "\"speciesKey\":\"7\",\"synonym\":true,\"taxonID\":\"taxonID\","
+            + "\"taxonKey\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"10\",\"11\"],\"usage\":{\"key\":10,"
+            + "\"guid\":null,\"name\":\"synonym\",\"rank\":\"SPECIES\"},\"usageParsedName\":{\"abbreviated\":false,"
+            + "\"autonym\":false,\"basionymAuthorship\":{\"authors\":[\"setBasionymAuthorship\"],\"exAuthors\":["
+            + "\"setBasionymAuthorship\"],\"empty\":true,\"year\":\"2000\"},\"binomial\":false,\"candidatus\":false,"
+            + "\"code\":\"BACTERIAL\",\"combinationAuthorship\":{\"authors\":[\"setCombinationAuthorship\"],"
             + "\"exAuthors\":[\"setCombinationAuthorship\"],\"empty\":false,\"year\":\"2020\"},\"doubtful\":false,"
             + "\"genericName\":\"setGenus\",\"genus\":\"setGenus\",\"incomplete\":false,\"indetermined\":false,"
             + "\"infraspecificEpithet\":\"infraspecificEpithet\",\"notho\":\"GENERIC\",\"rank\":\"ABERRATION\","
             + "\"specificEpithet\":\"specificEpithet\",\"state\":\"COMPLETE\",\"terminalEpithet\":\"terminalEpithet\","
-            + "\"trinomial\":false,\"type\":\"HYBRID_FORMULA\",\"uninomial\":\"setUninomial\"},\"verbatimScientificName\":"
-            + "\"scientificName\",\"iucnRedListCategoryCode\":\"setIucnRedListCategoryCode\",\"class\":\"CLASS\"}";
+            + "\"trinomial\":false,\"type\":\"HYBRID_FORMULA\",\"uninomial\":\"setUninomial\"},"
+            + "\"verbatimScientificName\":\"scientificName\",\"iucnRedListCategoryCode\":\"setIucnRedListCategoryCode\","
+            + "\"class\":\"CLASS\"}";
+
     assertEquals(expectedGbifClassification, result.path("gbifClassification").toString());
 
     assertEquals("111", result.path("gbifId").asText());

--- a/sdks/models/src/main/avro/core/basic-record.avsc
+++ b/sdks/models/src/main/avro/core/basic-record.avsc
@@ -18,6 +18,7 @@
     "doc": "Interpreted values at the occurrence record level",
     "fields": [
       {"name": "id", "type": "string", "doc": "Pipelines identifier"},
+      {"name": "coreId","type":["null","string"],"default":null, "doc":"Id of the core record when this record belongs to an extension"},
       {"name": "created", "type": ["null", "long"], "default" : null, "doc":"The timestamp the record was created"},
       {"name": "basisOfRecord", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/basisOfRecord"},
       {"name": "sex", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/sex"},

--- a/sdks/models/src/main/avro/core/event-core-record.avsc
+++ b/sdks/models/src/main/avro/core/event-core-record.avsc
@@ -17,7 +17,7 @@
     "fields": [
       {"name": "id", "type": "string", "doc": "Pipelines identifier"},
       {"name": "parentEventID", "type": ["null", "string"], "default" : null, "doc": "http://purl.org/dc/terms/parentEventID"},
-      {"name": "eventType", "type": ["null", "VocabularyConcept"], "default" : null, "doc": ""},
+      {"name": "eventType", "type": ["null", "VocabularyConcept"], "default" : null, "doc": "http://rs.gbif.org/terms/1.0/eventType"},
       {"name": "created", "type": ["null", "long"], "default" : null, "doc":"The timestamp the record was created"},
       {"name": "sampleSizeValue", "type": ["null", "double"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/sampleSizeValue"},
       {"name": "sampleSizeUnit", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/sampleSizeUnit"},

--- a/sdks/models/src/main/avro/core/taxon-record.avsc
+++ b/sdks/models/src/main/avro/core/taxon-record.avsc
@@ -33,24 +33,6 @@
     ]
   },
   {
-    "name" : "ALAMatchType",
-    "namespace" : "org.gbif.pipelines.io.avro",
-    "type" : "enum",
-    "symbols" : [
-      "exactMatch", "canoncialMatch", "phraseMatch", "fuzzyMatch", "vernacularMatch", "higherMatch", "taxonIdMatch", "noMatch"
-    ]
-  },
-  {
-    "name" : "ALAMatchIssueType",
-    "namespace" : "org.gbif.pipelines.io.avro",
-    "type" : "enum",
-    "symbols" : [
-      "affinitySpecies", "associatedNameExcluded", "conferSpecies", "excludedSpecies", "genericError",
-      "hintMismatch", "homonym", "indeterminateSpecies", "matchedToMisappliedName", "misappliedName",
-      "noIssue", "noMatch", "parentChildSynonym", "questionSpecies", "speciesPlural"
-     ]
-  },
-  {
     "name" : "Nomenclature",
     "namespace" : "org.gbif.pipelines.io.avro",
     "type" : "record",
@@ -154,42 +136,5 @@
       {"name" : "issues", "type": "IssueRecord", "default":{}},
       {"name" : "iucnRedListCategoryCode", "type" : ["null", "string"], "default" : null, "doc":"The IUCN Red List Category or conservation status"}
     ]
-  },
-{
-  "name":"ALATaxonRecord",
-  "namespace":"org.gbif.pipelines.io.avro",
-  "type":"record",
-  "doc":"An ALA Name Match",
-  "fields":[
-    {"name": "id","type":"string"},
-    {"name": "scientificName", "type": ["null", "string"], "default" : null },
-    {"name": "scientificNameAuthorship", "type": ["null", "string"], "default" : null },
-    {"name": "taxonConceptID", "type": ["null", "string"], "default" : null },
-    {"name": "taxonRank", "type": ["null", "string"], "default" : null },
-    {"name": "taxonRankID", "type": ["null", "int"], "default" : null },
-    {"name": "lft", "type": ["null", "int"], "default" : null },
-    {"name": "rgt", "type": ["null", "int"], "default" : null },
-    {"name": "matchType", "type": ["null", "string"], "default" : null },
-    {"name": "nameType", "type": ["null", "string"], "default" : null },
-    {"name": "kingdom", "type": ["null", "string"], "default" : null },
-    {"name": "kingdomID", "type": ["null", "string"], "default" : null },
-    {"name": "phylum", "type": ["null", "string"], "default" : null },
-    {"name": "phylumID", "type": ["null", "string"], "default" : null },
-    {"name": "classs", "type": ["null", "string"], "default" : null },
-    {"name": "classID", "type": ["null", "string"], "default" : null },
-    {"name": "order", "type": ["null", "string"], "default" : null },
-    {"name": "orderID", "type": ["null", "string"], "default" : null },
-    {"name": "family", "type": ["null", "string"], "default" : null },
-    {"name": "familyID", "type": ["null", "string"], "default" : null },
-    {"name": "genus", "type": ["null", "string"], "default" : null },
-    {"name": "genusID", "type": ["null", "string"], "default" : null },
-    {"name": "species", "type": ["null", "string"], "default" : null },
-    {"name": "speciesID", "type": ["null", "string"], "default" : null },
-    {"name": "vernacularName", "type": ["null", "string"], "default" : null },
-    {"name": "speciesGroup", "type": {"type": "array", "items": "string"}, "default" : [] },
-    {"name": "speciesSubgroup", "type": {"type": "array", "items": "string"}, "default" : [] },
-    {"name": "diagnostics", "type" : ["null", "Diagnostic"], "default" : null},
-    {"name": "issues", "type": "IssueRecord", "default":{}}
-  ]
-}
+  }
 ]

--- a/sdks/models/src/main/avro/event-search-record.avsc
+++ b/sdks/models/src/main/avro/event-search-record.avsc
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "EventSearchRecord",
+    "namespace": "org.gbif.pipelines.io.avro",
+    "type": "record",
+    "doc": "An AVRO export used to support Spark SQL exports",
+    "fields": [
+      {"name": "id", "type": "string", "doc": "Pipelines identifier"},
+      {"name": "datasetKey", "type": "string", "doc": "Pipelines identifier"},
+      {"name": "eventHierarchy", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "eventTypeHierarchy", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "samplingProtocol", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "taxonKey", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "locationID", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "measurementOrFactTypes", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "stateProvince", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "countryCode", "type": {"type" : "array", "items" : "string"}, "default" : [], "doc": ""},
+      {"name": "year", "type": ["null", "int"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/year"},
+      {"name": "month", "type": ["null", "int"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/month"}
+    ]
+  }
+]

--- a/sdks/models/src/main/avro/json/common-json-record.avsc
+++ b/sdks/models/src/main/avro/json/common-json-record.avsc
@@ -121,6 +121,7 @@
     "type":"record",
     "fields":[
       {"name":"key","type":["null","int"],"default":null,"doc":""},
+      {"name":"guid","type":["null","string"],"default":null,"doc":""},
       {"name":"name","type":["null","string"],"default":null,"doc":""},
       {"name":"rank","type":["null","string"],"default":null}
     ]
@@ -205,6 +206,23 @@
       {"name":"usageParsedName","type":["null","ParsedName"],"default":null,"doc":""},
       {"name":"verbatimScientificName","type":["null","string"],"default":null,"doc":""},
       {"name":"iucnRedListCategoryCode","type":["null","string"],"default":null,"doc":""}
+    ]
+  },
+  {
+    "name":"MeasurementOrFactJsonRecord",
+    "namespace":"org.gbif.pipelines.io.avro.json",
+    "type":"record",
+    "doc":"Represents the occurrence json object for elasticsearch document",
+    "fields":[
+      {"name": "measurementID", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementID"},
+      {"name": "measurementType", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementType"},
+      {"name": "measurementValue", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementValue"},
+      {"name": "measurementUnit", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementUnit"},
+      {"name": "measurementAccuracy", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementAccuracy"},
+      {"name": "measurementDeterminedBy", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementDeterminedBy"},
+      {"name": "measurementDeterminedDate", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementDeterminedDate"},
+      {"name": "measurementMethod", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementMethod"},
+      {"name": "measurementRemarks", "type": ["null", "string"], "default" : null, "doc": "http://rs.tdwg.org/dwc/terms/measurementRemarks"}
     ]
   }
 ]

--- a/sdks/models/src/main/avro/json/event-json-record.avsc
+++ b/sdks/models/src/main/avro/json/event-json-record.avsc
@@ -24,6 +24,7 @@
       {"name":"derivedMetadata","type":["null","DerivedMetadataRecord"],"default":null,"doc":""},
       // Record-level
       {"name":"eventType","type":["null","VocabularyConcept"],"default":null,"doc":""},
+      {"name":"eventName","type":["null","string"],"default":null,"doc":""},
       {"name":"references","type":["null","string"],"default":null,"doc":""},
       {"name":"institutionCode","type":["null","string"],"default":null,"doc":""},
       {"name":"datasetID","type":{"type":"array","items":"string"},"default":null,"doc":""},
@@ -71,7 +72,7 @@
       {"name":"hasGeospatialIssue","type":["null","boolean"],"default":null,"doc":""},
       {"name":"footprintWKT","type":["null","string"],"default":null,"doc":""},
       {"name":"publishingCountry","type":["null","string"],"default":null,"doc":""},
-      //Taxonomy
+      // Taxonomy
       {"name":"gbifClassification","type":["null","GbifClassification"],"default":null,"doc":""},
       // Multimedia
       {"name":"mediaTypes","type":{"type":"array","items":"string"},"default":null,"doc":""},
@@ -80,10 +81,21 @@
       // MeasurementOrFact
       {"name":"measurementOrFactTypes","type":{"type":"array","items":"string"},"default":null,"doc":""},
       {"name":"measurementOrFactMethods","type":{"type":"array","items":"string"},"default":null,"doc":""},
+      {"name":"measurementOrFactCount","type":["null","int"],"default":null,"doc":""},
       // Extra
       {"name":"issues","type":{"type":"array","items":"string"},"default":[],"doc":""},
       {"name":"notIssues","type":{"type":"array","items":"string"},"default":[],"doc":""},
-      {"name":"extensions","type":{"type":"array","items":"string"},"default":[],"doc":""}
+      {"name":"extensions","type":{"type":"array","items":"string"},"default":[],"doc":""},
+      {"name":"verbatim","type":["null","VerbatimRecord"],"default":null,"doc":""},
+      // Aggregations
+      {"name":"occurrenceCount","type":["null","int"],"default":null,"doc":""},
+      // Denormalised event info
+      {"name":"eventHierarchy","type":{"type":"array","items":"string"},"default":[],"doc":""},
+      {"name":"eventTypeHierarchy","type":{"type":"array","items":"string"},"default":[],"doc":""},
+      {"name":"eventHierarchyJoined","type":["null","string"],"default":null,"doc":""},
+      {"name":"eventTypeHierarchyJoined","type":["null","string"],"default":null,"doc":""},
+      {"name":"eventHierarchyLevels","type":["null","int"],"default":null,"doc":""},
+      {"name":"measurementOrFacts","type":{"type":"array","items":"org.gbif.pipelines.io.avro.json.MeasurementOrFactJsonRecord"},"default":[],"doc":""}
     ]
   }
 ]

--- a/sdks/models/src/main/avro/json/occurrence-json-record.avsc
+++ b/sdks/models/src/main/avro/json/occurrence-json-record.avsc
@@ -1,6 +1,16 @@
 /** Represents the occurrence json object for indexing */
 [
   {
+    "name":"Taxonomy",
+    "namespace":"org.gbif.pipelines.io.avro.json",
+    "type":"record",
+    "doc":"Used to create a index to support autocomplete on top of the occurrences",
+    "fields":[
+      {"name":"taxonKey","type":["null","string"],"default":null,"doc":""},
+      {"name":"name","type":["null","string"],"default":null,"doc":""}
+    ]
+  },
+  {
     "name":"OccurrenceJsonRecord",
     "namespace":"org.gbif.pipelines.io.avro.json",
     "type":"record",
@@ -59,6 +69,7 @@
       {"name":"locality","type":["null","string"],"default":null,"doc":""},
       {"name":"occurrenceId","type":["null","string"],"default":null,"doc":""},
       {"name":"datasetID","type":{"type":"array","items":"string"},"default":null,"doc":""},
+      {"name":"locationID","type":["null","string"],"default":null,"doc":""},
       {"name":"datasetName","type":{"type":"array","items":"string"},"default":null,"doc":""},
       {"name":"otherCatalogNumbers","type":{"type":"array","items":"string"},"default":null,"doc":""},
       {"name":"otherCatalogNumbersJoined","type":["null","string"],"default":null,"doc":""},
@@ -110,7 +121,19 @@
       {"name":"mediaTypes","type":{"type":"array","items":"string"},"default":null,"doc":""},
       {"name":"mediaLicenses","type":{"type":"array","items":"string"},"default":null,"doc":""},
       {"name":"multimediaItems","type":{"type":"array","items":"Multimedia"},"default":null,"doc":""},
-      {"name":"verbatim","type":["null","VerbatimRecord"],"default":null,"doc":""}
+      {"name":"verbatim","type":["null","VerbatimRecord"],"default":null,"doc":""},
+      // De-normalised event info
+      {"name":"eventHierarchy","type":{"type":"array","items":"string"},"default":[],"doc":""},
+      {"name":"eventTypeHierarchy","type":{"type":"array","items":"string"},"default":[],"doc":""},
+      {"name":"eventHierarchyJoined","type":["null","string"],"default":null,"doc":""},
+      {"name":"eventTypeHierarchyJoined","type":["null","string"],"default":null,"doc":""},
+      {"name":"eventHierarchyLevels","type":["null","int"],"default":null,"doc":""},
+      // MeasurementOrFact
+      {"name":"measurementOrFactTypes","type":{"type":"array","items":"string"},"default":null,"doc":""},
+      {"name":"measurementOrFactMethods","type":{"type":"array","items":"string"},"default":null,"doc":""},
+      {"name":"measurementOrFactCount","type":["null","int"],"default":null,"doc":""},
+      {"name":"measurementOrFacts","type":{"type":"array","items":"org.gbif.pipelines.io.avro.json.MeasurementOrFactJsonRecord"},"default":[],"doc":""},
+      {"name":"taxonomy","type":{"type":"array","items":"org.gbif.pipelines.io.avro.json.Taxonomy"},"default":[],"doc":""}
     ]
   }
 ]

--- a/sdks/models/src/main/avro/specific/ala-taxon-record.avsc
+++ b/sdks/models/src/main/avro/specific/ala-taxon-record.avsc
@@ -1,0 +1,58 @@
+[
+  {
+    "name" : "ALAMatchType",
+    "namespace" : "org.gbif.pipelines.io.avro",
+    "type" : "enum",
+    "symbols" : [
+      "exactMatch", "canonicalMatch", "phraseMatch", "fuzzyMatch", "vernacularMatch", "higherMatch", "taxonIdMatch", "noMatch"
+    ]
+  },
+  {
+    "name" : "ALAMatchIssueType",
+    "namespace" : "org.gbif.pipelines.io.avro",
+    "type" : "enum",
+    "symbols" : [
+      "affinitySpecies", "associatedNameExcluded", "conferSpecies", "excludedSpecies", "genericError",
+      "hintMismatch", "homonym", "indeterminateSpecies", "matchedToMisappliedName", "misappliedName",
+      "noIssue", "noMatch", "parentChildSynonym", "questionSpecies", "speciesPlural"
+    ]
+  },
+  {
+    "name":"ALATaxonRecord",
+    "namespace":"org.gbif.pipelines.io.avro",
+    "type":"record",
+    "doc":"An ALA Name Match",
+    "fields":[
+      {"name": "id","type":"string"},
+      {"name": "parentId","type":["null","string"],"default":null, "doc":"Parent record identifier"},
+      {"name": "coreId","type":["null","string"],"default":null, "doc":"Id of the core record when this record belongs to an extension"},
+      {"name": "scientificName", "type": ["null", "string"], "default" : null },
+      {"name": "scientificNameAuthorship", "type": ["null", "string"], "default" : null },
+      {"name": "taxonConceptID", "type": ["null", "string"], "default" : null },
+      {"name": "taxonRank", "type": ["null", "string"], "default" : null },
+      {"name": "taxonRankID", "type": ["null", "int"], "default" : null },
+      {"name": "lft", "type": ["null", "int"], "default" : null },
+      {"name": "rgt", "type": ["null", "int"], "default" : null },
+      {"name": "matchType", "type": ["null", "string"], "default" : null },
+      {"name": "nameType", "type": ["null", "string"], "default" : null },
+      {"name": "kingdom", "type": ["null", "string"], "default" : null },
+      {"name": "kingdomID", "type": ["null", "string"], "default" : null },
+      {"name": "phylum", "type": ["null", "string"], "default" : null },
+      {"name": "phylumID", "type": ["null", "string"], "default" : null },
+      {"name": "classs", "type": ["null", "string"], "default" : null },
+      {"name": "classID", "type": ["null", "string"], "default" : null },
+      {"name": "order", "type": ["null", "string"], "default" : null },
+      {"name": "orderID", "type": ["null", "string"], "default" : null },
+      {"name": "family", "type": ["null", "string"], "default" : null },
+      {"name": "familyID", "type": ["null", "string"], "default" : null },
+      {"name": "genus", "type": ["null", "string"], "default" : null },
+      {"name": "genusID", "type": ["null", "string"], "default" : null },
+      {"name": "species", "type": ["null", "string"], "default" : null },
+      {"name": "speciesID", "type": ["null", "string"], "default" : null },
+      {"name": "vernacularName", "type": ["null", "string"], "default" : null },
+      {"name": "speciesGroup", "type": {"type": "array", "items": "string"}, "default" : [] },
+      {"name": "speciesSubgroup", "type": {"type": "array", "items": "string"}, "default" : [] },
+      {"name": "issues", "type": "IssueRecord", "default":{}}
+    ]
+  }
+]


### PR DESCRIPTION
This is reasonably big PR with the following changes:

* ALA Event pipelines for:
  * Verbatim to interpretations of Events
  * Elastic search indexing
  * Generation of an AVRO output used to support downloads
 
It includes:
* YAML configuration
* Extensions to  pipelines to add event hierarchy to occurrence indexing in Elastic
 
This PR lacks end to end integration tests which will come in #799. I've separated these PRs to make the reviews easier.


Related issue: https://github.com/AtlasOfLivingAustralia/extended-data-model/issues/62