### PR TITLE
Changes to allow downloading of records with a specified taxonomy

### DIFF
--- a/gbif/validator/validator-checklists/src/main/java/org/gbif/pipelines/validator/checklists/model/ObjectToTermMapper.java
+++ b/gbif/validator/validator-checklists/src/main/java/org/gbif/pipelines/validator/checklists/model/ObjectToTermMapper.java
@@ -331,10 +331,10 @@ public class ObjectToTermMapper {
         .ifPresent(v -> termsMap.put(GbifTerm.ageInDays, v.toString()));
 
     Optional.ofNullable(speciesProfile.getSizeInMillimeter())
-        .ifPresent(v -> termsMap.put(GbifTerm.sizeInMillimeter, v.toString()));
+        .ifPresent(v -> termsMap.put(GbifTerm.sizeInMillimeters, v.toString()));
 
     Optional.ofNullable(speciesProfile.getMassInGram())
-        .ifPresent(v -> termsMap.put(GbifTerm.massInGram, v.toString()));
+        .ifPresent(v -> termsMap.put(GbifTerm.massInGrams, v.toString()));
 
     Optional.ofNullable(speciesProfile.getHabitat())
         .ifPresent(v -> termsMap.put(DwcTerm.habitat, v));

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
     <!-- GBIF libraries -->
     <gbif-parsers.version>0.67</gbif-parsers.version>
     <dwca-io.version>3.0.0</dwca-io.version>
-    <gbif-api.version>2.1.13-SNAPSHOT</gbif-api.version>
+    <gbif-api.version>2.1.15</gbif-api.version>
     <gbif-common.version>0.60</gbif-common.version>
-    <dwc-api.version>2.1.1</dwc-api.version>
+    <dwc-api.version>2.1.6</dwc-api.version>
     <kvs.version>3.0</kvs.version>
     <hbase-utils.version>1.0.0</hbase-utils.version>
     <gbif-wrangler.version>1.0.0</gbif-wrangler.version>

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/utils/ModelUtils.java
@@ -25,6 +25,9 @@ public class ModelUtils {
   public static final String DEFAULT_SEPARATOR = "\\|";
 
   public static String extractValue(ExtendedRecord er, Term term) {
+    if (er == null || term == null) {
+      return null;
+    }
     String value = er.getCoreTerms().get(term.qualifiedName());
     return value != null ? value.trim() : extractFromIdentificationExtension(er, term);
   }


### PR DESCRIPTION
With this PR, users can specify a checklist to use in the downloads using a checklistKey parameter.
This provides the ability for the user to select the kingdom, phylum,....species and other taxonomic fields provided in the DWCA, CSV, AVRO etc from the chosen classification.

This PR works alongside this pR:  https://github.com/gbif/occurrence/pull/418