### PR TITLE
#205 taking values from identification extension when missing from core

### DIFF
--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
@@ -30,6 +30,7 @@ import org.gbif.nameparser.NameParserGbifV1;
 import org.gbif.nameparser.api.NameParser;
 import org.gbif.nameparser.api.UnparsableNameException;
 import org.gbif.pipelines.core.parsers.taxonomy.TaxonRecordConverter;
+import org.gbif.pipelines.core.utils.IdentificationUtils;
 import org.gbif.pipelines.core.utils.ModelUtils;
 import org.gbif.pipelines.io.avro.Authorship;
 import org.gbif.pipelines.io.avro.ExtendedRecord;
@@ -75,7 +76,7 @@ public class TaxonomyInterpreter {
 
       ModelUtils.checkNullOrEmpty(er);
 
-      Map<String, String> termsSource = ModelUtils.getIdentificationFieldTermsSource(er);
+      Map<String, String> termsSource = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
       // https://github.com/gbif/portal-feedback/issues/4231
       String scientificName =

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
@@ -75,26 +75,29 @@ public class TaxonomyInterpreter {
 
       ModelUtils.checkNullOrEmpty(er);
 
+      Map<String, String> termsSource = ModelUtils.getIdentificationFieldTermsSource(er);
+
       // https://github.com/gbif/portal-feedback/issues/4231
       String scientificName =
-          extractNullAwareOptValue(er, DwcTerm.scientificName)
-              .orElse(extractValue(er, DwcTerm.verbatimIdentification));
+          extractNullAwareOptValue(termsSource, DwcTerm.scientificName)
+              .orElse(extractValue(termsSource, DwcTerm.verbatimIdentification));
 
       SpeciesMatchRequest matchRequest =
           SpeciesMatchRequest.builder()
-              .withKingdom(extractValue(er, DwcTerm.kingdom))
-              .withPhylum(extractValue(er, DwcTerm.phylum))
-              .withClazz(extractValue(er, DwcTerm.class_))
-              .withOrder(extractValue(er, DwcTerm.order))
-              .withFamily(extractValue(er, DwcTerm.family))
-              .withGenus(extractValue(er, DwcTerm.genus))
+              .withKingdom(extractValue(termsSource, DwcTerm.kingdom))
+              .withPhylum(extractValue(termsSource, DwcTerm.phylum))
+              .withClazz(extractValue(termsSource, DwcTerm.class_))
+              .withOrder(extractValue(termsSource, DwcTerm.order))
+              .withFamily(extractValue(termsSource, DwcTerm.family))
+              .withGenus(extractValue(termsSource, DwcTerm.genus))
               .withScientificName(scientificName)
-              .withRank(extractValue(er, DwcTerm.taxonRank))
-              .withVerbatimRank(extractValue(er, DwcTerm.verbatimTaxonRank))
-              .withSpecificEpithet(extractValue(er, DwcTerm.specificEpithet))
-              .withInfraspecificEpithet(extractValue(er, DwcTerm.infraspecificEpithet))
-              .withScientificNameAuthorship(extractValue(er, DwcTerm.scientificNameAuthorship))
-              .withGenericName(extractValue(er, DwcTerm.genericName))
+              .withRank(extractValue(termsSource, DwcTerm.taxonRank))
+              .withVerbatimRank(extractValue(termsSource, DwcTerm.verbatimTaxonRank))
+              .withSpecificEpithet(extractValue(termsSource, DwcTerm.specificEpithet))
+              .withInfraspecificEpithet(extractValue(termsSource, DwcTerm.infraspecificEpithet))
+              .withScientificNameAuthorship(
+                  extractValue(termsSource, DwcTerm.scientificNameAuthorship))
+              .withGenericName(extractValue(termsSource, DwcTerm.genericName))
               .build();
 
       NameUsageMatch usageMatch = null;

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/temporal/TemporalParser.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/temporal/TemporalParser.java
@@ -209,4 +209,34 @@ public class TemporalParser implements Serializable {
 
     return likelyRange.contains(LocalDate.of(year, month, day));
   }
+
+  public static Optional<Long> getTime(TemporalAccessor temporalAccessor) {
+    if (temporalAccessor == null) {
+      return Optional.empty();
+    }
+
+    int year;
+    if (temporalAccessor.isSupported(ChronoField.YEAR)) {
+      year = temporalAccessor.get(ChronoField.YEAR);
+    } else {
+      return Optional.empty();
+    }
+
+    int month = 1;
+    if (temporalAccessor.isSupported(ChronoField.MONTH_OF_YEAR)) {
+      month = temporalAccessor.get(ChronoField.MONTH_OF_YEAR);
+    }
+
+    int day = 1;
+    if (temporalAccessor.isSupported(ChronoField.DAY_OF_MONTH)) {
+      day = temporalAccessor.get(ChronoField.DAY_OF_MONTH);
+    }
+
+    long time = LocalDate.of(year, month, day).toEpochDay();
+    if (temporalAccessor.isSupported(ChronoField.NANO_OF_DAY)) {
+      time += temporalAccessor.getLong(ChronoField.NANO_OF_DAY);
+    }
+
+    return Optional.of(time);
+  }
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/temporal/TemporalParser.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/temporal/TemporalParser.java
@@ -9,7 +9,11 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.gbif.api.vocabulary.OccurrenceIssue;
@@ -208,35 +212,5 @@ public class TemporalParser implements Serializable {
     }
 
     return likelyRange.contains(LocalDate.of(year, month, day));
-  }
-
-  public static Optional<Long> getTime(TemporalAccessor temporalAccessor) {
-    if (temporalAccessor == null) {
-      return Optional.empty();
-    }
-
-    int year;
-    if (temporalAccessor.isSupported(ChronoField.YEAR)) {
-      year = temporalAccessor.get(ChronoField.YEAR);
-    } else {
-      return Optional.empty();
-    }
-
-    int month = 1;
-    if (temporalAccessor.isSupported(ChronoField.MONTH_OF_YEAR)) {
-      month = temporalAccessor.get(ChronoField.MONTH_OF_YEAR);
-    }
-
-    int day = 1;
-    if (temporalAccessor.isSupported(ChronoField.DAY_OF_MONTH)) {
-      day = temporalAccessor.get(ChronoField.DAY_OF_MONTH);
-    }
-
-    long time = LocalDate.of(year, month, day).toEpochDay();
-    if (temporalAccessor.isSupported(ChronoField.NANO_OF_DAY)) {
-      time += temporalAccessor.getLong(ChronoField.NANO_OF_DAY);
-    }
-
-    return Optional.of(time);
   }
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/utils/IdentificationUtils.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/utils/IdentificationUtils.java
@@ -1,0 +1,134 @@
+package org.gbif.pipelines.core.utils;
+
+import static org.gbif.dwc.terms.DwcTerm.GROUP_IDENTIFICATION;
+import static org.gbif.dwc.terms.DwcTerm.GROUP_TAXON;
+import static org.gbif.pipelines.core.utils.ModelUtils.hasValue;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.gbif.api.vocabulary.Extension;
+import org.gbif.common.parsers.date.DateParsers;
+import org.gbif.common.parsers.date.TemporalParser;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.Term;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+
+/** Utility class to help with the extraction of the identification fields. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IdentificationUtils {
+
+  private static final Set<Term> IDENTIFICATION_FIELDS =
+      Arrays.stream(DwcTerm.values())
+          .filter(
+              t ->
+                  (t.getGroup().equals(GROUP_IDENTIFICATION) || t.getGroup().equals(GROUP_TAXON))
+                      && !t.isClass())
+          .collect(Collectors.toSet());
+
+  private static final TemporalParser TEMPORAL_PARSER = DateParsers.defaultTemporalParser();
+
+  public static Map<String, String> getIdentificationFieldTermsSource(ExtendedRecord er) {
+    return areAllIdentificationFieldsNull(er)
+        ? getLatestIdentificationExtension(er).orElse(new HashMap<>())
+        : er.getCoreTerms();
+  }
+
+  public static String extractFromIdentificationExtension(ExtendedRecord er, Term term) {
+    if (IDENTIFICATION_FIELDS.contains(term)
+        && ModelUtils.hasExtension(er, Extension.IDENTIFICATION)
+        && areAllIdentificationFieldsNull(er)) {
+      return getLatestIdentificationExtension(er)
+          .map(ext -> ext.get(term.qualifiedName()))
+          .orElse(null);
+    }
+    return null;
+  }
+
+  private static Optional<Map<String, String>> getLatestIdentificationExtension(ExtendedRecord er) {
+    if (!ModelUtils.hasExtension(er, Extension.IDENTIFICATION)) {
+      return Optional.empty();
+    }
+
+    List<Map<String, String>> identificationExtension =
+        er.getExtensions().get(DwcTerm.Identification.qualifiedName());
+    if (identificationExtension.size() > 1
+        && identificationExtension.stream()
+            .allMatch(v -> hasValue(v.get(DwcTerm.dateIdentified.qualifiedName())))) {
+      // if there are multiple extensions we choose the most recent one but only if we can
+      // determine it. Therefore, if there are extensions without date we discard them all
+      Map<String, String> latestIdentification = null;
+      Long latestTime = null;
+      for (Map<String, String> ext : identificationExtension) {
+        String rawDateIdentified = ext.get(DwcTerm.dateIdentified.qualifiedName());
+        TemporalAccessor result = TEMPORAL_PARSER.parse(rawDateIdentified).getPayload();
+
+        Optional<Long> time = getTime(result);
+        if (!time.isPresent()) {
+          // since we can't determine the time of this extension we can't determine which extension
+          // is the most recent
+          return Optional.empty();
+        }
+
+        if (latestIdentification == null || time.get() > latestTime) {
+          latestIdentification = ext;
+          latestTime = time.get();
+        }
+      }
+
+      return Optional.ofNullable(latestIdentification);
+    } else if (identificationExtension.size() == 1) {
+      return Optional.of(identificationExtension.get(0));
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * This method is needed because we follow an all-or-nothing approach, so we take values from the
+   * identification extension only if all the identification fields in the core are null.
+   */
+  private static boolean areAllIdentificationFieldsNull(ExtendedRecord er) {
+    return IDENTIFICATION_FIELDS.stream()
+        .noneMatch(f -> hasValue(er.getCoreTerms().get(f.qualifiedName())));
+  }
+
+  private static Optional<Long> getTime(TemporalAccessor temporalAccessor) {
+    if (temporalAccessor == null) {
+      return Optional.empty();
+    }
+
+    int year;
+    if (temporalAccessor.isSupported(ChronoField.YEAR)) {
+      year = temporalAccessor.get(ChronoField.YEAR);
+    } else {
+      return Optional.empty();
+    }
+
+    int month = 1;
+    if (temporalAccessor.isSupported(ChronoField.MONTH_OF_YEAR)) {
+      month = temporalAccessor.get(ChronoField.MONTH_OF_YEAR);
+    }
+
+    int day = 1;
+    if (temporalAccessor.isSupported(ChronoField.DAY_OF_MONTH)) {
+      day = temporalAccessor.get(ChronoField.DAY_OF_MONTH);
+    }
+
+    long time = LocalDate.of(year, month, day).toEpochDay();
+    if (temporalAccessor.isSupported(ChronoField.NANO_OF_DAY)) {
+      time += temporalAccessor.getLong(ChronoField.NANO_OF_DAY);
+    }
+
+    return Optional.of(time);
+  }
+}

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
@@ -1,11 +1,7 @@
 package org.gbif.pipelines.core.utils;
 
