### PR TITLE
#1298 dataset deletion

### DIFF
--- a/gbif/ingestion/spark-coordinator/pom.xml
+++ b/gbif/ingestion/spark-coordinator/pom.xml
@@ -254,6 +254,10 @@
             <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.gbif.pipelines</groupId>
+            <artifactId>elasticsearch-tools</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/CloseableMessageCallback.java
+++ b/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/CloseableMessageCallback.java
@@ -1,0 +1,13 @@
+package org.gbif.pipelines.coordinator;
+
+import java.io.IOException;
+import org.gbif.common.messaging.api.MessageCallback;
+
+public interface CloseableMessageCallback<I> extends MessageCallback<I>, AutoCloseable {
+
+  boolean isRunning();
+
+  int getRunningCounter();
+
+  void init() throws IOException;
+}

--- a/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/Coordinator.java
+++ b/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/Coordinator.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.gbif.api.vocabulary.DatasetType;
 import org.gbif.common.messaging.ConnectionParameters;
 import org.gbif.common.messaging.DefaultMessagePublisher;
 import org.gbif.common.messaging.MessageListener;
@@ -142,7 +143,7 @@ public class Coordinator {
       Supplier<MessageListener> listenerSupplier,
       Supplier<DefaultMessagePublisher> publisherSupplier) {
 
-    Function<MessagePublisher, PipelinesCallback> callbackFn = null;
+    Function<MessagePublisher, CloseableMessageCallback> callbackFn = null;
 
     switch (mode) {
       case IDENTIFIER:
@@ -220,6 +221,16 @@ public class Coordinator {
         callbackFn =
             (messagePublisher -> new FragmenterDistributedCallback(config, messagePublisher));
         break;
+      case OCCURRENCE_DELETION:
+        callbackFn =
+            (messagePublisher -> new DatasetDeleteCallback(config, master, DatasetType.OCCURRENCE));
+        break;
+      case EVENT_DELETION:
+        callbackFn =
+            (messagePublisher ->
+                new DatasetDeleteCallback(config, master, DatasetType.SAMPLING_EVENT));
+        break;
+
       default:
         throw new IllegalArgumentException(
             "Unknown mode: "
@@ -237,7 +248,7 @@ public class Coordinator {
     // create listener and publisher up-front using the supplied factories
     try (MessageListener listener = listenerSupplier.get();
         DefaultMessagePublisher publisher = publisherSupplier.get();
-        PipelinesCallback callback = callbackFn.apply(publisher)) {
+        CloseableMessageCallback callback = callbackFn.apply(publisher)) {
 
       // initialise spark session & filesystem
       callback.init();
@@ -278,7 +289,7 @@ public class Coordinator {
           callback.getRunningCounter());
       log.info("No longer running and no active datasets. Proceeding to shutdown.");
 
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error("Error starting standalone", e);
     }
 
@@ -328,6 +339,8 @@ public class Coordinator {
     EVENTS_INDEXING,
     EVENTS_INDEXING_DISTRIBUTED,
     FRAGMENTER,
-    FRAGMENTER_DISTRIBUTED
+    FRAGMENTER_DISTRIBUTED,
+    OCCURRENCE_DELETION,
+    EVENT_DELETION
   }
 }

--- a/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/DatasetDeleteCallback.java
+++ b/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/DatasetDeleteCallback.java
@@ -1,0 +1,156 @@
+package org.gbif.pipelines.coordinator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SparkSession;
+import org.gbif.api.vocabulary.DatasetType;
+import org.gbif.common.messaging.AbstractMessageCallback;
+import org.gbif.common.messaging.api.messages.DeleteDatasetOccurrencesMessage;
+import org.gbif.pipelines.core.config.model.PipelinesConfig;
+import org.gbif.pipelines.estools.EsIndex;
+import org.gbif.pipelines.estools.client.EsConfig;
+import org.gbif.pipelines.spark.Directories;
+import org.gbif.pipelines.spark.util.TableUtil;
+
+@Slf4j
+public class DatasetDeleteCallback extends AbstractMessageCallback<DeleteDatasetOccurrencesMessage>
+    implements CloseableMessageCallback<DeleteDatasetOccurrencesMessage> {
+
+  private final PipelinesConfig pipelinesConfig;
+  private final SparkSession sparkSession;
+  private final FileSystem fileSystem;
+  private final DatasetType datasetType;
+  public static final String SHUTDOWN_FILE_PATH = "/tmp/shutdown_now";
+  private static final AtomicInteger runningCounter = new AtomicInteger(0);
+
+  public DatasetDeleteCallback(
+      PipelinesConfig pipelinesConfig, String sparkMaster, DatasetType datasetType) {
+    super();
+    this.pipelinesConfig = pipelinesConfig;
+    this.datasetType = datasetType;
+
+    try {
+      SparkSession.Builder sparkBuilder = SparkSession.builder().appName("pipelines_standalone");
+      sparkBuilder = sparkBuilder.master(sparkMaster);
+      sparkBuilder.config("spark.driver.extraClassPath", "/etc/hadoop/conf");
+      sparkBuilder.config("spark.executor.extraClassPath", "/etc/hadoop/conf");
+      sparkBuilder
+          .enableHiveSupport()
+          .config("spark.hadoop.hive.metastore.uris", this.pipelinesConfig.getHiveMetastoreUris());
+
+      this.sparkSession = sparkBuilder.getOrCreate();
+      Configuration hadoopConf = this.sparkSession.sparkContext().hadoopConfiguration();
+      if (pipelinesConfig.getHdfsSiteConfig() != null
+          && pipelinesConfig.getCoreSiteConfig() != null) {
+        hadoopConf.addResource(new Path(pipelinesConfig.getHdfsSiteConfig()));
+        hadoopConf.addResource(new Path(pipelinesConfig.getCoreSiteConfig()));
+        this.fileSystem = FileSystem.get(hadoopConf);
+      } else {
+        log.warn("Using local filesystem - this is suitable for local development only");
+        this.fileSystem = FileSystem.getLocal(hadoopConf);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void handleMessage(DeleteDatasetOccurrencesMessage message) {
+
+    runningCounter.incrementAndGet();
+    try {
+      log.info("Deleting dataset {}....", message.getDatasetUuid());
+
+      String esAlias =
+          datasetType == DatasetType.OCCURRENCE
+              ? pipelinesConfig.getIndexConfig().getOccurrenceAlias()
+              : pipelinesConfig.getIndexConfig().getEventAlias();
+
+      // remove from iceberg tables
+      log.info("Deleting dataset {} from iceberg", message.getDatasetUuid());
+      TableUtil.deleteRecordsForDataset(
+          this.sparkSession,
+          this.pipelinesConfig,
+          message.getDatasetUuid().toString(),
+          datasetType);
+
+      // remove from elastic
+      log.info(
+          "Deleting dataset {} from elastic indexes for {}", message.getDatasetUuid(), datasetType);
+      EsConfig esConfig = EsConfig.from(pipelinesConfig.getIndexConfig().getDefaultIndexCatUrl());
+
+      EsIndex.deleteRecordsByDatasetId(
+          esConfig,
+          new String[] {esAlias},
+          message.getDatasetUuid().toString(),
+          idxName -> !idxName.startsWith(message.getDatasetUuid().toString()),
+          60,
+          5);
+
+      // remove files to avoid inclusion in index  & table rebuilds
+      deleteFileSystemOutputs(message);
+
+      log.info("Deleted dataset {}", message.getDatasetUuid());
+    } finally {
+      runningCounter.decrementAndGet();
+    }
+  }
+
+  private void deleteFileSystemOutputs(DeleteDatasetOccurrencesMessage message) {
+    try {
+      log.info("Deleting dataset outputs from file system for {}", message.getDatasetUuid());
+      // remove hdfs & json directories for this dataset for all attempts
+      String[] targets =
+          datasetType == DatasetType.OCCURRENCE
+              ? new String[] {Directories.OCCURRENCE_HDFS, Directories.OCCURRENCE_JSON}
+              : new String[] {Directories.EVENT_HDFS, Directories.EVENT_JSON};
+
+      for (String target : targets) {
+        Path pattern =
+            new Path(
+                pipelinesConfig.getOutputPath() + "/" + message.getDatasetUuid() + "/*/" + target);
+        FileStatus[] matches = fileSystem.globStatus(pattern);
+        if (matches != null) {
+          for (FileStatus status : matches) {
+            log.info("Deleting dataset outputs from file system for {}", status.getPath());
+            fileSystem.delete(status.getPath(), true);
+          }
+        }
+      }
+
+    } catch (IOException e) {
+      log.warn("Failed to delete dataset {} from hdfs", message.getDatasetUuid(), e);
+    }
+  }
+
+  @Override
+  public boolean isRunning() {
+    return !new File(SHUTDOWN_FILE_PATH).exists();
+  }
+
+  @Override
+  public int getRunningCounter() {
+    return runningCounter.get();
+  }
+
+  @Override
+  public void init() throws IOException {}
+
+  @Override
+  public void close() throws IOException {
+    log.info("Closing Spark Session and FileSystem connections");
+    if (sparkSession != null) {
+      sparkSession.close();
+    }
+    if (fileSystem != null) {
+      fileSystem.close();
+    }
+    log.info("Closed Spark Session and FileSystem connections");
+  }
+}

--- a/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/PipelinesCallback.java
+++ b/gbif/ingestion/spark-coordinator/src/main/java/org/gbif/pipelines/coordinator/PipelinesCallback.java
@@ -41,7 +41,6 @@ import org.apache.spark.sql.SparkSession;
 import org.gbif.api.model.pipelines.*;
 import org.gbif.api.model.pipelines.ws.PipelineProcessParameters;
 import org.gbif.api.vocabulary.DatasetType;
-import org.gbif.common.messaging.api.MessageCallback;
 import org.gbif.common.messaging.api.MessagePublisher;
 import org.gbif.common.messaging.api.messages.PipelineBasedMessage;
 import org.gbif.common.messaging.api.messages.PipelinesBalancerMessage;
@@ -52,7 +51,7 @@ import org.gbif.pipelines.core.config.model.PipelinesConfig;
 @Slf4j
 public abstract class PipelinesCallback<
         I extends PipelineBasedMessage, O extends PipelineBasedMessage>
-    implements MessageCallback<I>, AutoCloseable {
+    implements CloseableMessageCallback<I> {
 
   private static final AtomicInteger runningCounter = new AtomicInteger(0);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();


### PR DESCRIPTION
See #1298

This PR replaces the occurrence-cli occurrence-dataset-deleter with some additional functionality. It includes:

* deletion from active elastic indexes
* deletion from iceberg tables (including verbatim extension tables)
* deletion of /hdfs and /json directories to avoid including deleted datasets in full index / table rebuilds

A [followup issue](https://github.com/gbif/occurrence/issues/503) for this PR is to review the dataset deletion logic from the occurrence repo.