### PR TITLE
Debian build fix after last code restructure

### DIFF
--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -24,7 +24,7 @@ ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
 # Also we can -DskipITs tests
-	mvn -Dmaven.repo.local=$(M2_REPO) clean package -DskipTests
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -P gbif-artifacts,livingatlas-artifacts,extra-artifacts -DskipTests
 endif
 
 override_dh_auto_clean:

--- a/livingatlas/debian/rules
+++ b/livingatlas/debian/rules
@@ -24,7 +24,7 @@ ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
 # Also we can -DskipITs tests
-	mvn -Dmaven.repo.local=$(M2_REPO) clean package -P gbif-artifacts,livingatlas-artifacts,extra-artifacts -DskipTests
+	mvn -Dmaven.repo.local=$(M2_REPO) clean package -P livingatlas-artifacts -DskipTests
 endif
 
 override_dh_auto_clean:


### PR DESCRIPTION
the la-pipelines debian package is not building correctly since the last code restructuration: 
```
make[1]: Entering directory '/build/la-pipelines-2.13.0'
cp /build/la-pipelines-2.13.0/livingatlas/pipelines/target/pipelines-2.13.0-SNAPSHOT-shaded.jar /build/la-pipelines-2.13.0/livingatlas/pipelines/target/la-pipelines.jar
cp: cannot stat '/build/la-pipelines-2.13.0/livingatlas/pipelines/target/pipelines-2.13.0-SNAPSHOT-shaded.jar': No such file or directory
debian/rules:35: recipe for target 'override_dh_auto_install' failed
```
I updated the `debian/rules` similarly to `build.sh` and now the debian package is generated correctly again:

```
make[1]: Entering directory '/build/la-pipelines-2.13.0'
cp /build/la-pipelines-2.13.0/livingatlas/pipelines/target/pipelines-2.13.0-SNAPSHOT-shaded.jar /build/la-pipelines-2.13.0/livingatlas/pipelines/target/la-pipelines.jar
cp /build/la-pipelines-2.13.0/livingatlas/migration/target/migration-2.13.0-SNAPSHOT-shaded.jar /build/la-pipelines-2.13.0/livingatlas/pipelines/target/la-pipelines-migration.jar
cp /build/la-pipelines-2.13.0/livingatlas/scripts/la-pipelines-bash-completion.sh /build/la-pipelines-2.13.0/livingatlas/pipelines/target/la-pipelines
cp /build/la-pipelines-2.13.0/livingatlas/configs/la-pipelines-local.yaml /build/la-pipelines-2.13.0/livingatlas/pipelines/target/la-pipelines-local.yaml.sample
dh_auto_install
```