### PR TITLE
Country checklist support

### DIFF
--- a/gbif/ingestion/ingest-gbif-beam/src/main/java/org/gbif/pipelines/ingest/pipelines/interpretation/TransformsFactory.java
+++ b/gbif/ingestion/ingest-gbif-beam/src/main/java/org/gbif/pipelines/ingest/pipelines/interpretation/TransformsFactory.java
@@ -1,6 +1,7 @@
 package org.gbif.pipelines.ingest.pipelines.interpretation;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
@@ -186,16 +187,25 @@ public class TransformsFactory {
     SerializableSupplier<KeyValueStore<NameUsageMatchRequest, NameUsageMatchResponse>>
         nameUsageMatchServiceSupplier = null;
 
+    SerializableSupplier<KeyValueStore<GeocodeRequest, GeocodeResponse>> geocodeServiceSupplier =
+        null;
+
     if (!options.getTestMode()) {
       nameUsageMatchServiceSupplier = NameUsageMatchStoreFactory.createMultiServiceSupplier(config);
+      geocodeServiceSupplier = GeocodeKvStoreFactory.createSupplier(hdfsConfigs, config);
     }
 
     return MultiTaxonomyTransform.builder()
         .kvStoresSupplier(nameUsageMatchServiceSupplier)
+        .geoKvStoreSupplier(geocodeServiceSupplier)
         .checklistKeys(
             config.getNameUsageMatchingService() != null
                 ? config.getNameUsageMatchingService().getChecklistKeys()
                 : List.of())
+        .countryCheckistKeyMap(
+            config.getNameUsageMatchingService() != null
+                ? config.getNameUsageMatchingService().getCountryChecklistKeyMap()
+                : Map.of())
         .create();
   }
 

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/config/model/ChecklistKvConfig.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/config/model/ChecklistKvConfig.java
@@ -3,6 +3,7 @@ package org.gbif.pipelines.core.config.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,4 +13,5 @@ import lombok.NoArgsConstructor;
 public class ChecklistKvConfig implements Serializable {
   List<String> checklistKeys;
   KvConfig ws;
+  Map<String, String> countryChecklistKeyMap;
 }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreter.java
@@ -1,19 +1,29 @@
 package org.gbif.pipelines.core.interpreters.core;
 
+import static org.gbif.api.vocabulary.OccurrenceIssue.COUNTRY_INVALID;
 import static org.gbif.pipelines.core.interpreters.core.TaxonomyInterpreter.createNameUsageMatchRequest;
 import static org.gbif.pipelines.core.interpreters.core.TaxonomyInterpreter.createTaxonRecord;
+import static org.gbif.pipelines.core.parsers.location.parser.LocationParser.parseCountry;
 import static org.gbif.pipelines.core.utils.ModelUtils.*;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.gbif.api.vocabulary.Country;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.kvs.KeyValueStore;
+import org.gbif.kvs.geocode.GeocodeRequest;
 import org.gbif.kvs.species.NameUsageMatchRequest;
+import org.gbif.pipelines.core.parsers.VocabularyParser;
+import org.gbif.pipelines.core.parsers.common.ParsedField;
+import org.gbif.pipelines.core.parsers.location.parser.LocationParser;
+import org.gbif.pipelines.core.parsers.location.parser.ParsedLocation;
 import org.gbif.pipelines.core.utils.ModelUtils;
 import org.gbif.pipelines.io.avro.*;