-import static org.gbif.dwc.terms.DwcTerm.GROUP_IDENTIFICATION;
-import static org.gbif.dwc.terms.DwcTerm.GROUP_TAXON;
+import static org.gbif.pipelines.core.utils.IdentificationUtils.extractFromIdentificationExtension;
 
-import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,9 +13,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.gbif.api.vocabulary.Extension;
 import org.gbif.api.vocabulary.OccurrenceIssue;
-import org.gbif.common.parsers.date.DateParsers;
-import org.gbif.common.parsers.date.TemporalParser;
-import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.Term;
 import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.gbif.pipelines.io.avro.Issues;
@@ -29,16 +22,6 @@ import org.gbif.pipelines.io.avro.Issues;
 public class ModelUtils {
 
   public static final String DEFAULT_SEPARATOR = "\\|";
-
-  private static final Set<Term> IDENTIFICATION_FIELDS =
-      Arrays.stream(DwcTerm.values())
-          .filter(
-              t ->
-                  (t.getGroup().equals(GROUP_IDENTIFICATION) || t.getGroup().equals(GROUP_TAXON))
-                      && !t.isClass())
-          .collect(Collectors.toSet());
-
-  private static final TemporalParser TEMPORAL_PARSER = DateParsers.defaultTemporalParser();
 
   public static String extractValue(ExtendedRecord er, Term term) {
     String value = er.getCoreTerms().get(term.qualifiedName());
@@ -68,7 +51,7 @@ public class ModelUtils {
     return hasValue(value) ? value : null;
   }
 
-  private static boolean hasValue(String value) {
+  public static boolean hasValue(String value) {
     return value != null && !value.isEmpty() && !"null".equalsIgnoreCase(value.trim());
   }
 
@@ -147,71 +130,5 @@ public class ModelUtils {
 
   public static void addIssueSet(Issues model, Set<OccurrenceIssue> issues) {
     issues.forEach(x -> addIssue(model, x));
-  }
-
-  public static Map<String, String> getIdentificationFieldTermsSource(ExtendedRecord er) {
-    return areAllIdentificationFieldsNull(er)
-        ? getLatestIdentificationExtension(er).orElse(new HashMap<>())
-        : er.getCoreTerms();
-  }
-
-  private static String extractFromIdentificationExtension(ExtendedRecord er, Term term) {
-    if (IDENTIFICATION_FIELDS.contains(term)
-        && ModelUtils.hasExtension(er, Extension.IDENTIFICATION)
-        && areAllIdentificationFieldsNull(er)) {
-      return getLatestIdentificationExtension(er)
-          .map(ext -> ext.get(term.qualifiedName()))
-          .orElse(null);
-    }
-    return null;
-  }
-
-  private static Optional<Map<String, String>> getLatestIdentificationExtension(ExtendedRecord er) {
-    if (!ModelUtils.hasExtension(er, Extension.IDENTIFICATION)) {
-      return Optional.empty();
-    }
-
-    List<Map<String, String>> identificationExtension =
-        er.getExtensions().get(DwcTerm.Identification.qualifiedName());
-    if (identificationExtension.size() > 1
-        && identificationExtension.stream()
-            .allMatch(v -> hasValue(v.get(DwcTerm.dateIdentified.qualifiedName())))) {
-      // if there are multiple extensions we choose the most recent one but only if we can
-      // determine it. Therefore, if there are extensions without date we discard them all
-      Map<String, String> latestIdentification = null;
-      Long latestTime = null;
-      for (Map<String, String> ext : identificationExtension) {
-        String rawDateIdentified = ext.get(DwcTerm.dateIdentified.qualifiedName());
-        TemporalAccessor result = TEMPORAL_PARSER.parse(rawDateIdentified).getPayload();
-
-        Optional<Long> time =
-            org.gbif.pipelines.core.parsers.temporal.TemporalParser.getTime(result);
-        if (!time.isPresent()) {
-          // since we can't determine the time of this extension we can't determine which extension
-          // is the most recent
-          return Optional.empty();
-        }
-
-        if (latestIdentification == null || time.get() > latestTime) {
-          latestIdentification = ext;
-          latestTime = time.get();
-        }
-      }
-
-      return Optional.ofNullable(latestIdentification);
-    } else if (identificationExtension.size() == 1) {
-      return Optional.of(identificationExtension.get(0));
-    }
-
-    return Optional.empty();
-  }
-
-  /**
-   * This method is needed because we follow an all-or-nothing approach, so we take values from the
-   * identification extension only if all the identification fields in the core are null.
-   */
-  private static boolean areAllIdentificationFieldsNull(ExtendedRecord er) {
-    return IDENTIFICATION_FIELDS.stream()
-        .noneMatch(f -> hasValue(er.getCoreTerms().get(f.qualifiedName())));
   }
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
@@ -1,13 +1,7 @@
 package org.gbif.pipelines.core.utils;
 
-import org.gbif.api.vocabulary.Extension;
-import org.gbif.api.vocabulary.OccurrenceIssue;
-import org.gbif.common.parsers.date.DateParsers;
-import org.gbif.common.parsers.date.TemporalParser;
-import org.gbif.dwc.terms.DwcTerm;
-import org.gbif.dwc.terms.Term;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-import org.gbif.pipelines.io.avro.Issues;
+import static org.gbif.dwc.terms.DwcTerm.GROUP_IDENTIFICATION;
+import static org.gbif.dwc.terms.DwcTerm.GROUP_TAXON;
 
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
@@ -19,12 +13,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-
-import static org.gbif.dwc.terms.DwcTerm.GROUP_IDENTIFICATION;
-import static org.gbif.dwc.terms.DwcTerm.GROUP_TAXON;
+import org.gbif.api.vocabulary.Extension;
+import org.gbif.api.vocabulary.OccurrenceIssue;
+import org.gbif.common.parsers.date.DateParsers;
+import org.gbif.common.parsers.date.TemporalParser;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.Term;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.Issues;
 
 /** Helps to work with org.gbif.pipelines.io.avro models */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/utils/IdentificationUtilsTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/utils/IdentificationUtilsTest.java
@@ -11,7 +11,7 @@ import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ModelUtilsTest {
+public class IdentificationUtilsTest {
 
   @Test
   public void getIdentificationFieldTermsSourceOnlyOneExtensionTest() {
@@ -23,7 +23,7 @@ public class ModelUtilsTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
 
     // When
-    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+    Map<String, String> source = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
     // Then
     Assert.assertEquals(1, source.size());
@@ -41,7 +41,7 @@ public class ModelUtilsTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
 
     // When
-    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+    Map<String, String> source = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
     // Then
     Assert.assertTrue(source.isEmpty());
@@ -85,7 +85,7 @@ public class ModelUtilsTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
 
     // When
-    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+    Map<String, String> source = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
     // Then
     Assert.assertEquals(2, source.size());
@@ -111,7 +111,7 @@ public class ModelUtilsTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
 
     // When
-    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+    Map<String, String> source = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
     // Then
     Assert.assertTrue(source.isEmpty());
@@ -130,7 +130,7 @@ public class ModelUtilsTest {
         ExtendedRecord.newBuilder().setId("1").setCoreTerms(coreMap).setExtensions(ext).build();
 
     // When
-    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+    Map<String, String> source = IdentificationUtils.getIdentificationFieldTermsSource(er);
 
     // Then
     Assert.assertEquals(1, source.size());

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/utils/ModelUtilsTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/utils/ModelUtilsTest.java
@@ -1,15 +1,13 @@
 package org.gbif.pipelines.core.utils;
 
-import org.gbif.api.vocabulary.Extension;
-import org.gbif.dwc.terms.DwcTerm;
-import org.gbif.pipelines.io.avro.ExtendedRecord;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.gbif.api.vocabulary.Extension;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/utils/ModelUtilsTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/utils/ModelUtilsTest.java
@@ -1,0 +1,142 @@
+package org.gbif.pipelines.core.utils;
+
+import org.gbif.api.vocabulary.Extension;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ModelUtilsTest {
+
+  @Test
+  public void getIdentificationFieldTermsSourceOnlyOneExtensionTest() {
+    // State
+    Map<String, List<Map<String, String>>> ext = new HashMap<>(1);
+    Map<String, String> identification1 = new HashMap<>(1);
+    identification1.put(DwcTerm.kingdom.qualifiedName(), "Animalia");
+    ext.put(Extension.IDENTIFICATION.getRowType(), Collections.singletonList(identification1));
+    ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
+
+    // When
+    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+
+    // Then
+    Assert.assertEquals(1, source.size());
+  }
+
+  @Test
+  public void getIdentificationFieldTermsSourceMultipleExtensionsWithoutDateTest() {
+    // State
+    Map<String, List<Map<String, String>>> ext = new HashMap<>(1);
+    Map<String, String> identification1 = new HashMap<>(1);
+    identification1.put(DwcTerm.kingdom.qualifiedName(), "Animalia");
+    Map<String, String> identification2 = new HashMap<>(1);
+    identification2.put(DwcTerm.kingdom.qualifiedName(), "Animalia");
+    ext.put(Extension.IDENTIFICATION.getRowType(), Arrays.asList(identification1, identification2));
+    ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
+
+    // When
+    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+
+    // Then
+    Assert.assertTrue(source.isEmpty());
+  }
+
+  @Test
+  public void getIdentificationFieldTermsSourceMultipleExtensionsWithDateTest() {
+    // State
+    Map<String, List<Map<String, String>>> ext = new HashMap<>(1);
+    Map<String, String> identification1 = new HashMap<>(1);
+    identification1.put(DwcTerm.kingdom.qualifiedName(), "k");
+    identification1.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01T10:00:01");
+    Map<String, String> identification2 = new HashMap<>(1);
+    identification2.put(DwcTerm.class_.qualifiedName(), "c");
+    identification2.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01T10:00:00");
+    Map<String, String> identification3 = new HashMap<>(1);
+    identification3.put(DwcTerm.genus.qualifiedName(), "g");
+    identification3.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01");
+    Map<String, String> identification4 = new HashMap<>(1);
+    identification4.put(DwcTerm.family.qualifiedName(), "f");
+    identification4.put(DwcTerm.dateIdentified.qualifiedName(), "2022");
+    Map<String, String> identification5 = new HashMap<>(1);
+    identification5.put(DwcTerm.subfamily.qualifiedName(), "sf");
+    identification5.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01/02");
+    Map<String, String> identification6 = new HashMap<>(1);
+    identification6.put(DwcTerm.subgenus.qualifiedName(), "sg");
+    identification6.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09");
+    Map<String, String> identification7 = new HashMap<>(1);
+    identification7.put(DwcTerm.order.qualifiedName(), "0");
+    identification7.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01T10:00");
+    ext.put(
+        Extension.IDENTIFICATION.getRowType(),
+        Arrays.asList(
+            identification1,
+            identification2,
+            identification3,
+            identification4,
+            identification5,
+            identification6,
+            identification7));
+    ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
+
+    // When
+    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+
+    // Then
+    Assert.assertEquals(2, source.size());
+    Assert.assertTrue(source.containsKey(DwcTerm.kingdom.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.class_.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.genus.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.family.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.subfamily.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.subgenus.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.order.qualifiedName()));
+  }
+
+  @Test
+  public void getIdentificationFieldTermsSourceMultipleExtensionsWithOnlyOneDateTest() {
+    // State
+    Map<String, List<Map<String, String>>> ext = new HashMap<>(1);
+    Map<String, String> identification1 = new HashMap<>(1);
+    identification1.put(DwcTerm.kingdom.qualifiedName(), "k");
+    identification1.put(DwcTerm.dateIdentified.qualifiedName(), "2022-09-01T10:00:01");
+    Map<String, String> identification2 = new HashMap<>(1);
+    identification2.put(DwcTerm.class_.qualifiedName(), "c");
+    ext.put(Extension.IDENTIFICATION.getRowType(), Arrays.asList(identification1, identification2));
+    ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setExtensions(ext).build();
+
+    // When
+    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+
+    // Then
+    Assert.assertTrue(source.isEmpty());
+  }
+
+  @Test
+  public void getIdentificationFieldTermsSourceWithCoreTest() {
+    // State
+    Map<String, List<Map<String, String>>> ext = new HashMap<>(1);
+    Map<String, String> coreMap = new HashMap<>(1);
+    coreMap.put(DwcTerm.kingdom.qualifiedName(), "Animalia");
+    Map<String, String> identification = new HashMap<>(1);
+    identification.put(DwcTerm.class_.qualifiedName(), "Aves");
+    ext.put(Extension.IDENTIFICATION.getRowType(), Collections.singletonList(identification));
+    ExtendedRecord er =
+        ExtendedRecord.newBuilder().setId("1").setCoreTerms(coreMap).setExtensions(ext).build();
+
+    // When
+    Map<String, String> source = ModelUtils.getIdentificationFieldTermsSource(er);
+
+    // Then
+    Assert.assertEquals(1, source.size());
+    Assert.assertTrue(source.containsKey(DwcTerm.kingdom.qualifiedName()));
+    Assert.assertFalse(source.containsKey(DwcTerm.class_.qualifiedName()));
+  }
+}


### PR DESCRIPTION
#205 Basically, if it's an identification field and all the identification fields in the core are null we take the values of these fields from the Identification extension if exists. If there are multiple identification extensions we take it from the most recent one but only if we can determine which one it's the most recent. 