### PR TITLE
Living Atlas Multimedia Extension issue

### DIFF
--- a/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceExtensionConverter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/converters/OccurrenceExtensionConverter.java
@@ -77,6 +77,11 @@ public class OccurrenceExtensionConverter {
         // Extract occurrenceID and use it as map key
         String occurrenceId = rawExtensionData.get(DwcTerm.occurrenceID.qualifiedName());
 
+        // If no occurrenceId found, use id from the "parent" extended record
+        if (occurrenceId == null) {
+          occurrenceId = er.getCoreTerms().get(DwcTerm.occurrenceID.qualifiedName());
+        }
+
         Map<String, List<Map<String, String>>> parsedExtensions = result.get(occurrenceId);
 
         // If the map is null we create new map for the extension


### PR DESCRIPTION
Fixes issue processing iNaturalist GBIF exports in the living atlas pipelines.

The multimedia extension does not have an outright occurrenceId column, so the existing logic was mapping the extension to a null value.