### PR TITLE
Allow using living-atlas services hosted on sub-paths

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/images/ImageService.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/images/ImageService.java
@@ -10,10 +10,10 @@ import retrofit2.http.*;
 public interface ImageService {
 
   @Multipart
-  @POST("/batch/upload")
+  @POST("batch/upload")
   Call<BatchUploadResponse> upload(
       @Part("dataResourceUid") RequestBody dataResourceUid, @Part MultipartBody.Part file);
 
-  @GET("/ws/exportDataset/{dataResourceUid}")
+  @GET("ws/exportDataset/{dataResourceUid}")
   Call<ResponseBody> downloadMappingFile(@Path("dataResourceUid") String dataResourceUid);
 }

--- a/livingatlas/pipelines/src/main/java/au/org/ala/specieslists/SpeciesListService.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/specieslists/SpeciesListService.java
@@ -7,9 +7,9 @@ import retrofit2.http.Path;
 
 public interface SpeciesListService {
 
-  @GET("/ws/speciesList?isAuthoritative=eq:true&max=1000")
+  @GET("ws/speciesList?isAuthoritative=eq:true&max=1000")
   Call<ListSearchResponse> getAuthoritativeLists();
 
-  @GET("/speciesListItem/downloadList/{dataResourceUid}?fetch=%7BkvpValues%3Dselect%7")
+  @GET("speciesListItem/downloadList/{dataResourceUid}?fetch=%7BkvpValues%3Dselect%7")
   Call<ResponseBody> downloadList(@Path("dataResourceUid") String dataResourceUid);
 }


### PR DESCRIPTION
For the Flemish Biodiversity Portal we switched to using subpaths for routing all our services.
There were a few places in the pipelines that force the use of absolute paths.
This should fix that.