### PR TITLE
fix(pipelines): NULL for no match for COL #563

### DIFF
--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/MultiTaxonomyInterpreter.java
@@ -60,7 +60,7 @@ public class MultiTaxonomyInterpreter {
             createNameUsageMatchRequest(er, checklistKey);
         TaxonRecord taxonRecord =
             TaxonRecord.newBuilder().setId(er.getId()).setDatasetKey(checklistKey).build();
-        createTaxonRecord(nameUsageMatchRequest, kvStore, taxonRecord);
+        createTaxonRecord(nameUsageMatchRequest, kvStore, checklistKey, taxonRecord);
         trs.add(taxonRecord);
       }
 
@@ -113,7 +113,7 @@ public class MultiTaxonomyInterpreter {
               createNameUsageMatchRequest(er, checklistKey);
           TaxonRecord taxonRecord =
               TaxonRecord.newBuilder().setId(er.getId()).setDatasetKey(checklistKey).build();
-          createTaxonRecord(nameUsageMatchRequest, kvStore, taxonRecord);
+          createTaxonRecord(nameUsageMatchRequest, kvStore, checklistKey, taxonRecord);
           trs.add(taxonRecord);
         }
       }

--- a/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
+++ b/sdks/core/src/main/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreter.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.gbif.api.model.Constants;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.kvs.KeyValueStore;
 import org.gbif.kvs.species.NameUsageMatchRequest;
@@ -66,7 +67,7 @@ public class TaxonomyInterpreter {
 
       ModelUtils.checkNullOrEmpty(er);
       NameUsageMatchRequest nameUsageMatchRequest = createNameUsageMatchRequest(er, checklistKey);
-      createTaxonRecord(nameUsageMatchRequest, kvStore, tr);
+      createTaxonRecord(nameUsageMatchRequest, kvStore, checklistKey, tr);
       tr.setId(er.getId());
     };
   }
@@ -107,14 +108,20 @@ public class TaxonomyInterpreter {
   protected static void createTaxonRecord(
       NameUsageMatchRequest nameUsageMatchRequest,
       KeyValueStore<NameUsageMatchRequest, NameUsageMatchResponse> kvStore,
+      String checklistKey,
       TaxonRecord tr) {
     matchTaxon(
         nameUsageMatchRequest,
         kvStore,
         tr,
         r -> {
-          tr.setUsage(INCERTAE_SEDIS_WITH_AUTHORSHIP);
-          tr.setClassification(Collections.singletonList(INCERTAE_SEDIS));
+          if (Constants.NUB_DATASET_KEY.toString().equals(checklistKey)) {
+            tr.setUsage(INCERTAE_SEDIS_WITH_AUTHORSHIP);
+            tr.setClassification(Collections.singletonList(INCERTAE_SEDIS));
+          } else {
+            tr.setUsage(null);
+            tr.setClassification(Collections.emptyList());
+          }
         },
         r -> {
           TaxonRecordConverter.convert(r, tr);

--- a/sdks/core/src/test/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreterTest.java
+++ b/sdks/core/src/test/java/org/gbif/pipelines/core/interpreters/core/TaxonomyInterpreterTest.java
@@ -1,5 +1,8 @@
 package org.gbif.pipelines.core.interpreters.core;
 
+import static org.gbif.api.model.Constants.COL_DATASET_KEY;
+import static org.gbif.api.model.Constants.NUB_DATASET_KEY;
+
 import java.io.IOException;
 import java.util.Map;
 import org.gbif.api.vocabulary.OccurrenceIssue;
@@ -95,7 +98,7 @@ public class TaxonomyInterpreterTest {
   }
 
   @Test
-  public void checkNonMatchTest() {
+  public void checkNonMatchTestNub() {
 
     // State
     NameUsageMatchRequest identification = NameUsageMatchRequest.builder().build();
@@ -118,7 +121,7 @@ public class TaxonomyInterpreterTest {
               @Override
               public void close() throws IOException {}
             },
-            "fake-checklist-key")
+            NUB_DATASET_KEY.toString())
         .accept(
             ExtendedRecord.newBuilder()
                 .setId("112345")
@@ -133,5 +136,49 @@ public class TaxonomyInterpreterTest {
             .getIssues()
             .getIssueList()
             .contains(OccurrenceIssue.TAXON_MATCH_NONE.toString()));
+    Assert.assertNotNull(testRecord.getUsage());
+    Assert.assertEquals("0", testRecord.getUsage().getKey());
+  }
+
+  @Test
+  public void checkNonMatchTestCol() {
+
+    // State
+    NameUsageMatchRequest identification = NameUsageMatchRequest.builder().build();
+
+    NameUsageMatchResponse noMatch = new NameUsageMatchResponse();
+    Diagnostics diagnostics = new Diagnostics();
+    diagnostics.setMatchType(MatchType.NONE);
+    noMatch.setDiagnostics(diagnostics);
+
+    TaxonRecord testRecord = TaxonRecord.newBuilder().setId("not-an-id").build();
+
+    // When
+    TaxonomyInterpreter.taxonomyInterpreter(
+            new KeyValueStore<NameUsageMatchRequest, NameUsageMatchResponse>() {
+              @Override
+              public NameUsageMatchResponse get(NameUsageMatchRequest nameUsageMatchRequest) {
+                return noMatch;
+              }
+
+              @Override
+              public void close() throws IOException {}
+            },
+            COL_DATASET_KEY.toString())
+        .accept(
+            ExtendedRecord.newBuilder()
+                .setId("112345")
+                .setCoreTerms(Map.of(DwcTerm.scientificName.name(), "nonsense"))
+                .build(),
+            testRecord);
+
+    // Should
+    Assert.assertNotNull(testRecord.getIssues());
+    Assert.assertTrue(
+        testRecord
+            .getIssues()
+            .getIssueList()
+            .contains(OccurrenceIssue.TAXON_MATCH_NONE.toString()));
+    Assert.assertNull(testRecord.getUsage());
   }
 }


### PR DESCRIPTION
NULL for no match for COL and other non backbone classification 

Using NULL as otherwise it places a requirement on a checklist we use in matching to have an incertae sedis record.

We'll treat the gbif backbone as a special case for no match to taxonkey=0 to make things backwards compatible, but no match for other checklists will result in a NULL usage, empty classification etc.