### PR TITLE
changed registry ws call to notify about identifiers validation issues

### DIFF
--- a/gbif/coordinator/tasks/src/main/java/org/gbif/pipelines/tasks/occurrences/identifier/IdentifierCallback.java
+++ b/gbif/coordinator/tasks/src/main/java/org/gbif/pipelines/tasks/occurrences/identifier/IdentifierCallback.java
@@ -111,9 +111,10 @@ public class IdentifierCallback extends AbstractMessageCallback<PipelinesVerbati
         if (validationResult.isResultValid()) {
           log.info(validationResult.getValidationMessage());
         } else {
-          historyClient.sendAbsentIndentifiersEmail(
+          historyClient.notifyAbsentIdentifiers(
               message.getDatasetUuid(),
               message.getAttempt(),
+              message.getExecutionId(),
               validationResult.getValidationMessage());
           log.error(validationResult.getValidationMessage());
           throw new PipelinesException(validationResult.getValidationMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <!-- GBIF libraries -->
     <gbif-parsers.version>0.60</gbif-parsers.version>
     <dwca-io.version>2.14</dwca-io.version>
-    <gbif-api.version>1.5.0</gbif-api.version>
+    <gbif-api.version>1.6.0</gbif-api.version>
     <gbif-common.version>0.56</gbif-common.version>
     <dwc-api.version>1.43</dwc-api.version>
     <kvs.version>1.26</kvs.version>
@@ -98,7 +98,7 @@
     <gbif-wrangler.version>0.3</gbif-wrangler.version>
     <gbif-occurrence.version>0.173.1</gbif-occurrence.version>
     <vocabulary-lookup.version>0.47</vocabulary-lookup.version>
-    <registry.version>3.93</registry.version>
+    <registry.version>3.94.7</registry.version>
     <gbif-common-ws.version>1.18</gbif-common-ws.version>
     <gbif-postal-service.version>1.7.0</gbif-postal-service.version>
     <gbif-common-spreadsheet.version>0.2</gbif-common-spreadsheet.version>


### PR DESCRIPTION
Changes for #882 

The changes in the registry are deployed to DEV and UAT and will be deployed to prod at the beginning of the next week.

This branch `#882_gh_issues` was created from the [pipelines-parent-2.14.5 tag](https://github.com/gbif/pipelines/releases/tag/pipelines-parent-2.14.5) so we can use it to do the release.