### PR TITLE
Download updated resources on la-pipelines copy

### DIFF
--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -379,7 +379,7 @@ function copy () {
     if [[ "$DR_URL" == http* ]]; then
       # Try to resume previous download (continue if fails)
       set +e
-      $_D curl -sLC - -o "$DR_DEST/$dr.zip" -f "$DR_CONN_URL"
+      $_D curl -sL -o "$DR_DEST/$dr.zip" -f "$DR_CONN_URL"
       set -e
     # else, other types like sftp
     else


### PR DESCRIPTION
The `--continue-at` (`-C`) option in `curl` doesn't download update resources. I added it to try to resume downloads and save bandwidth/time on existing downloaded resources. As it doesn't work as expected, I'm removing it. 

```bash
$ sha1sum dr971*
eeff8a4141d49f770d7c8be1382d69d016cb36cb  dr971.zip
eeff8a4141d49f770d7c8be1382d69d016cb36cb  dr971.zip.v1
a937e97be6bdb40e51602cee813a5f7af1e904c2  dr971.zip.v2
$ curl -sLC - -o dr971.zip -f https://ipt.gbif.es/archive.do?r=macrofauna-mar-21_ips3-25-1-r1
$ sha1sum dr971*
eeff8a4141d49f770d7c8be1382d69d016cb36cb  dr971.zip
eeff8a4141d49f770d7c8be1382d69d016cb36cb  dr971.zip.v1
a937e97be6bdb40e51602cee813a5f7af1e904c2  dr971.zip.v2
$ curl -sL -o dr971.zip -f https://ipt.gbif.es/archive.do?r=macrofauna-mar-21_ips3-25-1-r1
$ sha1sum dr971*
a937e97be6bdb40e51602cee813a5f7af1e904c2  dr971.zip
eeff8a4141d49f770d7c8be1382d69d016cb36cb  dr971.zip.v1
a937e97be6bdb40e51602cee813a5f7af1e904c2  dr971.zip.v2
```