### PR TITLE
Update ALAUUIDValidationPipeline.java - Validation fix

### DIFF
--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDValidationPipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDValidationPipeline.java
@@ -274,7 +274,7 @@ public class ALAUUIDValidationPipeline {
         "Validation finished. Results written to: {}",
         getValidationFilePath(options, VALIDATION_REPORT_FILE));
 
-    if (ValidationUtils.checkValidationFile(options).getValid()
+    if (!ValidationUtils.checkValidationFile(options).getValid()
         && options.getThrowErrorOnValidationFail()) {
       throw new RuntimeException(
           "Validation of dataset failed. Check validation file at: "


### PR DESCRIPTION
The code was failing the validation when the validation was true and the option to send an error on validation fail was set to true, due to a missing "!".