+import org.gbif.rest.client.geocode.GeocodeResponse;
 import org.gbif.rest.client.species.NameUsageMatchResponse;
 
 /**
@@ -34,7 +44,9 @@ public class MultiTaxonomyInterpreter {
    */
   public static BiConsumer<ExtendedRecord, MultiTaxonRecord> interpretMultiTaxonomy(
       KeyValueStore<NameUsageMatchRequest, NameUsageMatchResponse> kvStore,
-      List<String> checklistKeys) {
+      KeyValueStore<GeocodeRequest, GeocodeResponse> geocodeKvStore,
+      List<String> checklistKeys,
+      Map<String, String> countryChecklistKeyMap) {
     return (er, mtr) -> {
       if (kvStore == null) {
         return;
@@ -50,6 +62,60 @@ public class MultiTaxonomyInterpreter {
             TaxonRecord.newBuilder().setId(er.getId()).setDatasetKey(checklistKey).build();
         createTaxonRecord(nameUsageMatchRequest, kvStore, taxonRecord);
         trs.add(taxonRecord);
+      }
+
+      // country specific checklist keys
+      if (countryChecklistKeyMap != null
+          && !countryChecklistKeyMap.isEmpty()
+          && geocodeKvStore != null) {
+
+        AtomicReference<String> isoCountryCode = new AtomicReference<>();
+
+        // if country is in the er, no need to do geocode lookup
+        ParsedField<Country> parsedCountry =
+            parseCountry(er, VocabularyParser.countryParser(), COUNTRY_INVALID.name());
+
+        if (parsedCountry.isSuccessful() && parsedCountry.getResult() != null) {
+          isoCountryCode.set(parsedCountry.getResult().getIso2LetterCode());
+        }
+
+        // if countrycode is in the er, no need to do geocode lookup
+        if (isoCountryCode.get() == null) {
+          // Parse country code
+          ParsedField<Country> parsedCountryCode =
+              parseCountry(er, VocabularyParser.countryCodeParser(), COUNTRY_INVALID.name());
+          if (parsedCountryCode.isSuccessful() && parsedCountryCode.getResult() != null) {
+            isoCountryCode.set(parsedCountryCode.getResult().getIso2LetterCode());
+          }
+        }
+
+        // if we dont have country code, do a geocode lookup
+        if (isoCountryCode.get() == null) {
+
+          // do the geocode lookup as we don't have ISO country code yet
+          ParsedField<ParsedLocation> parsedResult = LocationParser.parse(er, geocodeKvStore);
+
+          // set values in the location record
+          ParsedLocation parsedLocation = parsedResult.getResult();
+
+          Optional.ofNullable(parsedLocation.getCountry())
+              .ifPresent(
+                  country -> {
+                    isoCountryCode.set(country.getIso2LetterCode());
+                  });
+        }
+
+        // if we have a isoCountryCode and there is a mapping for it, do the name usage match
+        if (isoCountryCode.get() != null
+            && countryChecklistKeyMap.containsKey(isoCountryCode.get())) {
+          String checklistKey = countryChecklistKeyMap.get(isoCountryCode.get());
+          final NameUsageMatchRequest nameUsageMatchRequest =
+              createNameUsageMatchRequest(er, checklistKey);
+          TaxonRecord taxonRecord =
+              TaxonRecord.newBuilder().setId(er.getId()).setDatasetKey(checklistKey).build();
+          createTaxonRecord(nameUsageMatchRequest, kvStore, taxonRecord);
+          trs.add(taxonRecord);
+        }
       }
 
       mtr.setId(er.getId());

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/parser/LocationParser.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/parsers/location/parser/LocationParser.java
@@ -101,7 +101,7 @@ public class LocationParser {
         .build();
   }
 
-  private static ParsedField<Country> parseCountry(
+  public static ParsedField<Country> parseCountry(
       ExtendedRecord er, VocabularyParser<Country> parser, String issue) {
     Optional<ParseResult<Country>> parseResultOpt = parser.map(er, parseRes -> parseRes);
 

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreterTest.java
@@ -1,0 +1,473 @@
+package org.gbif.pipelines.core.interpreters.core;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.kvs.KeyValueStore;
+import org.gbif.kvs.geocode.GeocodeRequest;
+import org.gbif.kvs.species.NameUsageMatchRequest;
+import org.gbif.pipelines.io.avro.ExtendedRecord;
+import org.gbif.pipelines.io.avro.MultiTaxonRecord;
+import org.gbif.rest.client.geocode.GeocodeResponse;
+import org.gbif.rest.client.species.NameUsageMatchResponse;
+import org.gbif.rest.client.species.NameUsageMatchResponse.Diagnostics;
+import org.gbif.rest.client.species.NameUsageMatchResponse.MatchType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MultiTaxonomyInterpreterTest {
+
+  /**
+   * Isocountry or decimal latitude/longitude is not present in the er, so geocode webservices
+   * should not be called, nameusage SHOULD NOT be called with the checklist key from the map
+   */
+  @Test
+  public void checkGeocodeNotCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("ZA").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "fake-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(Map.of(DwcTerm.scientificName.qualifiedName(), "nonsense"))
+            .build(),
+        testRecord);
+
+    Assert.assertFalse(geocodeCalled[0]);
+    Assert.assertFalse(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is present in the er, so geocode webservices should not be called, nameusage SHOULD
+   * be called with the checklist key from the map
+   */
+  @Test
+  public void checkGeocodeNotCalledNameUsageWithChecklistCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("ZA").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.countryCode.qualifiedName(), "ZA"))
+            .build(),
+        testRecord);
+
+    Assert.assertFalse(geocodeCalled[0]);
+    Assert.assertTrue(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is present in the er, so geocode webservices should not be called, nameusage SHOULD
+   * NOT be called as ISO code doesnt match anything in map
+   */
+  @Test
+  public void checkGeocodeNotCalledNameUsageWithChecklistNotCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("ZA").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.countryCode.qualifiedName(), "US"))
+            .build(),
+        testRecord);
+
+    Assert.assertFalse(geocodeCalled[0]);
+    Assert.assertFalse(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is present in the er, so geocode webservices should not be called, nameusage SHOULD
+   * NOT be called as ISO code doesnt match anything in map
+   */
+  @Test
+  public void checkGeocodeNotCalledCountrySuppliedNameUsageWithChecklistNotCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("ZA").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.country.qualifiedName(), "UNITED STATES"))
+            .build(),
+        testRecord);
+
+    Assert.assertFalse(geocodeCalled[0]);
+    Assert.assertFalse(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is present in the er, so geocode webservices should not be called, nameusage SHOULD
+   * NOT be called as ISO code doesnt match anything in map
+   */
+  @Test
+  public void checkGeocodeNotCalledCountrySuppliedNameUsageWithChecklistCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("ZA").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.country.qualifiedName(), "South Africa"))
+            .build(),
+        testRecord);
+
+    Assert.assertFalse(geocodeCalled[0]);
+    Assert.assertTrue(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is not present in the er, so geocode webservices should not be called, nameusage
+   * SHOULD be called with the checklist key from the map
+   */
+  @Test
+  public void checkGeocodeCalledNameUsageWithChecklistNotCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(GeocodeResponse.Location.builder().isoCountryCode2Digit("US").build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.decimalLatitude.qualifiedName(), "88",
+                    DwcTerm.decimalLongitude.qualifiedName(), "137"))
+            .build(),
+        testRecord);
+
+    Assert.assertTrue(geocodeCalled[0]);
+    Assert.assertFalse(nameUsageCalledWithChecklist[0]);
+  }
+
+  /**
+   * Isocountry is present in the er, so geocode webservices should not be called, nameusage SHOULD
+   * be called with the checklist key from the map
+   */
+  @Test
+  public void checkGeocodeCalledNameUsageWithChecklistCalled() {
+
+    // State
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    MultiTaxonRecord testRecord = MultiTaxonRecord.newBuilder().setId("not-an-id").build();
+
+    final Boolean[] geocodeCalled = {false};
+    final Boolean[] nameUsageCalledWithChecklist = {false};
+
+    // When
+    BiConsumer<ExtendedRecord, MultiTaxonRecord> consumer =
+        MultiTaxonomyInterpreter.interpretMultiTaxonomy(
+            new KeyValueStore<>() {
+
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                if (nameUsageMatchRequest.getChecklistKey().equals("za-checklist-key")) {
+                  nameUsageCalledWithChecklist[0] = true;
+                }
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            new KeyValueStore<>() {
+              @Override
+              public GeocodeResponse get(GeocodeRequest nameUsageMatchRequest) {
+                geocodeCalled[0] = true;
+                GeocodeResponse r = new GeocodeResponse();
+                r.setLocations(
+                    List.of(
+                        GeocodeResponse.Location.builder()
+                            .name("South Africa")
+                            .type("Political")
+                            .isoCountryCode2Digit("ZA")
+                            .build()));
+                return r;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            List.of("fake-checklist-key"),
+            Map.of("ZA", "za-checklist-key"));
+
+    consumer.accept(
+        ExtendedRecord.newBuilder()
+            .setId("112345")
+            .setCoreTerms(
+                Map.of(
+                    DwcTerm.scientificName.qualifiedName(), "nonsense",
+                    DwcTerm.decimalLatitude.qualifiedName(), "88",
+                    DwcTerm.decimalLongitude.qualifiedName(), "137"))
+            .build(),
+        testRecord);
+
+    Assert.assertTrue(geocodeCalled[0]);
+    Assert.assertTrue(nameUsageCalledWithChecklist[0]);
+  }
+}

--- a/sdks/core/src/test/resources/pipelines.yaml
+++ b/sdks/core/src/test/resources/pipelines.yaml
@@ -7,6 +7,19 @@ nameUsageMatch:
   wsCacheSizeMb: 65
   numOfKeyBuckets: 6
   tableName: test_name_usage_kv
+nameUsageMatchingService:
+  checklistKeys:
+    - d7dddbf4-2cf0-4f39-9b2a-bb099caae36c
+    - 2d59e5db-57ad-41ff-97d6-11f5fb264527
+    - 7ddf754f-d193-4cc9-b351-99906754a03b
+  countryChecklistKeyMap:
+    ZA: d7dddbf4-2cf0-4f39-9b2a-bb099caae36c
+  ws:
+    numOfKeyBuckets: 5
+    zkConnectionString: test11.gbif-test.org,test2.gbif-test.org,test3.gbif-test.org
+    tableName: test_name_usage_kv
+    api:
+      wsUrl: http://test.test-mt
 geocode:
   zkConnectionString: test12.gbif-test.org,test2.gbif-test.org,test3.gbif-test.org
   wsTimeoutSec: 62


### PR DESCRIPTION
Work for https://github.com/gbif/pipelines/issues/1202

Support for indexing records from a country with a checklist for that country. Supported by configuration

```yaml
nameUsageMatchingService:
  checklistKeys:
    - d7dddbf4-2cf0-4f39-9b2a-bb099caae36c
    - 7ddf754f-d193-4cc9-b351-99906754a03b
  countryChecklistKeyMap:
    SE: de8934f4-a136-481c-a87a-b0b202b80a31
    GB: dbaa27eb-29e7-4cbb-8eab-3f689cfce116
```    
    