### PR TITLE
POM `exclusion` additions to fix errors running tests on ARM Macs

### DIFF
--- a/examples/transform/pom.xml
+++ b/examples/transform/pom.xml
@@ -129,6 +129,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Beam -->

--- a/gbif/coordinator/tasks/pom.xml
+++ b/gbif/coordinator/tasks/pom.xml
@@ -288,6 +288,10 @@
           <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-cli</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.elasticsearch</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -427,6 +431,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Fault tolerance - Used for API service calls-->
     <dependency>

--- a/gbif/ingestion/ingest-gbif-beam/pom.xml
+++ b/gbif/ingestion/ingest-gbif-beam/pom.xml
@@ -148,6 +148,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Utils -->

--- a/gbif/ingestion/ingest-gbif-java/pom.xml
+++ b/gbif/ingestion/ingest-gbif-java/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.elasticsearch</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Hadoop -->

--- a/gbif/ingestion/ingestion-integration-tests/pom.xml
+++ b/gbif/ingestion/ingestion-integration-tests/pom.xml
@@ -153,6 +153,12 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/gbif/validator/validator-core/pom.xml
+++ b/gbif/validator/validator-core/pom.xml
@@ -94,10 +94,22 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.elasticsearch</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.elasticsearch</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/livingatlas/migration/pom.xml
+++ b/livingatlas/migration/pom.xml
@@ -42,6 +42,12 @@
       <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
@@ -53,6 +59,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,12 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
         <version>${avro.version}</version>
       </dependency>
 
@@ -741,6 +747,12 @@
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-high-level-client</artifactId>
         <version>${elasticsearch.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>jna</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.elasticsearch</groupId>
@@ -869,6 +881,10 @@
           <exclusion>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>

--- a/sdks/beam-transforms/pom.xml
+++ b/sdks/beam-transforms/pom.xml
@@ -45,6 +45,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Beam -->

--- a/sdks/core/pom.xml
+++ b/sdks/core/pom.xml
@@ -192,6 +192,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Jackson -->

--- a/sdks/models/pom.xml
+++ b/sdks/models/pom.xml
@@ -137,6 +137,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/sdks/plugins/maven-extension-avsc-schema-generator/pom.xml
+++ b/sdks/plugins/maven-extension-avsc-schema-generator/pom.xml
@@ -54,6 +54,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test -->

--- a/sdks/tools/archives-converters/pom.xml
+++ b/sdks/tools/archives-converters/pom.xml
@@ -71,6 +71,12 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Running all tests on an M2 Mac resulted in many errors, mostly for container-dependent integration tests. I traced them to transitive dependency versions (for `org.elasticsearch:jna` and `org.xerial.snappy:snappy-java`) that were old and pre-dated fixes for ARM based Macs. The updated version of these libraries were already present in the project but some jars were still pulling in the older transitive dependencies, so the fix was to add `<exclusion>` tags for these deps. 