### PR TITLE
#921 Stop interpreting rank and incertae sedis instead of null kingdoms

### DIFF
--- a/gbif/ingestion/pre-backbone-release/src/main/java/org/gbif/pipelines/backbone/impact/BackbonePreRelease.java
+++ b/gbif/ingestion/pre-backbone-release/src/main/java/org/gbif/pipelines/backbone/impact/BackbonePreRelease.java
@@ -173,6 +173,12 @@ public class BackbonePreRelease {
             proposed = GBIFClassification.buildFromNameUsageMatch(usageMatch);
           }
 
+          // copy pipelines to put unknown content into incertae sedis kingdom
+          if (proposed.getKingdom() == null) {
+            proposed.setKingdom("incertae sedis");
+            proposed.setKingdomKey(0);
+          }
+
           // emit classifications that differ, optionally considering the keys
           if (skipKeys && !existing.classificationEquals(proposed)) {
             c.output(toTabDelimited(count, matchRequest, existing, proposed, skipKeys));

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <gbif-api.version>1.6.0</gbif-api.version>
     <gbif-common.version>0.56</gbif-common.version>
     <dwc-api.version>1.46</dwc-api.version>
-    <kvs.version>1.26</kvs.version>
+    <kvs.version>1.27-SNAPSHOT</kvs.version>
     <hbase-utils.version>0.12</hbase-utils.version>
     <gbif-wrangler.version>0.3</gbif-wrangler.version>
     <gbif-occurrence.version>0.173.1</gbif-occurrence.version>


### PR DESCRIPTION
This brings in the KV store change you just reviewd @mdoering which will go into indexing and the pre-backbone release script. I also fixed up the null kingdom to incertae sedis to reduce the amount of noise 