### PR TITLE
Fix for #1008 - multiple shards for verbatim avro output

### DIFF
--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -156,6 +156,7 @@ dwca-avro:
   # Path of the input file
   inputPath: /data/biocache-load/{datasetId}/{datasetId}.zip
   tempLocation: /data/biocache-load/{datasetId}/tmp/
+  numShards: 48
 
 # class: au.org.ala.pipelines.beam.ALAVerbatimToInterpretedPipeline
 interpret:
@@ -339,17 +340,11 @@ validation-report:
 
 
 
--dwca-avro-sh-args:
+dwca-avro-sh-args:
   local:
     jvm: -Xmx2g
   spark-embedded:
     jvm: -Xmx2g
-  spark-cluster:
-    conf: spark.default.parallelism=144
-    num-executors: 6
-    executor-cores: 8
-    executor-memory: 24G
-    driver-memory: 4G
 
 ### la-pipelines cli additional arguments, like JVM or spark command line arguments
 interpret-sh-args:

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALADwcaToVerbatimPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALADwcaToVerbatimPipeline.java
@@ -113,7 +113,9 @@ public class ALADwcaToVerbatimPipeline {
 
     log.info("Write path: {}", targetPath);
     p.apply("Read from Darwin Core Archive", reader)
-        .apply("Write to avro", VerbatimTransform.create().write(targetPath));
+        .apply(
+            "Write to avro",
+            VerbatimTransform.create().write(targetPath).withNumShards(options.getNumShards()));
 
     log.info("Running the pipeline");
     PipelineResult result = p.run();

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/DwcaToVerbatimPipelineOptions.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/options/DwcaToVerbatimPipelineOptions.java
@@ -1,6 +1,15 @@
 package au.org.ala.pipelines.options;
 
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
 import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
 
 /** Options for running DwCA to Verbatim AVRO pipelines. */
-public interface DwcaToVerbatimPipelineOptions extends InterpretationPipelineOptions {}
+public interface DwcaToVerbatimPipelineOptions extends InterpretationPipelineOptions {
+
+  @Description("The number of shards to use when writing to HDFS")
+  @Default.Integer(48)
+  Integer getNumShards();
+
+  void setNumShards(Integer numShards);
+}


### PR DESCRIPTION
Simple change that allows a configurable number of shards of the verbatim avro to be generated. Currently only 1 shard is output.