### PR TITLE
Unit test validating processing of an extension that is missing the occurrencID field

### DIFF
--- a/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceExtensionConverterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/converters/OccurrenceExtensionConverterTest.java
@@ -98,7 +98,11 @@ public class OccurrenceExtensionConverterTest {
     exts.put(MeasurementOrFact.qualifiedName(), Arrays.asList(extMap, extMap));
 
     ExtendedRecord extendedRecord =
-            ExtendedRecord.newBuilder().setId(occurrenceId).setCoreTerms(coreMap).setExtensions(exts).build();
+        ExtendedRecord.newBuilder()
+            .setId(occurrenceId)
+            .setCoreTerms(coreMap)
+            .setExtensions(exts)
+            .build();
 
     // When
     List<ExtendedRecord> result = OccurrenceExtensionConverter.convert(extendedRecord);
@@ -114,7 +118,7 @@ public class OccurrenceExtensionConverterTest {
 
     Assert.assertEquals(2, erResult.getExtensions().get(MeasurementOrFact.qualifiedName()).size());
     Assert.assertEquals(
-            1, erResult.getExtensions().get(MeasurementOrFact.qualifiedName()).get(0).size());
+        1, erResult.getExtensions().get(MeasurementOrFact.qualifiedName()).get(0).size());
 
     // coreId has the id reported in the Core
     Assert.assertEquals(occurrenceId, erResult.getCoreId());


### PR DESCRIPTION
Fix was merged a while ago, but promissed to actually provide a test for it too.
The included test more or less matches what I observer when processing a DWCA export from GBIF that includes multimedia items.