### PR TITLE
fix(elastic): fixed tests + better exception message

### DIFF
--- a/sdks/tools/elasticsearch-tools/src/main/java/org/gbif/pipelines/estools/service/HttpRequestBuilder.java
+++ b/sdks/tools/elasticsearch-tools/src/main/java/org/gbif/pipelines/estools/service/HttpRequestBuilder.java
@@ -247,8 +247,12 @@ class HttpRequestBuilder {
   static InputStream loadFile(Path path) {
     if (path.isAbsolute()) {
       return new FileInputStream(path.toFile());
-    } else {
-      return Thread.currentThread().getContextClassLoader().getResourceAsStream(path.toString());
     }
+    InputStream is =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream(path.toString());
+    if (is == null) {
+      throw new IllegalArgumentException("ES Mapping resource not found on classpath: " + path);
+    }
+    return is;
   }
 }

--- a/sdks/tools/elasticsearch-tools/src/test/java/org/gbif/pipelines/estools/service/HttpRequestBuilderTest.java
+++ b/sdks/tools/elasticsearch-tools/src/test/java/org/gbif/pipelines/estools/service/HttpRequestBuilderTest.java
@@ -202,30 +202,42 @@ public class HttpRequestBuilderTest {
     assertTrue(node.has(Field.MAPPINGS));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void bodyWithNullMappingsTest() {
 
     // State
     String mappings = null;
 
+    // Expect
+    thrown.expectMessage("Mappings cannot be null or empty");
+
     // When
     HttpRequestBuilder.newInstance().withMappings(mappings).build();
-
-    // Should
-    thrown.expectMessage("Mappings cannot be null or empty");
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void bodyWithNullPathMappingsTest() {
 
     // State
     Path mappings = null;
 
+    // Expect
+    thrown.expectMessage("mappingsPath is marked non-null but is null");
+
     // When
     HttpRequestBuilder.newInstance().withMappings(mappings).build();
+  }
 
-    // Should
-    thrown.expectMessage("The path of the mappings cannot be null");
+  @Test
+  public void testInvalidLoadingPath() {
+    // State
+    Path mappings = Path.of("elastic/someconfig.json");
+
+    // expect
+    thrown.expectMessage("ES Mapping resource not found on classpath: ");
+
+    // When
+    HttpRequestBuilder.newInstance().withMappings(mappings).build();
   }
 
   private void assertMappings(JsonNode mappingsNode) {


### PR DESCRIPTION
Fixed tests, that didn't validate message part. 
The `thrown.expectMessage(...)` was completely disregarded. 

Added explicit exception message when loading goes wrong.