### PR TITLE
LA module update

### DIFF
--- a/livingatlas/bitmap/pom.xml
+++ b/livingatlas/bitmap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>au.org.ala</groupId>
     <artifactId>livingatlas</artifactId>
-    <version>3.2.14-events-SNAPSHOT</version>
+    <version>3.2.23-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/livingatlas/migration/pom.xml
+++ b/livingatlas/migration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>au.org.ala</groupId>
     <artifactId>livingatlas</artifactId>
-    <version>3.2.14-events-SNAPSHOT</version>
+    <version>3.2.23-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/livingatlas/pipelines/pom.xml
+++ b/livingatlas/pipelines/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>au.org.ala</groupId>
     <artifactId>livingatlas</artifactId>
-    <version>3.2.14-events-SNAPSHOT</version>
+    <version>3.2.23-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/livingatlas/pom.xml
+++ b/livingatlas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif.pipelines</groupId>
     <artifactId>pipelines-parent</artifactId>
-    <version>3.2.14-events-SNAPSHOT</version>
+    <version>3.2.23-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   <modules>
     <module>gbif</module>
     <module>sdks</module>
-<!--    <module>livingatlas</module>-->
+    <!-- Please comment livingatlas module if gives problems with the build and ask for help -->
+    <module>livingatlas</module>
   </modules>
 
   <name>Pipelines :: Parent</name>


### PR DESCRIPTION
This pull request updates the `livingatlas` modules to use a newer parent version and re-enables the `livingatlas` module in the main build. Please feel free to comment it again if affect your builds and ping us to take a look.

