### PR TITLE
Update of yq to support v4.X.X versions in la-pipelines

### DIFF
--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -32,7 +32,7 @@ then
         echo "$OUT"
     }
 else
-    if [[ $YQ_VERSION =~ ^4 ]]
+    if [[ $YQ_VERSION =~ ^[a-zA-Z]*4\.[0-9]+\.[0-9]+ ]]
 then
     function YQ_VERIFY() {
         cat "$1" | yq e 'true' - > /dev/null


### PR DESCRIPTION
Using a part of #824 to detect new v4.X.X versions of yq instead of old ones (4.X.X).

Tested with:
```
$ yq --version
yq (https://github.com/mikefarah/yq/) version 4.16.2
$ yq --version
yq (https://github.com/mikefarah/yq/) version v4.30.5
```
So #824 can be closed. Kudos to @sadeghim .