### PR TITLE
updated versions for camtrap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <!-- GBIF libraries -->
     <gbif-parsers.version>0.63</gbif-parsers.version>
     <dwca-io.version>2.14</dwca-io.version>
-    <gbif-api.version>1.13.0</gbif-api.version>
+    <gbif-api.version>1.14.0-SNAPSHOT</gbif-api.version>
     <gbif-common.version>0.56</gbif-common.version>
     <dwc-api.version>1.48</dwc-api.version>
     <kvs.version>1.32</kvs.version>
@@ -100,9 +100,9 @@
     <gbif-wrangler.version>0.3</gbif-wrangler.version>
     <gbif-occurrence.version>0.194.0</gbif-occurrence.version>
     <vocabulary-lookup.version>1.0.0</vocabulary-lookup.version>
-    <registry.version>3.95.3</registry.version>
+    <registry.version>3.95.15</registry.version>
     <gbif-common-ws.version>1.18</gbif-common-ws.version>
-    <gbif-postal-service.version>1.7.0</gbif-postal-service.version>
+    <gbif-postal-service.version>1.9.0-SNAPSHOT</gbif-postal-service.version>
     <gbif-common-spreadsheet.version>0.2</gbif-common-spreadsheet.version>
 
     <!-- Common libraries -->


### PR DESCRIPTION
We need to update versions to support the new endpoint type of `CAMTRAP_DP`. It's just a new value in the enum(actually it was renamed).